### PR TITLE
Use runtime_host instead of read_only_runtime_host in JSON-RPC code

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Changed
 
 - When a full node refuses an outbound transactions or GrandPa substream even though a block announces substream has been established, smoldot now tries to reopen the failed substream. This bypasses a Substrate issue. ([#240](https://github.com/smol-dot/smoldot/pull/240))
+- Runtime functions called through the JSON-RPC function `state_call` are now allowed to modify the storage of the chain. These storage modifications are silently discarded. Previously, a JSON-RPC error was returned.
 
 ## Fixed
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## Changed
 
 - When a full node refuses an outbound transactions or GrandPa substream even though a block announces substream has been established, smoldot now tries to reopen the failed substream. This bypasses a Substrate issue. ([#240](https://github.com/smol-dot/smoldot/pull/240))
-- Runtime functions called through the JSON-RPC function `state_call` are now allowed to modify the storage of the chain. These storage modifications are silently discarded. Previously, a JSON-RPC error was returned.
+- Runtime functions called through the JSON-RPC function `state_call` are now allowed to modify the storage of the chain. These storage modifications are silently discarded. Previously, a JSON-RPC error was returned. ([#259](https://github.com/smol-dot/smoldot/pull/259))
 
 ## Fixed
 


### PR DESCRIPTION
Fix #254 

In practice, this affects not only `state_call` but also `state_getMetadata`, `system_accountNextIndex`, and `payment_queryInfo`. Of course, the last three aren't really affected since the runtime function being called is hardcoded.