### PR TITLE
Zero the Wasm VM memory after a reset

### DIFF
--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -212,7 +212,10 @@ pub struct Prepare {
 
 impl Prepare {
     /// See [`super::Prepare::into_prototype`].
-    pub fn into_prototype(self) -> InterpreterPrototype {
+    pub fn into_prototype(mut self) -> InterpreterPrototype {
+        // Zero-ing the memory to cancel any write that might have been performed.
+        self.inner.memory.data_mut(&mut self.inner.store).fill(0);
+
         self.inner
     }
 
@@ -562,7 +565,8 @@ impl Interpreter {
 
     /// See [`super::VirtualMachine::into_prototype`].
     pub fn into_prototype(mut self) -> InterpreterPrototype {
-        // TODO: zero the memory
+        // Zero the memory.
+        self.memory.data_mut(&mut self.store).fill(0);
 
         // Because we have successfully instantiated the module in the past, there's no reason
         // why instantiating again could fail now and not before.

--- a/lib/src/executor/vm/tests.rs
+++ b/lib/src/executor/vm/tests.rs
@@ -643,6 +643,75 @@ fn memory_grow_detects_limit_within_host_function() {
     }
 }
 
+#[test]
+fn memory_zeroed_after_reset() {
+    let module_bytes = wat::parse_str(
+        r#"
+        (module
+            (import "env" "memory" (memory $mem 1024 4096))
+            (func (export "hello"))
+        )
+        "#,
+    )
+    .unwrap();
+
+    for exec_hint in super::ExecHint::available_engines() {
+        let module = super::Module::new(&module_bytes, exec_hint).unwrap();
+        let prototype = super::VirtualMachinePrototype::new(&module, |_, _, _| Ok(0)).unwrap();
+
+        let mut vm = prototype.prepare();
+        vm.write_memory(11, &[5, 6]).unwrap();
+
+        let mut vm = vm.start("hello", &[]).unwrap();
+        assert_eq!(vm.read_memory(12, 1).unwrap().as_ref()[0], 6);
+        vm.write_memory(12, &[7]).unwrap();
+        assert_eq!(vm.read_memory(12, 1).unwrap().as_ref()[0], 7);
+
+        assert!(matches!(
+            vm.run(None),
+            Ok(super::ExecOutcome::Finished {
+                return_value: Ok(None),
+            })
+        ));
+
+        assert_eq!(vm.read_memory(11, 2).unwrap().as_ref(), &[5, 7]);
+
+        let prototype = vm.into_prototype();
+        let vm = prototype.prepare();
+        assert_eq!(vm.read_memory(11, 2).unwrap().as_ref(), &[0, 0]);
+        assert_eq!(vm.read_memory(12, 1).unwrap().as_ref(), &[0]);
+
+        let vm = vm.start("hello", &[]).unwrap();
+        assert_eq!(vm.read_memory(11, 2).unwrap().as_ref(), &[0, 0]);
+        assert_eq!(vm.read_memory(12, 1).unwrap().as_ref(), &[0]);
+    }
+}
+
+#[test]
+fn memory_zeroed_after_prepare() {
+    let module_bytes = wat::parse_str(
+        r#"
+        (module
+            (import "env" "memory" (memory $mem 1024 4096))
+            (func (export "hello"))
+        )
+        "#,
+    )
+    .unwrap();
+
+    for exec_hint in super::ExecHint::available_engines() {
+        let module = super::Module::new(&module_bytes, exec_hint).unwrap();
+        let prototype = super::VirtualMachinePrototype::new(&module, |_, _, _| Ok(0)).unwrap();
+
+        let mut vm = prototype.prepare();
+        assert_eq!(vm.read_memory(11, 2).unwrap().as_ref(), &[0, 0]);
+        vm.write_memory(11, &[5, 6]).unwrap();
+
+        let vm = vm.into_prototype().prepare();
+        assert_eq!(vm.read_memory(11, 2).unwrap().as_ref(), &[0, 0]);
+    }
+}
+
 // TODO: test for memory reads and writes, including within host functions
 
-// TODO: test that the memory gets reinitialized when reusing the prototype
+// TODO: test that the stack/locals get reinitialized when reusing the prototype after a trap

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- The memory of the Wasm virtual machine is now properly zeroed between runs.
+- The memory of the Wasm virtual machine is now properly zeroed between runs. ([#205](https://github.com/smol-dot/smoldot/pull/205))
 - The Wasm virtual machine no longer tries to grab a table symbol named `__indirect_function_table`. This removes support for an old Substrate feature that no longer exists. ([#181](https://github.com/smol-dot/smoldot/pull/181))
 - The signature of host functions called by the Wasm runtime is now checked when the Wasm code is compiled rather than when the functions are called. ([#183](https://github.com/smol-dot/smoldot/pull/183))
 - When a Wasm function is being called, the parameters of the function are now allocated using the same allocator as used during the execution (`ext_allocator_malloc_version_1` and `ext_allocator_free_version_1`) rather than being written at a specific location in memory. This is consistent with what Substrate is doing, and makes it legal for a Wasm runtime to call `ext_allocator_free_version_1` on the input data if desired. ([#188](https://github.com/smol-dot/smoldot/pull/188))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- The memory of the Wasm virtual machine is now properly zeroed between runs.
 - The Wasm virtual machine no longer tries to grab a table symbol named `__indirect_function_table`. This removes support for an old Substrate feature that no longer exists. ([#181](https://github.com/smol-dot/smoldot/pull/181))
 - The signature of host functions called by the Wasm runtime is now checked when the Wasm code is compiled rather than when the functions are called. ([#183](https://github.com/smol-dot/smoldot/pull/183))
 - When a Wasm function is being called, the parameters of the function are now allocated using the same allocator as used during the execution (`ext_allocator_malloc_version_1` and `ext_allocator_free_version_1`) rather than being written at a specific location in memory. This is consistent with what Substrate is doing, and makes it legal for a Wasm runtime to call `ext_allocator_free_version_1` on the input data if desired. ([#188](https://github.com/smol-dot/smoldot/pull/188))


### PR DESCRIPTION
This simple change hasn't been done before because it slows down the execution of the full node by a lot.
However, correctness is more important than speed.

I've now added a test to make sure that this behavior stays, and we'll optimize the code later.