### PR TITLE
Remove grabbing __indirect_function_table

### DIFF
--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The Wasm virtual machine no longer tries to grab a table symbol named `__indirect_function_table`. This removes support for an old Substrate feature that no longer exists.
+
 ## 0.7.11 - 2022-02-13
 
 ### Changed

--- a/src/executor/vm.rs
+++ b/src/executor/vm.rs
@@ -30,16 +30,6 @@
 //! meaning, but will later be passed back to the user through [`ExecOutcome::Interrupted::id`]
 //! when the corresponding function is called.
 //!
-//! The WebAssembly code can export functions in two different ways:
-//!
-//! - Some functions are exported through an `(export)` statement.
-//!   See <https://webassembly.github.io/spec/core/bikeshed/#export-section%E2%91%A0>.
-//! - Some functions are stored in a global table called `__indirect_function_table`, and are
-//!   later referred to by their index in this table. This is how the concept of "function
-//!   pointers" commonly found in low-level programming languages is translated in WebAssembly.
-//!
-//! > **Note**: At the time of writing, it isn't possible to call the second type of functions yet.
-//!
 //! Use [`VirtualMachinePrototype::start`] in order to start executing a function exported through
 //! an `(export)` statement.
 //!
@@ -48,17 +38,6 @@
 //! the WebAssembly code calls a host function. In the latter case, [`ExecOutcome::Interrupted`]
 //! is returned and the virtual machine is now paused. Once the logic of the host function has
 //! been executed, call `run` again, passing the return value of that host function.
-//!
-//! # About `__indirect_function_table`
-//!
-//! At initialization, the virtual machine will look for a table named `__indirect_function_table`.
-//! If present, this table is expected to contain functions. These functions can then be referred
-//! to by their index in this table. This is how the concept of "function pointers" commonly found
-//! in programming languages is translated in WebAssembly.
-//!
-//! > **Note**: When compiling C, C++, Rust, or similar languages to WebAssembly, one must pass
-//! >           the `--export-table` option to the LLVM linker in order for this symbol to be
-//! >           exported.
 //!
 //! # About imported vs exported memory
 //!
@@ -712,9 +691,6 @@ pub enum NewErr {
     NoMemory,
     /// Wasm module both imports and exports a memory.
     TwoMemories,
-    /// If a `__indirect_function_table` symbol is provided, it must be a table.
-    #[display(fmt = "If a \"__indirect_function_table\" symbol is provided, it must be a table.")]
-    IndirectTableIsntTable,
     /// Failed to allocate memory for the virtual machine.
     CouldntAllocateMemory,
     /// Error while parsing or compiling the WebAssembly code.

--- a/src/executor/vm/interpreter.rs
+++ b/src/executor/vm/interpreter.rs
@@ -282,7 +282,7 @@ impl InterpreterPrototype {
                     .iter()
                     .map(|v| wasmi::Value::from(*v))
                     .collect::<Vec<_>>(),
-            ))
+            )),
         })
     }
 }

--- a/src/executor/vm/interpreter.rs
+++ b/src/executor/vm/interpreter.rs
@@ -63,12 +63,6 @@ pub struct InterpreterPrototype {
 
     /// Memory of the module instantiation.
     memory: wasmi::Memory,
-
-    /// Table of the indirect function calls.
-    ///
-    /// In Wasm, function pointers are in reality indices in a table called
-    /// `__indirect_function_table`. This is this table, if it exists.
-    indirect_table: Option<wasmi::Table>,
 }
 
 impl InterpreterPrototype {
@@ -177,21 +171,12 @@ impl InterpreterPrototype {
             return Err(NewErr::NoMemory);
         };
 
-        let indirect_table =
-            if let Some(tbl) = instance.get_table(&store, "__indirect_function_table") {
-                // TODO: we don't detect NewErr::IndirectTableIsntTable
-                Some(tbl.clone())
-            } else {
-                None
-            };
-
         Ok(InterpreterPrototype {
             store,
             instance,
             linker,
             module: module.inner.clone(),
             memory,
-            indirect_table,
         })
     }
 
@@ -297,8 +282,7 @@ impl InterpreterPrototype {
                     .iter()
                     .map(|v| wasmi::Value::from(*v))
                     .collect::<Vec<_>>(),
-            )),
-            indirect_table: self.indirect_table,
+            ))
         })
     }
 }
@@ -338,12 +322,6 @@ pub struct Interpreter {
 
     /// Linker used to create instances.
     linker: wasmi::Linker<()>,
-
-    /// Table of the indirect function calls.
-    ///
-    /// In Wasm, function pointers are in reality indices in a table called
-    /// `__indirect_function_table`. This is this table, if it exists.
-    indirect_table: Option<wasmi::Table>,
 
     /// Execution context of this virtual machine. This notably holds the program counter, state
     /// of the stack, and so on.
@@ -528,7 +506,6 @@ impl Interpreter {
             linker: self.linker,
             module: self.module,
             memory: self.memory,
-            indirect_table: self.indirect_table,
         }
     }
 }

--- a/src/executor/vm/jit.rs
+++ b/src/executor/vm/jit.rs
@@ -74,10 +74,6 @@ pub struct JitPrototype {
 
     /// Reference to the memory used by the module.
     memory: wasmtime::Memory,
-
-    /// Reference to the table of indirect functions, in case we need to access it.
-    /// `None` if the module doesn't export such table.
-    indirect_table: Option<wasmtime::Table>,
 }
 
 impl JitPrototype {
@@ -272,23 +268,11 @@ impl JitPrototype {
             (None, None) => return Err(NewErr::NoMemory),
         };
 
-        let indirect_table =
-            if let Some(tbl) = instance.get_export(&mut store, "__indirect_function_table") {
-                if let Some(tbl) = tbl.into_table() {
-                    Some(tbl)
-                } else {
-                    return Err(NewErr::IndirectTableIsntTable);
-                }
-            } else {
-                None
-            };
-
         Ok(JitPrototype {
             store,
             instance,
             shared,
             memory,
-            indirect_table,
         })
     }
 
@@ -356,7 +340,6 @@ impl JitPrototype {
             instance: self.instance,
             shared: self.shared,
             memory: self.memory,
-            indirect_table: self.indirect_table,
         })
     }
 }
@@ -460,9 +443,6 @@ pub struct Jit {
 
     /// See [`JitPrototype::memory`].
     memory: wasmtime::Memory,
-
-    /// See [`JitPrototype::indirect_table`].
-    indirect_table: Option<wasmtime::Table>,
 }
 
 enum JitInner {
@@ -834,7 +814,6 @@ impl Jit {
             instance: self.instance,
             shared: self.shared,
             memory: self.memory,
-            indirect_table: self.indirect_table,
         }
     }
 }


### PR DESCRIPTION
This finishes to remove support for the sandboxing feature that no longer exists.

cc https://github.com/smol-dot/smoldot/pull/170