### PR TITLE
Fix Debug impl of Children using hexadecimal

### DIFF
--- a/src/trie/proof_decode.rs
+++ b/src/trie/proof_decode.rs
@@ -739,13 +739,13 @@ impl Children {
 
 impl fmt::Debug for Children {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:016x}", self.children_bitmap)
+        write!(f, "{:016b}", self.children_bitmap)
     }
 }
 
 impl fmt::Binary for Children {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:016x}", self.children_bitmap)
+        write!(f, "{:016b}", self.children_bitmap)
     }
 }
 


### PR DESCRIPTION
Amends #175

It was intended to be binary. I changed it last second before opening the PR.