### PR TITLE
Generate a networking event in case of GrandPa neighbor packet

### DIFF
--- a/full-node/src/run/network_service.rs
+++ b/full-node/src/run/network_service.rs
@@ -947,6 +947,20 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                         },
                     );
                 }
+                service::Event::GrandpaNeighborPacket {
+                    chain_index,
+                    peer_id,
+                    state,
+                } => {
+                    log::debug!(
+                        "grandpa-neighbor-packet; peer_id={}; chain_index={}; round_number={}; set_id={}; commit_finalized_height={}",
+                        peer_id,
+                        chain_index,
+                        state.round_number,
+                        state.set_id,
+                        state.commit_finalized_height,
+                    );
+                }
                 service::Event::GrandpaCommitMessage {
                     chain_index,
                     peer_id,

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -1222,7 +1222,7 @@ pub enum Event {
         announce: EncodedBlockAnnounce,
     },
 
-    /// Received a  GrandPa neighor packet from the network. This constains an update to the
+    /// Received a  GrandPa neighbor packet from the network. This contains an update to the
     /// finality state of the given peer.
     GrandpaNeighborPacket {
         /// Identity of the sender of the message.

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -1222,6 +1222,17 @@ pub enum Event {
         announce: EncodedBlockAnnounce,
     },
 
+    /// Received a  GrandPa neighor packet from the network. This constains an update to the
+    /// finality state of the given peer.
+    GrandpaNeighborPacket {
+        /// Identity of the sender of the message.
+        peer_id: PeerId,
+        /// Index of the chain the message relates to.
+        chain_index: usize,
+        /// State of the remote.
+        state: GrandpaState,
+    },
+
     /// Received a GrandPa commit message from the network.
     GrandpaCommitMessage {
         /// Identity of the sender of the message.

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1235,6 +1235,21 @@ async fn update_round<TPlat: Platform>(
                     // All incoming requests are immediately answered.
                     unreachable!()
                 }
+                service::Event::GrandpaNeighborPacket {
+                    chain_index,
+                    peer_id,
+                    state,
+                } => {
+                    log::debug!(
+                        target: "network",
+                        "Connection({}, {}) => GrandpaNeighborPacket(round_number={}, set_id={}, commit_finalized_height={})",
+                        peer_id,
+                        &shared.log_chain_names[chain_index],
+                        state.round_number,
+                        state.set_id,
+                        state.commit_finalized_height,
+                    );
+                }
                 service::Event::GrandpaCommitMessage {
                     chain_index,
                     peer_id,


### PR DESCRIPTION
This is the first step towards https://github.com/smol-dot/smoldot/issues/239, and also a good change in general that would be useful for the full node.