### PR TITLE
Fix panic when Wasm input is too large

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -472,6 +472,15 @@ impl HostVmPrototype {
             }
         };
 
+        // While the allocator has reserved memory, it might have reserved more memory than its
+        // current size.
+        if let Some(to_grow) = ((data_ptr + data_len_u32).saturating_sub(1) / (64 * 1024) + 1)
+            .checked_sub(u32::from(vm.memory_size()))
+        {
+            // If the memory can't be grown, it indicates a bug in the allocator.
+            vm.grow_memory(HeapPages::from(to_grow)).unwrap();
+        }
+
         // Writing the input data into the VM.
         let mut data_ptr_iter = data_ptr;
         for data in data {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Fix panic when the input data of a Wasm function call is larger than a Wasm page.
+- Fix panic when the input data of a Wasm function call is larger than a Wasm page. ([#218](https://github.com/smol-dot/smoldot/pull/218))
 
 ## 0.7.12 - 2022-02-22
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+- Fix panic when the input data of a Wasm function call is larger than a Wasm page.
+
 ## 0.7.12 - 2022-02-22
 
 ### Changed


### PR DESCRIPTION
The allocator makes sure to the grow memory for its own metadata, but doesn't necessarily grow the memory enough for the allocated data to fit.