### PR TITLE
Fix two wrong host function signatures

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -4092,7 +4092,7 @@ impl HostFunction {
                 crate::signature!((vm::ValueType::I64, vm::ValueType::I64) => vm::ValueType::I64)
             }
             HostFunction::ext_default_child_storage_read_version_1 => {
-                crate::signature!((vm::ValueType::I64, vm::ValueType::I64, vm::ValueType::I64, vm::ValueType::I64) => vm::ValueType::I64)
+                crate::signature!((vm::ValueType::I64, vm::ValueType::I64, vm::ValueType::I64, vm::ValueType::I32) => vm::ValueType::I64)
             }
             HostFunction::ext_default_child_storage_storage_kill_version_1 => {
                 crate::signature!((vm::ValueType::I64) => ())
@@ -4125,7 +4125,7 @@ impl HostFunction {
                 crate::signature!((vm::ValueType::I64) => vm::ValueType::I64)
             }
             HostFunction::ext_default_child_storage_root_version_2 => {
-                crate::signature!((vm::ValueType::I64, vm::ValueType::I32) => vm::ValueType::I32)
+                crate::signature!((vm::ValueType::I64, vm::ValueType::I32) => vm::ValueType::I64)
             }
             HostFunction::ext_crypto_ed25519_public_keys_version_1 => {
                 crate::signature!((vm::ValueType::I32) => vm::ValueType::I64)

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Fixed
 
+- Fix the signatures of the `ext_default_child_storage_read_version_1` and `ext_default_child_storage_root_version_2` host functions. This would lead to a warning about these function being unresolved.
 - Fix panic when the input data of a Wasm function call is larger than a Wasm page. ([#218](https://github.com/smol-dot/smoldot/pull/218))
 - Subscriptions to the `chain_subscribeAllHeads` JSON-RPC function now generate notifications named `chain_allHead`, like in Substrate. They were erroneously named `chain_newHead`. ([#227](https://github.com/smol-dot/smoldot/pull/227))
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Fixed
 
-- Fix the signatures of the `ext_default_child_storage_read_version_1` and `ext_default_child_storage_root_version_2` host functions. This would lead to a warning about these function being unresolved.
+- Fix the signatures of the `ext_default_child_storage_read_version_1` and `ext_default_child_storage_root_version_2` host functions. This would lead to a warning about these function being unresolved. ([#244](https://github.com/smol-dot/smoldot/pull/244))
 - Fix panic when the input data of a Wasm function call is larger than a Wasm page. ([#218](https://github.com/smol-dot/smoldot/pull/218))
 - Subscriptions to the `chain_subscribeAllHeads` JSON-RPC function now generate notifications named `chain_allHead`, like in Substrate. They were erroneously named `chain_newHead`. ([#227](https://github.com/smol-dot/smoldot/pull/227))
 


### PR DESCRIPTION
See also https://github.com/w3f/polkadot-spec/pull/626

The implementations of the functions are actually correct, it's just the signature checking that was wrong.
