### PR TITLE
Properly accept relayChain and paraId spellings

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- The alternative spellings `relayChain` and `paraId` for the `relay_chain` and `para_id` fields in chain specifications are now properly accepted as intended.
+- The alternative spellings `relayChain` and `paraId` for the `relay_chain` and `para_id` fields in chain specifications are now properly accepted as intended. ([#160](https://github.com/smol-dot/smoldot/pull/160))
 
 ## 0.7.10 - 2022-02-10
 

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- The alternative spellings `relayChain` and `paraId` for the `relay_chain` and `para_id` fields in chain specifications are now properly accepted as intended.
+
 ## 0.7.10 - 2022-02-10
 
 ### Fixed

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -70,6 +70,10 @@ impl ChainSpec {
             structs::Genesis::StateRootHash(_) => true,
         });
 
+        if client_spec.relay_chain.is_some() != client_spec.para_id.is_some() {
+            return Err(ParseError(ParseErrorInner::Other));
+        }
+
         // Make sure that the light sync state can be successfully decoded.
         if let Some(light_sync_state) = &client_spec.light_sync_state {
             // TODO: this "4" constant is repeated
@@ -277,10 +281,13 @@ impl ChainSpec {
 
     // TODO: this API is probably unstable, as the meaning of the string is unclear
     pub fn relay_chain(&self) -> Option<(&str, u32)> {
-        self.client_spec
-            .parachain
-            .as_ref()
-            .map(|p| (p.relay_chain.as_str(), p.para_id))
+        match (
+            self.client_spec.relay_chain.as_ref(),
+            self.client_spec.para_id.as_ref(),
+        ) {
+            (Some(r), Some(p)) => Some((r.as_str(), *p)),
+            _ => None,
+        }
     }
 
     /// Gives access to what is known about the storage of the genesis block of the chain.
@@ -530,5 +537,94 @@ mod tests {
                 Bootnode::UnrecognizedFormat("/some/wrong/multiaddress")
             ]
         );
+    }
+
+    #[test]
+    fn relay_chain_para_id_either_both_present_or_absent() {
+        ChainSpec::from_json_bytes(
+            &r#"{
+            "name": "Test",
+            "id": "test",
+            "bootNodes": [],
+            "genesis": {
+              "raw": {
+                "top": {},
+                "childrenDefault": {}
+              }
+            }
+          }
+          "#,
+        )
+        .unwrap();
+
+        ChainSpec::from_json_bytes(
+            &r#"{
+            "name": "Test",
+            "id": "test",
+            "bootNodes": [],
+            "relay_chain": "foo",
+            "para_id": 1,
+            "genesis": {
+              "raw": {
+                "top": {},
+                "childrenDefault": {}
+              }
+            }
+          }
+          "#,
+        )
+        .unwrap();
+
+        ChainSpec::from_json_bytes(
+            &r#"{
+            "name": "Test",
+            "id": "test",
+            "bootNodes": [],
+            "relayChain": "foo",
+            "paraId": 1,
+            "genesis": {
+              "raw": {
+                "top": {},
+                "childrenDefault": {}
+              }
+            }
+          }
+          "#,
+        )
+        .unwrap();
+
+        assert!(ChainSpec::from_json_bytes(
+            &r#"{
+            "name": "Test",
+            "id": "test",
+            "bootNodes": [],
+            "relayChain": "foo",
+            "genesis": {
+              "raw": {
+                "top": {},
+                "childrenDefault": {}
+              }
+            }
+          }
+          "#,
+        )
+        .is_err());
+
+        assert!(ChainSpec::from_json_bytes(
+            &r#"{
+            "name": "Test",
+            "id": "test",
+            "bootNodes": [],
+            "paraId": 1,
+            "genesis": {
+              "raw": {
+                "top": {},
+                "childrenDefault": {}
+              }
+            }
+          }
+          "#,
+        )
+        .is_err());
     }
 }

--- a/src/chain_spec/structs.rs
+++ b/src/chain_spec/structs.rs
@@ -67,22 +67,15 @@ pub(super) struct ClientSpec {
     pub(super) consensus_engine: (),
     pub(super) genesis: Genesis,
     pub(super) light_sync_state: Option<LightSyncState>,
-    #[serde(flatten)]
-    pub(super) parachain: Option<ChainSpecParachain>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(deny_unknown_fields)]
-pub(super) struct ChainSpecParachain {
     // Note that in Substrate/Cumulus this field is only named `relay_chain` and `relayChain` is
     // not accepted (as of 2022-06-09). This seems to be an oversight, as there are only two
     // fields that use snake_case while the rest uses camelCase. For this reason, smoldot
     // supports both.
-    #[serde(alias = "relayChain")]
-    pub(super) relay_chain: String,
+    #[serde(alias = "relay_chain")]
+    pub(super) relay_chain: Option<String>,
     // Same remark concerning the name as `relay_chain`
-    #[serde(alias = "paraId")]
-    pub(super) para_id: u32,
+    #[serde(alias = "para_id")]
+    pub(super) para_id: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Fix #42 

I think that serde isn't working as intended, so let's do it differently.
