### PR TITLE
Remove lifetime requirement from RuntimeLock

### DIFF
--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -1413,10 +1413,10 @@ impl<TPlat: Platform> Background<TPlat> {
 
     /// Obtain a lock to the runtime of the given block against the runtime service.
     // TODO: return better error?
-    async fn runtime_lock<'a>(
-        self: &'a Arc<Self>,
+    async fn runtime_lock(
+        self: &Arc<Self>,
         block_hash: &[u8; 32],
-    ) -> Result<runtime_service::RuntimeLock<'a, TPlat>, RuntimeCallError> {
+    ) -> Result<runtime_service::RuntimeLock<TPlat>, RuntimeCallError> {
         let cache_lock = self.cache.lock().await;
 
         // Try to find the block in the cache of recent blocks. Most of the time, the call target


### PR DESCRIPTION
This PR removes the lifetime from `RuntimeLock`. `RuntimeLock` no longer borrows `RuntimeService` but instead clones the inner `Arc`.

This allows grabbing a lock in one task and sending it to another task.

This is a pre-requirement for some of my changes in https://github.com/smol-dot/smoldot/issues/291

I'm not 100% happy with change, as it adds a constraint to the implementation of `RuntimeService`, but pragmatically speaking it's by far the easiest way. There are other alternative ways, but they are all more complicated.
