### PR TITLE
fix random

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix randomness not being implemented properly, leading to the same random numbers always being generated. This issues leads to all instances of smoldot (even on different machines) always using the same networking key, which would lead to connectivity issues when multiple instances of smoldot (even on different machines). Note that because perfect forward secrecy is used, it is not possible to retroactively decipher networking communications. Additionally, the fact that the same random numbers are always generated makes smoldot vulnerable to HashDoS attacks. ([#142](https://github.com/smol-dot/smoldot/pull/142))
 - JSON-RPC requests without a `params` field are no longer invalid. ([#13](https://github.com/smol-dot/smoldot/pull/13))
 - Fix Merkle proofs whose trie root node has a size inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix randomness not being implemented properly, leading to the same random numbers always being generated. This issues leads to all instances of smoldot (even on different machines) always using the same networking key, which would lead to connectivity issues when multiple instances of smoldot (even on different machines). Note that because perfect forward secrecy is used, it is not possible to retroactively decipher networking communications. Additionally, the fact that the same random numbers are always generated makes smoldot vulnerable to HashDoS attacks. ([#142](https://github.com/smol-dot/smoldot/pull/142))
+- Fix randomness not being implemented properly, leading to the same random numbers always being generated. This issues leads to all instances of smoldot (even on different machines) always using the same networking key, which would lead to connectivity issues when multiple instances of smoldot connect to the same full node. Note that because perfect forward secrecy is used, it is not possible to retroactively decipher networking communications. Additionally, the fact that the same random numbers are always generated makes smoldot vulnerable to HashDoS attacks. ([#142](https://github.com/smol-dot/smoldot/pull/142))
 - JSON-RPC requests without a `params` field are no longer invalid. ([#13](https://github.com/smol-dot/smoldot/pull/13))
 - Fix Merkle proofs whose trie root node has a size inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix randomness not being implemented properly, leading to the same random numbers always being generated. This issues leads to all instances of smoldot (even on different machines) always using the same networking key, which would lead to connectivity issues when multiple instances of smoldot connect to the same full node. Note that because perfect forward secrecy is used, it is not possible to retroactively decipher networking communications. Additionally, the fact that the same random numbers are always generated makes smoldot vulnerable to HashDoS attacks. ([#142](https://github.com/smol-dot/smoldot/pull/142))
+- Fix randomness not being implemented properly, leading to the same random numbers always being generated. This issues leads to all instances of smoldot (even on different machines) always using the same networking key, which would lead to connectivity issues when multiple instances of smoldot connect to the same full node. Note that because perfect forward secrecy is used, it is not possible to retroactively decipher networking communications. Additionally, the fact that the same random numbers are always generated made smoldot vulnerable to HashDoS attacks. ([#142](https://github.com/smol-dot/smoldot/pull/142))
 - JSON-RPC requests without a `params` field are no longer invalid. ([#13](https://github.com/smol-dot/smoldot/pull/13))
 - Fix Merkle proofs whose trie root node has a size inferior to 32 bytes being considered as invalid. ([#3046](https://github.com/paritytech/smoldot/pull/3046))
 

--- a/bin/wasm-node/javascript/src/instance/bindings-wasi.ts
+++ b/bin/wasm-node/javascript/src/instance/bindings-wasi.ts
@@ -66,10 +66,10 @@ export default (config: Config): WebAssembly.ModuleImports => {
             len >>>= 0;
 
             const baseBuffer = new Uint8Array(instance.exports.memory.buffer)
-                .slice(ptr, ptr + len);
+                .subarray(ptr, ptr + len);
             for (let iter = 0; iter < len; iter += 65536) {
-                // `baseBuffer.slice` automatically saturates at the end of the buffer
-                config.getRandomValues(baseBuffer.slice(iter, iter + 65536))
+                // `baseBuffer.subarray` automatically saturates at the end of the buffer
+                config.getRandomValues(baseBuffer.subarray(iter, iter + 65536))
             }
 
             return 0;


### PR DESCRIPTION
wasm smoldot node always started with same peer id  
because [`.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice) (clone) and [`.subarray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray) (mutable reference) were confused  
so randomness was not written back to wasm memory

- https://github.com/paritytech/smoldot/pull/3095#issuecomment-1424384728