### PR TITLE
Finish implementing state_version = 1

### DIFF
--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -1332,7 +1332,9 @@ async fn database_blocks(
                         .as_ref()
                         .unwrap()
                         .storage_top_trie_changes
-                        .diff_iter_unordered(),
+                        .diff_iter_unordered()
+                        .map(|(k, v, ())| (k, v)),
+                    u8::from(block.full.as_ref().unwrap().state_trie_version),
                 );
 
                 match result {

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -28,6 +28,8 @@ use crate::{
 use alloc::vec::Vec;
 use core::{num::NonZeroU64, time::Duration};
 
+pub use runtime::TrieEntryVersion;
+
 /// Configuration for a block generation.
 pub struct Config<'a, TLocAuth> {
     /// Consensus-specific configuration.
@@ -311,8 +313,10 @@ impl StorageGet {
     pub fn inject_value(
         self,
         value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
+        storage_trie_node_version: TrieEntryVersion,
     ) -> BuilderAuthoring {
-        self.1.with_runtime_inner(self.0.inject_value(value))
+        self.1
+            .with_runtime_inner(self.0.inject_value(value, storage_trie_node_version))
     }
 }
 

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -312,11 +312,9 @@ impl StorageGet {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> BuilderAuthoring {
-        self.1
-            .with_runtime_inner(self.0.inject_value(value, storage_trie_node_version))
+        self.1.with_runtime_inner(self.0.inject_value(value))
     }
 }
 

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -58,6 +58,8 @@ use crate::{
 use alloc::{borrow::ToOwned as _, string::String, vec::Vec};
 use core::{iter, mem};
 
+pub use runtime_host::TrieEntryVersion;
+
 /// Configuration for a block generation.
 pub struct Config<'a> {
     /// Number of bytes used to encode block numbers in the header.
@@ -110,6 +112,9 @@ pub struct Success {
     pub parent_runtime: host::HostVmPrototype,
     /// List of changes to the storage top trie that the block performs.
     pub storage_top_trie_changes: storage_diff::StorageDiff,
+    /// State trie version indicated by the runtime. All the storage changes indicated by
+    /// [`Success::storage_top_trie_changes`] should store this version alongside with them.
+    pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: storage_diff::StorageDiff,
     /// Cache used for calculating the top trie root of the new block.
@@ -428,6 +433,7 @@ impl BlockBuild {
                         body: shared.block_body,
                         parent_runtime: success.virtual_machine.into_prototype(),
                         storage_top_trie_changes: success.storage_top_trie_changes,
+                        state_trie_version: success.state_trie_version,
                         offchain_storage_changes: success.offchain_storage_changes,
                         top_trie_root_calculation_cache: success.top_trie_root_calculation_cache,
                         logs: shared.logs,
@@ -595,8 +601,15 @@ impl StorageGet {
     }
 
     /// Injects the corresponding storage value.
-    pub fn inject_value(self, value: Option<impl Iterator<Item = impl AsRef<[u8]>>>) -> BlockBuild {
-        BlockBuild::from_inner(self.0.inject_value(value), self.1)
+    pub fn inject_value(
+        self,
+        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
+        storage_trie_node_version: TrieEntryVersion,
+    ) -> BlockBuild {
+        BlockBuild::from_inner(
+            self.0.inject_value(value, storage_trie_node_version),
+            self.1,
+        )
     }
 }
 

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -603,13 +603,9 @@ impl StorageGet {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> BlockBuild {
-        BlockBuild::from_inner(
-            self.0.inject_value(value, storage_trie_node_version),
-            self.1,
-        )
+        BlockBuild::from_inner(self.0.inject_value(value), self.1)
     }
 }
 

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -62,7 +62,7 @@ fn block_building_works() {
                     .iter()
                     .find(|(k, _)| *k == get.key().as_ref())
                     .map(|(_, v)| iter::once(v));
-                builder = get.inject_value(value, super::TrieEntryVersion::V0);
+                builder = get.inject_value(value.map(|v| (v, super::TrieEntryVersion::V0)));
             }
             super::BlockBuild::NextKey(_) => unimplemented!(), // Not needed for this test.
             super::BlockBuild::PrefixKeys(prefix) => {

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -62,7 +62,7 @@ fn block_building_works() {
                     .iter()
                     .find(|(k, _)| *k == get.key().as_ref())
                     .map(|(_, v)| iter::once(v));
-                builder = get.inject_value(value);
+                builder = get.inject_value(value, super::TrieEntryVersion::V0);
             }
             super::BlockBuild::NextKey(_) => unimplemented!(), // Not needed for this test.
             super::BlockBuild::PrefixKeys(prefix) => {

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -947,10 +947,9 @@ impl<T> StorageGet<T> {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> BodyVerifyStep2<T> {
-        let inner = self.inner.inject_value(value, storage_trie_node_version);
+        let inner = self.inner.inject_value(value);
         self.context.with_body_verify(inner)
     }
 }

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -143,7 +143,7 @@ impl ChainSpec {
                                 ) => {
                                     let key: alloc::vec::Vec<u8> = val.key().collect();
                                     let value = genesis_storage.value(&key[..]);
-                                    calculation = val.inject(state_version, value);
+                                    calculation = val.inject(value.map(move |v| (v, state_version)));
                                 }
                             }
                             }

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -116,12 +116,11 @@ impl ChainSpec {
         let mut chain_information_build = build::ChainInformationBuild::new(build::Config {
             finalized_block_header: build::ConfigFinalizedBlockHeader::Genesis {
                 state_trie_root_hash: {
-                    let state_version = match vm_prototype.runtime_version().decode().state_version
-                    {
-                        Some(0) | None => trie::TrieEntryVersion::V0,
-                        Some(1) => trie::TrieEntryVersion::V1,
-                        Some(_) => return Err(FromGenesisStorageError::UnknownStateVersion),
-                    };
+                    let state_version = vm_prototype
+                        .runtime_version()
+                        .decode()
+                        .state_version
+                        .unwrap_or(trie::TrieEntryVersion::V0);
 
                     match self.genesis_storage() {
                         GenesisStorage::TrieRootHash(hash) => *hash,
@@ -496,8 +495,6 @@ pub enum FromGenesisStorageError {
     /// Error when initializing the virtual machine.
     #[display(fmt = "Error when initializing the virtual machine: {}", _0)]
     VmInitialization(executor::host::NewErr),
-    /// State version in runtime specification is not supported.
-    UnknownStateVersion,
     /// Chain specification doesn't contain the list of storage items.
     UnknownStorageItems,
 }

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -383,14 +383,16 @@ impl SqliteFullDatabase {
                 .bind(1, &block_hash[..])
                 .unwrap()
                 .bind(2, key.as_ref())
-                .unwrap()
-                .bind(3, i64::from(trie_entries_version))
                 .unwrap();
             if let Some(value) = value {
-                statement = statement.bind(3, value.as_ref()).unwrap();
+                statement = statement
+                    .bind(3, value.as_ref())
+                    .unwrap()
+                    .bind(4, i64::from(trie_entries_version))
+                    .unwrap();
             } else {
                 // Binds NULL.
-                statement = statement.bind(3, ()).unwrap();
+                statement = statement.bind(3, ()).unwrap().bind(4, ()).unwrap();
             }
             statement.next().unwrap();
             statement = statement.reset().unwrap();

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -949,6 +949,7 @@ pub enum CorruptedError {
     ConsensusAlgorithmMix,
     /// The information about a Babe epoch found in the database has failed to decode.
     InvalidBabeEpochInformation,
+    /// The version information about a storage entry has failed to decode.
     InvalidTrieEntryVersion,
     #[display(fmt = "Internal error: {}", _0)]
     Internal(InternalError),

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -141,7 +141,8 @@ Storage at the highest block that is considered finalized.
 */
 CREATE TABLE IF NOT EXISTS finalized_storage_top_trie(
     key BLOB NOT NULL PRIMARY KEY,
-    value BLOB NOT NULL
+    value BLOB NOT NULL,
+    trie_entry_version INTEGER NOT NULL
 );
 
 /*
@@ -155,8 +156,11 @@ CREATE TABLE IF NOT EXISTS non_finalized_changes(
     -- `value` is NULL if the block removes the key from the storage, and NON-NULL if it inserts
     -- or replaces the value at the key.
     value BLOB,
+    -- Same NULL-ness remark as for `value`
+    trie_entry_version INTEGER,
     UNIQUE(hash, key),
     CHECK(length(hash) == 32),
+    CHECK((trie_entry_version IS NULL AND value IS NULL) OR (trie_entry_version IS NOT NULL AND value IS NOT NULL)),
     FOREIGN KEY (hash) REFERENCES blocks(hash) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
@@ -267,12 +271,13 @@ impl DatabaseEmpty {
     /// order to turn it into an actual database.
     ///
     /// Must also pass the body, justification, and state of the storage of the finalized block.
+    // TODO strong typing for finalized_block_storage_top_trie_entries
     pub fn initialize<'a>(
         self,
         chain_information: impl Into<chain_information::ChainInformationRef<'a>>,
         finalized_block_body: impl ExactSizeIterator<Item = &'a [u8]>,
         finalized_block_justification: Option<Vec<u8>>,
-        finalized_block_storage_top_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8])> + Clone,
+        finalized_block_storage_top_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8], u8)> + Clone,
     ) -> Result<SqliteFullDatabase, AccessError> {
         let chain_information = chain_information.into();
 
@@ -291,10 +296,16 @@ impl DatabaseEmpty {
         {
             let mut statement = self
                 .database
-                .prepare("INSERT INTO finalized_storage_top_trie(key, value) VALUES(?, ?)")
+                .prepare("INSERT INTO finalized_storage_top_trie(key, value, trie_entry_version) VALUES(?, ?, ?)")
                 .unwrap();
-            for (key, value) in finalized_block_storage_top_trie_entries {
-                statement = statement.bind(1, key).unwrap().bind(2, value).unwrap();
+            for (key, value, trie_entry_version) in finalized_block_storage_top_trie_entries {
+                statement = statement
+                    .bind(1, key)
+                    .unwrap()
+                    .bind(2, value)
+                    .unwrap()
+                    .bind(3, i64::from(trie_entry_version))
+                    .unwrap();
                 statement.next().unwrap();
                 statement = statement.reset().unwrap();
             }

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -277,7 +277,8 @@ impl DatabaseEmpty {
         chain_information: impl Into<chain_information::ChainInformationRef<'a>>,
         finalized_block_body: impl ExactSizeIterator<Item = &'a [u8]>,
         finalized_block_justification: Option<Vec<u8>>,
-        finalized_block_storage_top_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8], u8)> + Clone,
+        finalized_block_storage_top_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8])> + Clone,
+        finalized_block_state_version: u8,
     ) -> Result<SqliteFullDatabase, AccessError> {
         let chain_information = chain_information.into();
 
@@ -298,13 +299,13 @@ impl DatabaseEmpty {
                 .database
                 .prepare("INSERT INTO finalized_storage_top_trie(key, value, trie_entry_version) VALUES(?, ?, ?)")
                 .unwrap();
-            for (key, value, trie_entry_version) in finalized_block_storage_top_trie_entries {
+            for (key, value) in finalized_block_storage_top_trie_entries {
                 statement = statement
                     .bind(1, key)
                     .unwrap()
                     .bind(2, value)
                     .unwrap()
-                    .bind(3, i64::from(trie_entry_version))
+                    .bind(3, i64::from(finalized_block_state_version))
                     .unwrap();
                 statement.next().unwrap();
                 statement = statement.reset().unwrap();

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -271,7 +271,6 @@ impl DatabaseEmpty {
     /// order to turn it into an actual database.
     ///
     /// Must also pass the body, justification, and state of the storage of the finalized block.
-    // TODO strong typing for finalized_block_storage_top_trie_entries
     pub fn initialize<'a>(
         self,
         chain_information: impl Into<chain_information::ChainInformationRef<'a>>,

--- a/lib/src/executor/storage_diff.rs
+++ b/lib/src/executor/storage_diff.rs
@@ -43,7 +43,7 @@ use core::{cmp, fmt, iter, ops};
 use hashbrown::HashMap;
 
 #[derive(Clone)]
-pub struct StorageDiff {
+pub struct StorageDiff<T = ()> {
     /// Contains the same entries as [`StorageDiff::hashmap`], except that values are booleans
     /// indicating whether the value updates (`true`) or deletes (`false`) the underlying
     /// storage item.
@@ -54,10 +54,10 @@ pub struct StorageDiff {
     ///
     /// A FNV hasher is used because the runtime is supposed to guarantee a uniform distribution
     /// of storage keys.
-    hashmap: HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
+    hashmap: HashMap<Vec<u8>, (Option<Vec<u8>>, T), fnv::FnvBuildHasher>,
 }
 
-impl StorageDiff {
+impl<T> StorageDiff<T> {
     /// Builds a new empty diff.
     pub fn empty() -> Self {
         Self {
@@ -80,16 +80,19 @@ impl StorageDiff {
         &mut self,
         key: impl Into<Vec<u8>>,
         value: impl Into<Vec<u8>>,
-    ) -> Option<Option<Vec<u8>>> {
+        user_data: T,
+    ) -> Option<(Option<Vec<u8>>, T)> {
         let key = key.into();
         // Note that we clone the key here. This is considered as a tolerable overhead.
-        let previous = self.hashmap.insert(key.clone(), Some(value.into()));
+        let previous = self
+            .hashmap
+            .insert(key.clone(), (Some(value.into()), user_data));
         match &previous {
-            Some(Some(_)) => {
+            Some((Some(_), _)) => {
                 // No need to update `btree`.
                 debug_assert_eq!(self.btree.get(&key), Some(&true));
             }
-            None | Some(None) => {
+            None | Some((None, _)) => {
                 self.btree.insert(key, true);
             }
         }
@@ -100,16 +103,20 @@ impl StorageDiff {
     /// the base storage.
     ///
     /// Returns the value associated to this `key` that was previously in the diff, if any.
-    pub fn diff_insert_erase(&mut self, key: impl Into<Vec<u8>>) -> Option<Option<Vec<u8>>> {
+    pub fn diff_insert_erase(
+        &mut self,
+        key: impl Into<Vec<u8>>,
+        user_data: T,
+    ) -> Option<(Option<Vec<u8>>, T)> {
         let key = key.into();
         // Note that we clone the key here. This is considered as a tolerable overhead.
-        let previous = self.hashmap.insert(key.clone(), None);
+        let previous = self.hashmap.insert(key.clone(), (None, user_data));
         match &previous {
-            Some(None) => {
+            Some((None, _)) => {
                 // No need to update `btree`.
                 debug_assert_eq!(self.btree.get(&key), Some(&false));
             }
-            None | Some(Some(_)) => {
+            None | Some((Some(_), _)) => {
                 self.btree.insert(key, false);
             }
         }
@@ -119,21 +126,23 @@ impl StorageDiff {
     /// Removes from the diff the entry corresponding to the given `key`.
     ///
     /// Returns the value associated to this `key` that was previously in the diff, if any.
-    pub fn diff_remove(&mut self, key: impl AsRef<[u8]>) -> Option<Option<Vec<u8>>> {
+    pub fn diff_remove(&mut self, key: impl AsRef<[u8]>) -> Option<(Option<Vec<u8>>, T)> {
         let previous = self.hashmap.remove(key.as_ref());
         if let Some(_previous) = &previous {
             let _in_btree = self.btree.remove(key.as_ref());
-            debug_assert_eq!(_in_btree, Some(_previous.is_some()));
+            debug_assert_eq!(_in_btree, Some(_previous.0.is_some()));
         }
         previous
     }
 
     /// Returns the diff entry at the given key.
     ///
-    /// Returns `None` if the diff doesn't have any entry for this key, and `Some(None)` if the
-    /// diff has an entry that deletes the storage item.
-    pub fn diff_get(&self, key: &[u8]) -> Option<Option<&[u8]>> {
-        self.hashmap.get(key).map(|v| v.as_ref().map(|v| &v[..]))
+    /// Returns `None` if the diff doesn't have any entry for this key, and `Some((None, _))` if
+    /// the diff has an entry that deletes the storage item.
+    pub fn diff_get(&self, key: &[u8]) -> Option<(Option<&[u8]>, &T)> {
+        self.hashmap
+            .get(key)
+            .map(|(v, ud)| (v.as_ref().map(|v| &v[..]), ud))
     }
 
     /// Returns an iterator to all the entries in the diff.
@@ -142,10 +151,10 @@ impl StorageDiff {
     /// underlying value.
     pub fn diff_iter_unordered(
         &self,
-    ) -> impl ExactSizeIterator<Item = (&[u8], Option<&[u8]>)> + Clone {
+    ) -> impl ExactSizeIterator<Item = (&[u8], Option<&[u8]>, &T)> + Clone {
         self.hashmap
             .iter()
-            .map(|(k, v)| (&k[..], v.as_ref().map(|v| &v[..])))
+            .map(|(k, (v, ud))| (&k[..], v.as_ref().map(|v| &v[..]), ud))
     }
 
     /// Returns an iterator to all the entries in the diff.
@@ -154,8 +163,8 @@ impl StorageDiff {
     /// underlying value.
     pub fn diff_into_iter_unordered(
         self,
-    ) -> impl ExactSizeIterator<Item = (Vec<u8>, Option<Vec<u8>>)> {
-        self.hashmap.into_iter()
+    ) -> impl ExactSizeIterator<Item = (Vec<u8>, Option<Vec<u8>>, T)> {
+        self.hashmap.into_iter().map(|(k, (v, ud))| (k, v, ud))
     }
 
     /// Returns the storage value at the given key. `None` if this key doesn't have any value.
@@ -166,7 +175,7 @@ impl StorageDiff {
     ) -> Option<&'a [u8]> {
         self.hashmap
             .get(key)
-            .map_or_else(or_parent, |opt| opt.as_ref().map(|v| &v[..]))
+            .map_or_else(or_parent, |(opt, _)| opt.as_ref().map(|v| &v[..]))
     }
 
     /// Returns the storage key that immediately follows the provided `key`. Must be passed the
@@ -275,11 +284,14 @@ impl StorageDiff {
     }
 
     /// Applies the given diff on top of the current one.
-    pub fn merge(&mut self, other: &StorageDiff) {
+    pub fn merge(&mut self, other: &StorageDiff<T>)
+    where
+        T: Clone,
+    {
         // TODO: provide an alternative method that consumes `other` as well?
         for (key, value) in &other.hashmap {
             self.hashmap.insert(key.clone(), value.clone());
-            self.btree.insert(key.clone(), value.is_some());
+            self.btree.insert(key.clone(), value.0.is_some());
         }
     }
 }
@@ -307,17 +319,18 @@ impl Default for StorageDiff {
     }
 }
 
-impl FromIterator<(Vec<u8>, Option<Vec<u8>>)> for StorageDiff {
-    fn from_iter<T>(iter: T) -> Self
+impl<T> FromIterator<(Vec<u8>, Option<Vec<u8>>, T)> for StorageDiff<T> {
+    fn from_iter<I>(iter: I) -> Self
     where
-        T: IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
+        I: IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>, T)>,
     {
         let hashmap = iter
             .into_iter()
-            .collect::<HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>>();
+            .map(|(k, v, ud)| (k, (v, ud)))
+            .collect::<HashMap<Vec<u8>, (Option<Vec<u8>>, T), fnv::FnvBuildHasher>>();
         let btree = hashmap
             .iter()
-            .map(|(k, v)| (k.clone(), v.is_some()))
+            .map(|(k, (v, _))| (k.clone(), v.is_some()))
             .collect();
 
         Self { btree, hashmap }

--- a/lib/src/executor/storage_diff.rs
+++ b/lib/src/executor/storage_diff.rs
@@ -167,17 +167,6 @@ impl<T> StorageDiff<T> {
         self.hashmap.into_iter().map(|(k, (v, ud))| (k, v, ud))
     }
 
-    /// Returns the storage value at the given key. `None` if this key doesn't have any value.
-    pub fn storage_get<'a, 'b>(
-        &'a self,
-        key: &'b [u8],
-        or_parent: impl FnOnce() -> Option<&'a [u8]>,
-    ) -> Option<&'a [u8]> {
-        self.hashmap
-            .get(key)
-            .map_or_else(or_parent, |(opt, _)| opt.as_ref().map(|v| &v[..]))
-    }
-
     /// Returns the storage key that immediately follows the provided `key`. Must be passed the
     /// storage key that immediately follows the provided `key` according to the base storage this
     /// diff is based upon.

--- a/lib/src/executor/storage_diff.rs
+++ b/lib/src/executor/storage_diff.rs
@@ -288,10 +288,18 @@ impl<T> StorageDiff<T> {
     where
         T: Clone,
     {
+        self.merge_map(other, |v| v.clone())
+    }
+
+    /// Applies the given diff on top of the current one.
+    ///
+    /// Each user data in the other diff is first passed through the map.
+    pub fn merge_map<U>(&mut self, other: &StorageDiff<U>, map: impl FnMut(&U) -> T) {
         // TODO: provide an alternative method that consumes `other` as well?
-        for (key, value) in &other.hashmap {
-            self.hashmap.insert(key.clone(), value.clone());
-            self.btree.insert(key.clone(), value.0.is_some());
+        for (key, (value, user_data)) in &other.hashmap {
+            self.hashmap
+                .insert(key.clone(), (value.clone(), map(user_data)));
+            self.btree.insert(key.clone(), value.is_some());
         }
     }
 }

--- a/lib/src/executor/storage_diff.rs
+++ b/lib/src/executor/storage_diff.rs
@@ -294,7 +294,7 @@ impl<T> StorageDiff<T> {
     /// Applies the given diff on top of the current one.
     ///
     /// Each user data in the other diff is first passed through the map.
-    pub fn merge_map<U>(&mut self, other: &StorageDiff<U>, map: impl FnMut(&U) -> T) {
+    pub fn merge_map<U>(&mut self, other: &StorageDiff<U>, mut map: impl FnMut(&U) -> T) {
         // TODO: provide an alternative method that consumes `other` as well?
         for (key, (value, user_data)) in &other.hashmap {
             self.hashmap

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2606,10 +2606,9 @@ impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<&[u8]>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(&[u8], TrieEntryVersion)>,
     ) -> BlockVerification<TRq, TSrc, TBl> {
-        let inner = self.inner.inject_value(value, storage_trie_node_version);
+        let inner = self.inner.inject_value(value);
         BlockVerification::from_inner(inner, self.shared, self.user_data)
     }
 }

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -46,6 +46,7 @@ use core::{
     time::Duration,
 };
 
+pub use optimistic::TrieEntryVersion;
 pub use warp_sync::{FragmentError as WarpSyncFragmentError, WarpSyncFragment};
 
 /// Configuration for the [`AllSync`].
@@ -2603,8 +2604,12 @@ impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
     }
 
     /// Injects the corresponding storage value.
-    pub fn inject_value(self, value: Option<&[u8]>) -> BlockVerification<TRq, TSrc, TBl> {
-        let inner = self.inner.inject_value(value);
+    pub fn inject_value(
+        self,
+        value: Option<&[u8]>,
+        storage_trie_node_version: TrieEntryVersion,
+    ) -> BlockVerification<TRq, TSrc, TBl> {
+        let inner = self.inner.inject_value(value, storage_trie_node_version);
         BlockVerification::from_inner(inner, self.shared, self.user_data)
     }
 }

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2122,6 +2122,10 @@ pub struct BlockFull {
     /// Changes to the storage made by this block compared to its parent.
     pub storage_top_trie_changes: storage_diff::StorageDiff,
 
+    /// State trie version indicated by the runtime. All the storage changes indicated by
+    /// [`BlockFull::storage_top_trie_changes`] should store this version alongside with them.
+    pub state_trie_version: TrieEntryVersion,
+
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: storage_diff::StorageDiff,
 }
@@ -2334,6 +2338,7 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                                     body: b.body,
                                     offchain_storage_changes: b.offchain_storage_changes,
                                     storage_top_trie_changes: b.storage_top_trie_changes,
+                                    state_trie_version: b.state_trie_version,
                                 }),
                             })
                             .collect(),

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1999,8 +1999,8 @@ impl<'a, TRq, TSrc, TBl> BlockStorage<'a, TRq, TSrc, TBl> {
     pub fn get<'val: 'a>(
         &'val self, // TODO: unclear lifetime
         key: &[u8],
-        or_finalized: impl FnOnce() -> Option<&'val [u8]>,
-    ) -> Option<&'val [u8]> {
+        or_finalized: impl FnOnce() -> Option<(&'val [u8], TrieEntryVersion)>,
+    ) -> Option<(&'val [u8], TrieEntryVersion)> {
         match &self.inner {
             BlockStorageInner::Optimistic(inner) => inner.get(key, or_finalized),
         }

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -269,6 +269,10 @@ pub struct BlockFull {
     /// Changes to the storage made by this block compared to its parent.
     pub storage_top_trie_changes: storage_diff::StorageDiff,
 
+    /// State trie version indicated by the runtime. All the storage changes indicated by
+    /// [`BlockFull::storage_top_trie_changes`] should store this version alongside with them.
+    pub state_trie_version: TrieEntryVersion,
+
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: storage_diff::StorageDiff,
 }
@@ -1110,6 +1114,7 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                                 body: mem::take(&mut shared.block_body),
                                 storage_top_trie_changes,
                                 offchain_storage_changes,
+                                state_trie_version,
                             }),
                         })
                     };

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -1140,10 +1140,13 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                         .best_to_finalized_storage_diff
                         .diff_get(req.key().as_ref());
                     if let Some((value, storage_trie_node_version)) = value {
-                        inner = Inner::Step2(req.inject_value(
-                            value.as_ref().map(|v| iter::once(&v[..])),
-                            *storage_trie_node_version,
-                        ));
+                        inner = Inner::Step2(
+                            req.inject_value(
+                                value
+                                    .as_ref()
+                                    .map(|v| (iter::once(&v[..]), *storage_trie_node_version)),
+                            ),
+                        );
                         continue 'verif_steps;
                     }
 
@@ -1429,12 +1432,11 @@ impl<TRq, TSrc, TBl> StorageGet<TRq, TSrc, TBl> {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<&[u8]>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(&[u8], TrieEntryVersion)>,
     ) -> BlockVerification<TRq, TSrc, TBl> {
-        let inner = self
-            .inner
-            .inject_value(value.map(iter::once), storage_trie_node_version);
+        let inner = self.inner.inject_value(
+            value.map(|(v, storage_trie_node_version)| (iter::once(v), storage_trie_node_version)),
+        );
         BlockVerification::from(Inner::Step2(inner), self.shared)
     }
 }

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1222,7 +1222,7 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
                 };
 
             let finalized_storage_code = match decoded_downloaded_runtime.storage_value(b":code") {
-                Some(Some(code)) => code,
+                Some(Some((code, _))) => code,
                 Some(None) => {
                     self.inner.phase = Phase::DownloadFragments {
                         previous_verifier_values: Some((
@@ -1248,7 +1248,7 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
 
             let finalized_storage_heappages =
                 match decoded_downloaded_runtime.storage_value(b":heappages") {
-                    Some(val) => val,
+                    Some(val) => val.map(|(v, _)| v),
                     None => {
                         self.inner.phase = Phase::DownloadFragments {
                             previous_verifier_values: Some((
@@ -1446,7 +1446,7 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
                     chain_information::build::InProgress::StorageGet(get) => {
                         let proof = calls.get(&get.call_in_progress()).unwrap();
                         let value = match proof.storage_value(get.key().as_ref()) {
-                            Some(v) => v,
+                            Some(v) => v.map(|(v, _)| v),
                             None => {
                                 self.inner.phase = Phase::DownloadFragments {
                                     previous_verifier_values: Some((

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -574,15 +574,14 @@ impl StorageGet {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> Query {
         match self.0 {
             StorageGetInner::Stage1(inner, stage) => {
-                Query::from_step1(inner.inject_value(value, storage_trie_node_version), stage)
+                Query::from_step1(inner.inject_value(value), stage)
             }
             StorageGetInner::Stage2(inner, stage) => {
-                Query::from_step2(inner.inject_value(value, storage_trie_node_version), stage)
+                Query::from_step2(inner.inject_value(value), stage)
             }
         }
     }

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -25,6 +25,8 @@ use crate::{
 use alloc::{borrow::ToOwned as _, vec::Vec};
 use core::{iter, num::NonZeroU64};
 
+pub use runtime_host::TrieEntryVersion;
+
 /// Configuration for a transaction validation process.
 pub struct Config<'a, TTx> {
     /// Runtime used to get the validate the transaction. Must be built using the Wasm code found
@@ -570,13 +572,17 @@ impl StorageGet {
     }
 
     /// Injects the corresponding storage value.
-    pub fn inject_value(self, value: Option<impl Iterator<Item = impl AsRef<[u8]>>>) -> Query {
+    pub fn inject_value(
+        self,
+        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
+        storage_trie_node_version: TrieEntryVersion,
+    ) -> Query {
         match self.0 {
             StorageGetInner::Stage1(inner, stage) => {
-                Query::from_step1(inner.inject_value(value), stage)
+                Query::from_step1(inner.inject_value(value, storage_trie_node_version), stage)
             }
             StorageGetInner::Stage2(inner, stage) => {
-                Query::from_step2(inner.inject_value(value), stage)
+                Query::from_step2(inner.inject_value(value, storage_trie_node_version), stage)
             }
         }
     }

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -91,11 +91,11 @@
 //! associated to it.
 //!
 //! This version changes the way the hash of the node is calculated and how the Merkle proof is
-//! generated. Version 1 leads to more succint Merkle proofs, which is important when these proofs
+//! generated. Version 1 leads to more succinct Merkle proofs, which is important when these proofs
 //! are sent over the Internet.
 //!
 //! Note that most of the time all the entries of the trie have the same version. However, it is
-//! possible for the trie to be in a hybdrid state where some entries have a certain version and
+//! possible for the trie to be in a hybrid state where some entries have a certain version and
 //! other entries a different version. For this reason, most of the trie-related APIs require you
 //! to provide a trie entry version alongside with the value.
 //!

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -117,6 +117,18 @@ pub enum TrieEntryVersion {
     V1,
 }
 
+impl TryFrom<u8> for TrieEntryVersion {
+    type Error = (); // TODO: better error?
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(TrieEntryVersion::V0),
+            1 => Ok(TrieEntryVersion::V1),
+            _ => Err(()),
+        }
+    }
+}
+
 impl From<TrieEntryVersion> for u8 {
     fn from(v: TrieEntryVersion) -> u8 {
         match v {

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -137,9 +137,7 @@ pub fn empty_trie_merkle_value() -> [u8; 32] {
                 calculation = keys.inject(iter::empty::<iter::Empty<u8>>());
             }
             calculate_root::RootMerkleValueCalculation::StorageValue(val) => {
-                // Note that the version has no influence whatsoever on the output of the
-                // calculation. The version passed here is a dummy value.
-                calculation = val.inject(TrieEntryVersion::V1, None::<&[u8]>);
+                calculation = val.inject(None::<(&[u8], _)>);
             }
         }
     }
@@ -169,7 +167,7 @@ pub fn trie_root(
                     .iter()
                     .find(|(k, _)| k.as_ref().iter().copied().eq(value.key()))
                     .map(|(_, v)| v);
-                calculation = value.inject(version, result);
+                calculation = value.inject(result.map(move |v| (v, version)));
             }
         }
     }
@@ -205,7 +203,7 @@ pub fn ordered_root(version: TrieEntryVersion, entries: &[impl AsRef<[u8]>]) -> 
                     .collect::<arrayvec::ArrayVec<u8, USIZE_COMPACT_BYTES>>();
                 let (_, key) =
                     util::nom_scale_compact_usize::<nom::error::Error<&[u8]>>(&key).unwrap();
-                calculation = value.inject(version, entries.get(key));
+                calculation = value.inject(entries.get(key).map(move |v| (v, version)));
             }
         }
     }

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -117,6 +117,15 @@ pub enum TrieEntryVersion {
     V1,
 }
 
+impl From<TrieEntryVersion> for u8 {
+    fn from(v: TrieEntryVersion) -> u8 {
+        match v {
+            TrieEntryVersion::V0 => 0,
+            TrieEntryVersion::V1 => 1,
+        }
+    }
+}
+
 /// Returns the Merkle value of the root of an empty trie.
 pub fn empty_trie_merkle_value() -> [u8; 32] {
     let mut calculation = calculate_root::root_merkle_value(None);

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -55,7 +55,8 @@
 //!
 //! In the situation where we want to know the storage value associated to a node, but we only
 //! know the Merkle value of the root of the trie, it is possible to ask a third-party for the
-//! unhashed Merkle values of the desired node and all its ancestors.
+//! unhashed Merkle values of the desired node and all its ancestors. This is called a Merkle
+//! proof.
 //!
 //! After having verified that the third-party has provided correct values, and that they match
 //! the expected root node Merkle value known locally, we can extract the storage value from the
@@ -83,6 +84,21 @@
 //! its ancestors. As such, the time spent calculating the Merkle value of the root node of a trie
 //! mostly depends on the number of modifications that are performed on it, and only a bit on the
 //! size of the trie.
+//!
+//! ## Trie entry version
+//!
+//! In the Substrate/Polkadot trie, each trie node that contains a value also has a version
+//! associated to it.
+//!
+//! This version changes the way the hash of the node is calculated and how the Merkle proof is
+//! generated. Version 1 leads to more succint Merkle proofs, which is important when these proofs
+//! are sent over the Internet.
+//!
+//! Note that most of the time all the entries of the trie have the same version. However, it is
+//! possible for the trie to be in a hybdrid state where some entries have a certain version and
+//! other entries a different version. For this reason, most of the trie-related APIs require you
+//! to provide a trie entry version alongside with the value.
+//!
 
 use crate::util;
 

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -501,7 +501,7 @@ mod tests {
                 }
                 super::RootMerkleValueCalculation::StorageValue(value) => {
                     let key = value.key().collect::<Vec<u8>>();
-                    calculation = value.inject(trie.get(&key).map(|v| (v, TrieEntryVersion::V1)));
+                    calculation = value.inject(trie.get(&key).map(|v| (v, version)));
                 }
             }
         }

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -31,8 +31,8 @@
 //! use smoldot::trie::{TrieEntryVersion, calculate_root};
 //!
 //! // In this example, the storage consists in a binary tree map.
-//! let mut storage = BTreeMap::<Vec<u8>, Vec<u8>>::new();
-//! storage.insert(b"foo".to_vec(), b"bar".to_vec());
+//! let mut storage = BTreeMap::<Vec<u8>, (Vec<u8>, TrieEntryVersion)>::new();
+//! storage.insert(b"foo".to_vec(), (b"bar".to_vec(), TrieEntryVersion::V1));
 //!
 //! let trie_root = {
 //!     let mut calculation = calculate_root::root_merkle_value(None);
@@ -44,7 +44,7 @@
 //!             }
 //!             calculate_root::RootMerkleValueCalculation::StorageValue(value_request) => {
 //!                 let key = value_request.key().collect::<Vec<u8>>();
-//!                 calculation = value_request.inject(TrieEntryVersion::V1, storage.get(&key));
+//!                 calculation = value_request.inject(storage.get(&key).map(|(val, v)| (val, *v)));
 //!             }
 //!         }
 //!     }

--- a/lib/src/trie/node_value.rs
+++ b/lib/src/trie/node_value.rs
@@ -86,13 +86,10 @@ pub struct Config<TChIter, TPKey, TVal> {
     pub children: TChIter,
 
     /// Value of the node in the storage.
-    pub stored_value: Option<TVal>,
-
-    /// Version to use for the encoding.
     ///
-    /// Some input will lead to the same output no matter the version, but some other input will
-    /// produce a different output.
-    pub version: TrieEntryVersion,
+    /// If `Some`, also contains the version to use for the encoding. Some input will lead to the
+    /// same output no matter the version, but some other input will produce a different output.
+    pub stored_value: Option<(TVal, TrieEntryVersion)>,
 }
 
 /// Type of node whose node value is to be calculated.
@@ -137,10 +134,9 @@ where
 
     let has_children = config.children.clone().any(|c| c.is_some());
 
-    let stored_value_to_be_hashed = config
-        .stored_value
-        .as_ref()
-        .map(|value| matches!(config.version, TrieEntryVersion::V1) && value.as_ref().len() >= 33);
+    let stored_value_to_be_hashed = config.stored_value.as_ref().map(|(value, version)| {
+        matches!(version, TrieEntryVersion::V1) && value.as_ref().len() >= 33
+    });
 
     // This value will be used as the sink for all the components of the merkle value.
     let mut merkle_value_sink = if matches!(config.ty, NodeTy::Root { .. }) {
@@ -215,7 +211,7 @@ where
     // We take a shortcut and end the calculation now.
     if !has_children {
         if let Some(hash_stored_value) = stored_value_to_be_hashed {
-            let stored_value = config.stored_value.unwrap();
+            let stored_value = config.stored_value.unwrap().0;
 
             if hash_stored_value {
                 merkle_value_sink.update(
@@ -247,7 +243,7 @@ where
 
     // Add our own stored value.
     if let Some(hash_stored_value) = stored_value_to_be_hashed {
-        let stored_value = config.stored_value.unwrap();
+        let stored_value = config.stored_value.unwrap().0;
 
         if hash_stored_value {
             merkle_value_sink
@@ -386,8 +382,7 @@ mod tests {
         let obtained = super::calculate_merkle_value(super::Config {
             ty: super::NodeTy::Root { key: iter::empty() },
             children: (0..16).map(|_| None),
-            stored_value: None::<Vec<u8>>,
-            version: TrieEntryVersion::V0,
+            stored_value: None::<(Vec<u8>, _)>,
         });
 
         assert_eq!(
@@ -406,8 +401,7 @@ mod tests {
                 partial_key: iter::empty(),
             },
             children: (0..16).map(|_| None),
-            stored_value: None::<Vec<u8>>,
-            version: TrieEntryVersion::V0,
+            stored_value: None::<(Vec<u8>, _)>,
         });
 
         assert_eq!(obtained.as_ref(), &[0u8]);
@@ -442,8 +436,7 @@ mod tests {
                 .cloned(),
             },
             children: children.iter().map(|opt| opt.as_ref()),
-            stored_value: Some(b"hello world"),
-            version: TrieEntryVersion::V0,
+            stored_value: Some((b"hello world", TrieEntryVersion::V0)),
         });
 
         assert_eq!(
@@ -463,8 +456,7 @@ mod tests {
                 partial_key: iter::empty(),
             },
             children: iter::empty(),
-            stored_value: None::<Vec<u8>>,
-            version: TrieEntryVersion::V0,
+            stored_value: None::<(Vec<u8>, _)>,
         });
     }
 }

--- a/lib/src/trie/node_value.rs
+++ b/lib/src/trie/node_value.rs
@@ -54,8 +54,7 @@
 //!             .cloned(),
 //!         },
 //!         children: children.iter().map(|opt| opt.as_ref()),
-//!         stored_value: Some(b"hello world"),
-//!         version: TrieEntryVersion::V1,
+//!         stored_value: Some((b"hello world", TrieEntryVersion::V1)),
 //!     })
 //! };
 //!

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -119,7 +119,7 @@ impl PrefixScan {
 
                 if matches!(
                     info.storage_value,
-                    proof_decode::StorageValue::Known(_)
+                    proof_decode::StorageValue::Known { .. }
                         | proof_decode::StorageValue::HashKnownValueMissing(_)
                 ) {
                     // Trie nodes with a value are always aligned to "bytes-keys". In other words,

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -480,7 +480,7 @@ impl VerifyInner {
                             .diff_get(&b":heappages"[..]),
                     ) {
                         (None, None) => {}
-                        (Some(None), _) => {
+                        (Some((None, ())), _) => {
                             return Verify::Finished(Err((
                                 Error::CodeKeyErased,
                                 success.virtual_machine.into_prototype(),
@@ -492,11 +492,11 @@ impl VerifyInner {
                                 success.virtual_machine.into_prototype(),
                             )))
                         }
-                        (Some(Some(_code)), heap_pages) => {
+                        (Some((Some(_code), ())), heap_pages) => {
                             let parent_runtime = success.virtual_machine.into_prototype();
 
                             let heap_pages = match heap_pages {
-                                Some(heap_pages) => {
+                                Some((heap_pages, ())) => {
                                     match executor::storage_heap_pages_to_value(heap_pages) {
                                         Ok(hp) => hp,
                                         Err(err) => {
@@ -676,6 +676,7 @@ impl RuntimeCompilation {
             .storage_top_trie_changes
             .diff_get(&b":code"[..])
             .unwrap()
+            .0
             .unwrap();
 
         let new_runtime = match host::HostVmPrototype::new(host::Config {

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -582,11 +582,10 @@ impl StorageGet {
     /// Injects the corresponding storage value.
     pub fn inject_value(
         self,
-        value: Option<impl Iterator<Item = impl AsRef<[u8]>>>,
-        storage_trie_node_version: TrieEntryVersion,
+        value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> Verify {
         VerifyInner {
-            inner: self.inner.inject_value(value, storage_trie_node_version),
+            inner: self.inner.inject_value(value),
             execution_not_started: self.execution_not_started,
             consensus_success: self.consensus_success,
         }

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -1650,7 +1650,7 @@ impl<TPlat: Platform> Background<TPlat> {
                             break Err(RuntimeCallError::Call(err));
                         }
                     };
-                    runtime_call = get.inject_value(storage_value.map(iter::once));
+                    runtime_call = get.inject_value(storage_value.map(|(v, _)| iter::once(v)));
                 }
                 read_only_runtime_host::RuntimeHostVm::NextKey(nk) => {
                     // TODO:

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -243,8 +243,10 @@ impl<TPlat: Platform> Background<TPlat> {
                                                         .to_json_call_object_parameters(None);
                                                 }
                                             };
-                                            runtime_call =
-                                                get.inject_value(storage_value.map(iter::once));
+                                            runtime_call = get.inject_value(
+                                                storage_value
+                                                    .map(|(val, vers)| (iter::once(val), vers)),
+                                            );
                                         }
                                         runtime_host::RuntimeHostVm::NextKey(nk) => {
                                             // TODO: implement somehow

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -1186,7 +1186,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     spec_version: u64::from(runtime_spec.spec_version),
                     impl_version: u64::from(runtime_spec.impl_version),
                     transaction_version: runtime_spec.transaction_version.map(u64::from),
-                    state_version: runtime_spec.state_version.map(u64::from),
+                    state_version: runtime_spec.state_version.map(u8::from).map(u64::from),
                     apis: runtime_spec
                         .apis
                         .map(|api| (methods::HexString(api.name_hash.to_vec()), api.version))
@@ -1373,7 +1373,10 @@ impl<TPlat: Platform> Background<TPlat> {
                                 transaction_version: runtime_spec
                                     .transaction_version
                                     .map(u64::from),
-                                state_version: runtime_spec.state_version.map(u64::from),
+                                state_version: runtime_spec
+                                    .state_version
+                                    .map(u8::from)
+                                    .map(u64::from),
                                 apis: runtime_spec
                                     .apis
                                     .map(|api| {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -83,7 +83,7 @@ use smoldot::{
     executor, header,
     informant::{BytesDisplay, HashDisplay},
     network::protocol,
-    trie::{self, proof_decode},
+    trie::{self, proof_decode, TrieEntryVersion},
 };
 
 /// Configuration for a runtime service.
@@ -850,7 +850,10 @@ impl<'a> RuntimeCallLock<'a> {
     /// Returns an error if the key couldn't be found in the proof, meaning that the proof is
     /// invalid.
     // TODO: if proof is invalid, we should give the option to fetch another call proof
-    pub fn storage_entry(&self, requested_key: &[u8]) -> Result<Option<&[u8]>, RuntimeCallError> {
+    pub fn storage_entry(
+        &self,
+        requested_key: &[u8],
+    ) -> Result<Option<(&[u8], TrieEntryVersion)>, RuntimeCallError> {
         let call_proof = match &self.call_proof {
             Ok(p) => p,
             Err(err) => return Err(err.clone()),
@@ -889,7 +892,7 @@ impl<'a> RuntimeCallLock<'a> {
 
             if matches!(
                 node_info.storage_value,
-                proof_decode::StorageValue::Known(_)
+                proof_decode::StorageValue::Known { .. }
                     | proof_decode::StorageValue::HashKnownValueMissing(_)
             ) {
                 assert_eq!(key.len() % 2, 0);

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -441,7 +441,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                             decoded
                                 .storage_value(key.as_ref())
                                 .ok_or(StorageQueryErrorDetail::MissingProofEntry)?
-                                .map(|v| v.to_owned()),
+                                .map(|(v, _)| v.to_owned()),
                         );
                     }
                     debug_assert_eq!(result.len(), result.capacity());

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1149,7 +1149,7 @@ async fn parahead<TPlat: Platform>(
             read_only_runtime_host::RuntimeHostVm::StorageGet(get) => {
                 let storage_value = runtime_call_lock.storage_entry(get.key().as_ref());
                 let storage_value = match storage_value {
-                    Ok(v) => v,
+                    Ok(v) => v.map(|(v, _)| v),
                     Err(err) => {
                         runtime_call_lock.unlock(
                             read_only_runtime_host::RuntimeHostVm::StorageGet(get).into_prototype(),

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1206,7 +1206,8 @@ async fn validate_transaction<TPlat: Platform>(
                         ));
                     }
                 };
-                validation_in_progress = get.inject_value(storage_value.map(iter::once));
+                validation_in_progress =
+                    get.inject_value(storage_value.map(|(val, vers)| (iter::once(val), vers)));
             }
             validate::Query::NextKey(nk) => {
                 // TODO:


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/221

This PR finishes the implementation of the `state_version = 1` feature, also known as the trie v1.

This hasn't been tested thoroughly. However, the code for trie v0 and trie v1 is the same everywhere (the version is a value that can be either 0 or 1) except for the trie node encoding code which is known to work. For this reason, I have high confidence that it should work, in the sense that I don't see what could not work.

In terms of logic, each entry in the storage now has a "trie entry version" attached to it, whose value is either 0 or 1. Whenever a storage value is written, the corresponding trie entry version is indicated. When the storage value is retrieved, the trie entry version must be provided back. Note that providing the version back is only necessary for `runtime_host` and not for `read_only_runtime_host`, as the latter never needs to calculate any trie hash.

In terms of API, the biggest changes are:

- The `StorageDiff` struct now attaches a value to each entry in the diff, and has a template parameter indicating the type of this value. Often it's `StorageDiff<()>` that is used, but in `optimistic.rs` it's a `StorageDiff<TrieEntryVersion>`.
- `StorageGet::inject_value` must be passed the version of the storage entry.
- I've also modified the trie node generation code to only require passing a version if the value is `Some`, because if there is no value then the version doesn't matter. This change solves a couple of weird cases where we passed a dummy version.
- `CoreVersionRef::state_version` is now a `TrieEntryVersion` (an enum which can be either `V0` or `V1`) instead of a `u8`.

This PR breaks the database format of the full node and the database must be purged. Given that the full node is experimental, I don't want to bother with a migration system at the moment, even though the migration would be quite easy here.