### PR TITLE
Publish v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "0.7.13"
+version = "1.0.0"
 dependencies = [
  "event-listener",
  "fnv",

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,22 +2,24 @@
 
 ## Unreleased
 
-## Fixed
+## 1.0.0 - 2022-03-12
+
+### Fixed
 
 - Fix Deno throwing an exception when failing to connect to an unreachable node through a TCP/IP multiaddr. (([#246]https://github.com/smol-dot/smoldot/pull/246))
 
 ## 0.7.13 - 2022-03-03
 
-## Added
+### Added
 
 - Add support for the `ext_hashing_keccak_512_version_1` host function. ([#231](https://github.com/smol-dot/smoldot/pull/231))
 
-## Changed
+### Changed
 
 - When a full node refuses an outbound transactions or GrandPa substream even though a block announces substream has been established, smoldot now tries to reopen the failed substream. This bypasses a Substrate issue. ([#240](https://github.com/smol-dot/smoldot/pull/240))
 - Runtime functions called through the JSON-RPC function `state_call` are now allowed to modify the storage of the chain. These storage modifications are silently discarded. Previously, a JSON-RPC error was returned. ([#259](https://github.com/smol-dot/smoldot/pull/259))
 
-## Fixed
+### Fixed
 
 - Fix panic when connecting to a chain that hasn't finalized any block yet. ([#258](https://github.com/smol-dot/smoldot/pull/258))
 - Fix the signatures of the `ext_default_child_storage_read_version_1` and `ext_default_child_storage_root_version_2` host functions. This would lead to a warning about these function being unresolved. ([#244](https://github.com/smol-dot/smoldot/pull/244))

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "0.7.13",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "0.7.13",
+      "version": "1.0.0",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "pako": "^2.0.4",

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "0.7.13",
+  "version": "1.0.0",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "0.7.13"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Browser bindings to a light client for Substrate-based blockchains"
 repository = "https://github.com/smol-dot/smoldot"


### PR DESCRIPTION
Close #264 

This PR publishes v1.0.0 of smoldot.
Nothing much changes compared to v0.7, but I feel like it's time to send a signal by releasing v1.0 that the API is stable.

As an insubstantial change part of the PR, I've also fixed some CHANGELOG markdown mistake.
