### PR TITLE
Make proof_node_codec::encode return an error

### DIFF
--- a/fuzz/fuzz_targets/proof-node-codec.rs
+++ b/fuzz/fuzz_targets/proof-node-codec.rs
@@ -20,13 +20,12 @@
 libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     if let Ok(decoded) = smoldot::trie::proof_node_codec::decode(data) {
         assert_eq!(
-            smoldot::trie::proof_node_codec::encode(decoded.clone()).fold(
-                Vec::new(),
-                |mut a, b| {
+            smoldot::trie::proof_node_codec::encode(decoded.clone())
+                .unwrap()
+                .fold(Vec::new(), |mut a, b| {
                     a.extend_from_slice(b.as_ref());
                     a
-                }
-            ),
+                }),
             data,
             "{:?}",
             decoded

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -337,8 +337,13 @@ impl ProofBuilder {
                 }
 
                 // Re-encode the node value after its updates, and store it.
-                let updated_node_value =
-                    proof_node_codec::encode(decoded_node_value).fold(Vec::new(), |mut a, b| {
+                // `encode` can return an error only if there's no children and no storage value.
+                // Because we are guaranteed that the node was valid when we decoded it, and that
+                // we only ever add a storage value or add children, we are sure that encoding
+                // can't reach this situation.
+                let updated_node_value = proof_node_codec::encode(decoded_node_value)
+                    .unwrap()
+                    .fold(Vec::new(), |mut a, b| {
                         a.extend_from_slice(b.as_ref());
                         a
                     });
@@ -585,7 +590,8 @@ mod tests {
                     } else {
                         proof_node_codec::StorageValue::None
                     },
-                });
+                })
+                .unwrap();
 
                 proof_builder.set_node_value(&key, &node_value, None);
             }


### PR DESCRIPTION
In case the node doesn't have any valid encoding.

Ideally, the `Decoded` struct would make it impossible to represent nodes that don't have a valid encoding, but given the niche-ness of that situation, it would make this struct extremely weird and cumbersome.
