### PR TITLE
Remove usage of the `tracing` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,15 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,18 +423,6 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
 ]
 
 [[package]]
@@ -1538,15 +1517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,37 +1733,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2109,15 +2054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,15 +2234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,7 +2292,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parity-scale-codec",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pbkdf2",
  "pin-project",
  "rand",
@@ -2401,6 +2328,7 @@ dependencies = [
  "derive_more",
  "directories",
  "either",
+ "env_logger",
  "event-listener",
  "fnv",
  "futures",
@@ -2412,8 +2340,6 @@ dependencies = [
  "rand",
  "smoldot",
  "terminal_size",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2433,7 +2359,7 @@ dependencies = [
  "itertools",
  "log",
  "lru",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand",
  "serde",
  "serde_json",
@@ -2655,15 +2581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,71 +2631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "parking_lot 0.11.2",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-serde",
-]
-
-[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,12 +2673,6 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "futures-timer",
  "hashbrown 0.13.2",
  "hex",
+ "log",
  "mick-jaeger",
  "rand",
  "smoldot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,6 +2338,8 @@ dependencies = [
  "log",
  "mick-jaeger",
  "rand",
+ "serde",
+ "serde_json",
  "smoldot",
  "terminal_size",
 ]

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -28,6 +28,7 @@ futures = { version = "0.3.26", default-features = false, features = ["std", "th
 futures-timer = "3.0"
 hashbrown = { version = "0.13.2", default-features = false }
 hex = { version = "0.4.3", default-features = false }
+log = { version = "0.4.17", default-features = false }
 mick-jaeger = "0.1.8"
 rand = "0.8.5"
 smoldot = { version = "0.5.0", path = "../lib", default-features = false, features = ["database-sqlite", "std"] }

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -22,6 +22,7 @@ ctrlc = "3.2.5"
 derive_more = "0.99.17"
 directories = "4.0.1"
 either = { version = "1.8.1", default-features = false }
+env_logger = { version = "0.10.0", default-features = false, features = ["auto-color", "humantime"] }
 event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
 futures = { version = "0.3.26", default-features = false, features = ["std", "thread-pool"] }
@@ -33,5 +34,3 @@ mick-jaeger = "0.1.8"
 rand = "0.8.5"
 smoldot = { version = "0.5.0", path = "../lib", default-features = false, features = ["database-sqlite", "std"] }
 terminal_size = "0.2.5"
-tracing = { version = "0.1.37", features = ["attributes"] }
-tracing-subscriber = { version = "0.2.25", default-features = false, features = ["ansi", "chrono", "env-filter", "json", "fmt", "parking_lot", "smallvec"] }

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -32,5 +32,7 @@ hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.17", default-features = false }
 mick-jaeger = "0.1.8"
 rand = "0.8.5"
+serde = { version = "1.0.152", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.93", default-features = false, features = ["std"] }
 smoldot = { version = "0.5.0", path = "../lib", default-features = false, features = ["database-sqlite", "std"] }
 terminal_size = "0.2.5"

--- a/full-node/src/cli.rs
+++ b/full-node/src/cli.rs
@@ -36,7 +36,7 @@ use smoldot::{
         PeerId,
     },
 };
-use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+use std::{net::SocketAddr, path::PathBuf};
 
 // Note: the doc-comments applied to this struct and its field are visible when the binary is
 // started with `--help`.

--- a/full-node/src/cli.rs
+++ b/full-node/src/cli.rs
@@ -69,7 +69,7 @@ pub struct CliOptionsRun {
     pub output: Output,
     /// Log filter. Example: `foo=trace`
     #[arg(long)]
-    pub log: Vec<LogDirective>,
+    pub log: Vec<String>,
     /// Coloring: auto, always, never
     #[arg(long, default_value = "auto")]
     pub color: ColorChoice,
@@ -179,23 +179,6 @@ fn parse_json_rpc_address(string: &str) -> Result<JsonRpcAddress, String> {
     }
 
     Err("Failed to parse JSON-RPC server address".into())
-}
-
-#[derive(Debug)]
-pub struct LogDirective(pub tracing_subscriber::filter::Directive);
-
-impl Clone for LogDirective {
-    fn clone(&self) -> Self {
-        LogDirective(self.0.to_string().parse().unwrap())
-    }
-}
-
-impl FromStr for LogDirective {
-    type Err = <tracing_subscriber::filter::Directive as FromStr>::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(LogDirective(s.parse()?))
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -794,7 +794,7 @@ impl SyncBackground {
         // Block has now finished being generated.
         let new_block_hash = header::hash_from_scale_encoded_header(&block.scale_encoded_header);
         log::info!(
-            "block-generated; hash={}, body_len={}, runtime_logs={:?}",
+            "block-generated; hash={}; body_len={}; runtime_logs={:?}",
             HashDisplay(&new_block_hash),
             block.body.len(),
             block.logs

--- a/full-node/src/run/jaeger_service.rs
+++ b/full-node/src/run/jaeger_service.rs
@@ -38,7 +38,6 @@ use async_std::net::UdpSocket;
 use futures::prelude::*;
 use smoldot::libp2p::PeerId;
 use std::{convert::TryFrom as _, io, net::SocketAddr, num::NonZeroU128, sync::Arc};
-use tracing::Instrument as _;
 
 /// Configuration for a [`JaegerService`].
 pub struct Config<'a> {
@@ -68,18 +67,15 @@ impl JaegerService {
             let udp_socket = UdpSocket::bind("0.0.0.0:0").await?;
 
             // Spawn a background task that pulls span information and sends them on the network.
-            (config.tasks_executor)(Box::pin(
-                async move {
-                    loop {
-                        let buf = traces_out.next().await;
-                        // UDP sending errors happen only either if the API is misused (in which case
-                        // panicking is desirable) or in case of missing priviledge, in which case a
-                        // panic is preferable in order to inform the user.
-                        udp_socket.send_to(&buf, jaeger_agent).await.unwrap();
-                    }
+            (config.tasks_executor)(Box::pin(async move {
+                loop {
+                    let buf = traces_out.next().await;
+                    // UDP sending errors happen only either if the API is misused (in which case
+                    // panicking is desirable) or in case of missing priviledge, in which case a
+                    // panic is preferable in order to inform the user.
+                    udp_socket.send_to(&buf, jaeger_agent).await.unwrap();
                 }
-                .instrument(tracing::trace_span!(parent: None, "jaeger-service")),
-            ));
+            }));
         }
 
         Ok(Arc::new(JaegerService { traces_in }))


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/46

As explained in the issue, despite having tried it for a long time I don't actually see the point of this crate. Spans are confusing and quite useless, and there's no traces sink that works well apart from the same ones as `log` (stdout and writing to files).
