### PR TITLE
Check signatures of host functions at initialization and sync functions list with spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ serde_json = { version = "1.0.93", default-features = false, features = ["alloc"
 sha2 = { version = "0.10.6", default-features = false }
 siphasher = { version = "0.3.10", default-features = false }
 slab = { version = "0.4.7", default-features = false }
-smallvec = "1.10.0"
+smallvec = { version = "1.10.0", default-features = false }
 snow = { version = "0.9.1", default-features = false, features = ["default-resolver"] }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 twox-hash = { version = "1.6.3", default-features = false }

--- a/bin/wasm-node/CHANGELOG.md
+++ b/bin/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - The Wasm virtual machine no longer tries to grab a table symbol named `__indirect_function_table`. This removes support for an old Substrate feature that no longer exists.
+- The signature of host functions called by the Wasm runtime is now checked when the Wasm code is compiled rather than when the functions are called.
 
 ## 0.7.11 - 2022-02-13
 

--- a/src/executor/vm.rs
+++ b/src/executor/vm.rs
@@ -394,6 +394,17 @@ pub struct Signature {
     ret_ty: Option<ValueType>,
 }
 
+// TODO: figure out how to optimize so that we can use this macro in a const context
+#[macro_export]
+macro_rules! signature {
+    (($($param:expr),* $(,)?) => ()) => {
+        $crate::executor::vm::Signature::from_components(smallvec::smallvec!($($param),*), None)
+    };
+    (($($param:expr),* $(,)?) => $ret:expr) => {
+        $crate::executor::vm::Signature::from_components(smallvec::smallvec!($($param),*), Some($ret))
+    };
+}
+
 impl Signature {
     /// Creates a [`Signature`] from the given parameter types and return type.
     pub fn new(
@@ -404,6 +415,15 @@ impl Signature {
             params: params.collect(),
             ret_ty: ret_ty.into(),
         }
+    }
+
+    // TODO: find a way to remove? it is used only by the signature! macro
+    #[doc(hidden)]
+    pub(crate) fn from_components(
+        params: SmallVec<[ValueType; 8]>,
+        ret_ty: Option<ValueType>,
+    ) -> Self {
+        Signature { params, ret_ty }
     }
 
     /// Returns a list of all the types of the parameters.


### PR DESCRIPTION
We now verify the signatures of host functions directly when initializing the prototype.
This removes some error conditions.

Additionally, this PR synchronizes the list of functions that we support with the functions on https://spec.polkadot.network/
All the `todo!()`s have been removed, meaning that a malicious runtime can no longer make smoldot panic.
