### PR TITLE
Fix debug_assert failure in noise.rs

### DIFF
--- a/src/libp2p/connection/noise.rs
+++ b/src/libp2p/connection/noise.rs
@@ -592,6 +592,7 @@ impl HandshakeInProgress {
         };
 
         self.tx_buffer_encrypted.resize(512, 0);
+        self.tx_buffer_encrypted.make_contiguous(); // TODO: this is a hack to fix the follow-up debug_assert! from triggering; fixing this properly requires bigger changes
         debug_assert!(self.tx_buffer_encrypted.as_slices().1.is_empty());
         let written = self
             .inner


### PR DESCRIPTION
Fix #16 

I've opted for the hacky solution because the way this module is implemented is already very unsatisfactory. It was written in the early days of smoldot, and has big API issues that will require a big rewrite anyway.
