### PR TITLE
Add a tasks queue to requests_subscriptions

### DIFF
--- a/lib/src/json_rpc/requests_subscriptions.rs
+++ b/lib/src/json_rpc/requests_subscriptions.rs
@@ -37,7 +37,8 @@
 //!
 //! - One lightweight task for each client currently connected to the server.
 //! - A fixed number of lightweight tasks (e.g. 16) dedicated to answering requests.
-//! - A fixed number of lightweight tasks (e.g. 8) dedicated to processing subscription tasks.
+//! - A fixed number of lightweight tasks (e.g. 8) dedicated to processing subscription tasks by
+//! calling [`RequestsSubscriptions::run_subscription_task`] in a loop.
 //!
 //! ## Clients
 //!

--- a/lib/src/json_rpc/requests_subscriptions.rs
+++ b/lib/src/json_rpc/requests_subscriptions.rs
@@ -108,6 +108,7 @@
 //!
 
 use alloc::{
+    boxed::Box,
     collections::{BTreeMap, VecDeque},
     string::String,
     sync::{Arc, Weak},

--- a/lib/src/json_rpc/requests_subscriptions.rs
+++ b/lib/src/json_rpc/requests_subscriptions.rs
@@ -114,12 +114,14 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    cmp, fmt, hash,
+    cmp, fmt,
+    future::Future,
+    hash,
     num::NonZeroU32,
     ops,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
-use futures::{future, lock::Mutex};
+use futures::lock::Mutex;
 
 mod tests;
 
@@ -654,7 +656,7 @@ impl RequestsSubscriptions {
     /// The task doesn't run automatically. Instead,
     /// [`RequestsSubscriptions::run_subscription_task`] must be called.
     // TODO: it is planned to merge this into `start_subscription`
-    pub fn add_subscription_task(&self, task: future::BoxFuture<'static, ()>) {
+    pub fn add_subscription_task(&self, task: impl Future<Output = ()> + Send + 'static) {
         self.subscriptions_tasks.push(task);
     }
 

--- a/lib/src/json_rpc/requests_subscriptions.rs
+++ b/lib/src/json_rpc/requests_subscriptions.rs
@@ -657,7 +657,8 @@ impl RequestsSubscriptions {
     /// [`RequestsSubscriptions::run_subscription_task`] must be called.
     // TODO: it is planned to merge this into `start_subscription`
     pub fn add_subscription_task(&self, task: impl Future<Output = ()> + Send + 'static) {
-        self.subscriptions_tasks.push(task);
+        // TODO: it is planned to tweak task a bit, in which case accepting an impl Future makes sense, but if task isn't tweaked, then a BoxFuture makes more sense
+        self.subscriptions_tasks.push(Box::pin(task));
     }
 
     /// Waits until a subscription task is ready to be polled, and polls it.

--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -79,6 +79,7 @@ impl TasksQueue {
                 if let Some(task) = self.queue.pop() {
                     break match task {
                         QueuedTask::Task(t) => t,
+                        // TODO: future cancellation issue /!\ what if this await is cancelled after we've extracted an item from the queue
                         QueuedTask::InSlab(index) => self.sleeping_tasks.lock().await.remove(index),
                     };
                 }
@@ -152,6 +153,7 @@ impl TasksQueue {
             task::Poll::Ready(()) => {}
             task::Poll::Pending => {
                 // Prepare to store `NotPolling(task_index)` in `state`.
+                // TODO: future cancellation issue /!\ what if this await is cancelled and task is thrown away?
                 let task_index = self.sleeping_tasks.lock().await.insert(task);
                 let task_index_u64 = u64::try_from(task_index).unwrap();
                 debug_assert_ne!(task_index_u64, POLLING);

--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -86,7 +86,7 @@ impl TasksQueue {
         self.run_inner(task);
     }
 
-    /// Polls a future with a waker that pushes back the future to the back of the queue once
+    /// Polls a future with a `Waker` that pushes back the future to the back of the queue once
     /// ready to be polled again.
     fn run_inner(self: &Arc<Self>, mut task: BoxFuture<'static, ()>) {
         struct Waker {

--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -154,7 +154,7 @@ impl fmt::Debug for TasksQueue {
     }
 }
 
-/// Waker that it used when polling tasks.
+/// `Waker` that it used when polling tasks.
 struct Waker {
     /// A `Weak` is used in order to avoid cyclic references.
     tasks_queue: Weak<TasksQueue>,

--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -20,14 +20,14 @@
 //! This module provides the [`TasksQueue`] struct, which consists in a queue of `future`s.
 //! The futures in the queue must yield `()`.
 //!
-//! Use [`TasksQueue::add`] to add a future to the back of the queue.
+//! Use [`TasksQueue::push`] to add a future to the back of the queue.
 //!
-//! Use [`TasksQueue::run_once`] to pull a future from the queue and poll it. If the queue is
+//! Use [`TasksQueue::run_one`] to pull a future from the queue and poll it. If the queue is
 //! empty, this function waits until a future enters the queue. If the future finishes executing,
 //! then it is destroyed. Otherwise, it is added to the back of the queue once it is ready to be
 //! polled again.
 //!
-//! [`TasksQueue::run_once`] can be called multiple times in parallel.
+//! [`TasksQueue::run_one`] can be called multiple times in parallel.
 
 // Note: believe or not, but I couldn't find a library that does this in the Rust ecosystem.
 

--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -1,0 +1,249 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! FIFO queue of futures.
+//!
+//! This module provides the [`TasksQueue`] struct, which consists in a queue of `future`s.
+//! The futures in the queue must yield `()`.
+//!
+//! Use [`TasksQueue::add`] to add a future to the back of the queue.
+//!
+//! Use [`TasksQueue::run_once`] to pull a future from the queue and poll it. If the queue is
+//! empty, this function waits until a future enters the queue. If the future finishes executing,
+//! then it is destroyed. Otherwise, it is added to the back of the queue once it is ready to be
+//! polled again.
+//!
+//! [`TasksQueue::run_once`] can be called multiple times in parallel.
+
+// Note: believe or not, but I couldn't find a library that does this in the Rust ecosystem.
+
+use alloc::{
+    boxed::Box,
+    sync::{Arc, Weak},
+};
+use core::{future::Future as _, pin::Pin, ptr, sync::atomic, task};
+use futures::future::BoxFuture;
+
+/// See [the module-level documentation](..).
+pub struct TasksQueue {
+    queue: crossbeam_queue::SegQueue<BoxFuture<'static, ()>>,
+    item_pushed_to_queue: event_listener::Event,
+}
+
+impl TasksQueue {
+    /// Creates a new empty queue.
+    pub fn new() -> Arc<Self> {
+        Arc::new(TasksQueue {
+            queue: crossbeam_queue::SegQueue::new(),
+            item_pushed_to_queue: event_listener::Event::new(),
+        })
+    }
+
+    /// Pushes a task to the end of the queue.
+    pub fn push(self: &Arc<Self>, future: BoxFuture<'static, ()>) {
+        self.queue.push(future);
+        self.item_pushed_to_queue.notify_additional(1);
+    }
+
+    /// Pops a task from the head of the queue and polls it.
+    ///
+    /// If the queue is empty, this function waits until one is available.
+    ///
+    /// If the task being polled finishes, it is then destroyed. If the task is pending, is gets
+    /// pushed to the queue of the queue as soon as it is waken up.
+    pub async fn run_one(self: &Arc<Self>) {
+        // Pop a future from the queue, or waits until there is an item in the queue.
+        let task = {
+            let mut listener = None;
+
+            loop {
+                if let Some(task) = self.queue.pop() {
+                    break task;
+                }
+
+                match listener.take() {
+                    None => listener = Some(self.item_pushed_to_queue.listen()),
+                    Some(l) => l.await,
+                }
+            }
+        };
+
+        // Poll it.
+        self.run_inner(task);
+    }
+
+    /// Polls a future with a waker that pushes back the future to the back of the queue once
+    /// ready to be polled again.
+    fn run_inner(self: &Arc<Self>, mut task: BoxFuture<'static, ()>) {
+        struct Waker {
+            tasks_queue: Weak<TasksQueue>,
+
+            // While the easy solution here would be to use a `Mutex`, mutexes are unfortunately
+            // not available in no_std environments. `parking_lot` notably uses the clock for some
+            // reason, which is something we don't want.
+            // The good news is we don't need a `Mutex`. The bad news is that not using one makes
+            // things more complicated and requires using unsafe code.
+            //
+            // The `AtomicPtr` in this field is equivalent to the following enum:
+            // ```
+            // enum State {
+            //     Polling,
+            //     NotPolling(BoxFuture<'static, ()>),
+            //     WokeUp,
+            // }
+            // ```
+            //
+            // The state `WokeUp` is represented with a null pointer, the state `Polling` is
+            // represented as `invalid_non_null_ptr!()`, and any other pointer represents
+            // `NotPolling`.
+            //
+            // `WokeUp` means that the task has already woken up successfully.
+            // `Polling` means that the task hasn't been woken up yet, and that we are currently
+            // (or have just finished) polling the task.
+            // `NotPolling` means that the task hasn't been woken up yet, and that we are no
+            // longer polling the task.
+            //
+            // The distinction between `Polling` and `NotPolling` is necessary because we can't
+            // store the task in the waker while it is still being polled.
+            state: atomic::AtomicPtr<BoxFuture<'static, ()>>,
+        }
+
+        // In order to represent `Polling`, we use a pointer to a static variable. The pointer
+        // is invalid (because we convert it to the wrong type), but the important point here is
+        // that it isn't null and can't accidentally be equal to a pointer to `task`.
+        static DUMMY_POINTED_VALUE: usize = 0;
+        macro_rules! invalid_non_null_ptr {
+            () => {
+                (&DUMMY_POINTED_VALUE as *const usize as *mut usize as *mut BoxFuture<'static, ()>)
+            };
+        }
+
+        impl alloc::task::Wake for Waker {
+            fn wake(self: Arc<Self>) {
+                // Store `WokeUp` (i.e. null) in `state`, and examine what is inside.
+                match self.state.swap(ptr::null_mut(), atomic::Ordering::Relaxed) {
+                    ptr if ptr.is_null() || ptr == invalid_non_null_ptr!() => {}
+                    task_ptr => {
+                        // Any value other than null or `invalid_non_null_ptr!()` represents a
+                        // valid task.
+                        // If the state is `NotPolling`, push this task back to the queue.
+                        let task = unsafe { Box::from_raw(task_ptr) };
+                        let Some(tasks_queue) = self.tasks_queue.upgrade() else { return };
+                        tasks_queue.push(*task);
+                    }
+                }
+            }
+        }
+
+        let waker = Arc::new(Waker {
+            tasks_queue: Arc::downgrade(self),
+            // Initialize `state` to `Polling`.
+            state: atomic::AtomicPtr::new(invalid_non_null_ptr!()),
+        });
+
+        match Pin::new(&mut task).poll(&mut task::Context::from_waker(&waker.clone().into())) {
+            task::Poll::Ready(()) => {}
+            task::Poll::Pending => {
+                // Prepare to store `NotPolling(task)` in `state`.
+                let task_ptr = Box::into_raw(Box::new(task));
+                debug_assert_ne!(task_ptr, invalid_non_null_ptr!());
+
+                // Store `NotPolling` if equal to `Polling`.
+                match waker.state.compare_exchange(
+                    invalid_non_null_ptr!(),
+                    task_ptr,
+                    atomic::Ordering::Relaxed,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    Ok(_) => {}
+                    Err(_actual_val) => {
+                        // The only way we could reach here is if `wake()` has been called,
+                        // in which case it has replaced `Polling` with `WokeUp` (i.e. null).
+                        // In that case, push the task to the back of the queue.
+                        debug_assert!(_actual_val.is_null());
+                        let task = unsafe { Box::from_raw(task_ptr) };
+                        self.push(*task);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use core::sync::atomic;
+    use futures::{SinkExt as _, StreamExt as _};
+
+    #[test]
+    fn no_race_condition() {
+        // Push a lot of tasks in the queue. Each task sleeps a couple times then increments a
+        // counter. We check, at the end, that the counter has the expected value.
+        async_std::task::block_on(async move {
+            let queue = super::TasksQueue::new();
+            let counter = Arc::new(atomic::AtomicU64::new(0));
+
+            const NUM_TASKS: u64 = 100000;
+
+            // Spawn background tasks that will run the futures.
+            // A message is sent on `finished_tx` as soon as one executor detects that the
+            // counter has reached the target value.
+            // Note that we use a `ThreadPool` rather that spawn futures with
+            // `async_std::task::spawn`, as at the end of the test all executors but one will be
+            // stuck sleeping, and we preferably don't want them to leak.
+            let threads_pool = futures::executor::ThreadPool::new().unwrap();
+            let (finished_tx, mut finished_rx) = futures::channel::mpsc::channel::<()>(0);
+            for _ in 0..4 {
+                let queue = queue.clone();
+                let counter = counter.clone();
+                let mut finished_tx = finished_tx.clone();
+                threads_pool.spawn_ok(async move {
+                    loop {
+                        queue.run_one().await;
+                        if counter.load(atomic::Ordering::SeqCst) == NUM_TASKS {
+                            finished_tx.send(()).await.unwrap();
+                            break;
+                        }
+                    }
+                });
+            }
+
+            // Spawn the tasks themselves.
+            for _ in 0..NUM_TASKS {
+                let counter = counter.clone();
+                queue.push(Box::pin(async move {
+                    // Note that the randomness doesn't have uniform distrib, but we don't care.
+                    for _ in 0..(rand::random::<usize>() % 5) {
+                        if (rand::random::<usize>() % 10) == 0 {
+                            async_std::task::yield_now().await;
+                        }
+                        let num_us = rand::random::<u64>() % 50000;
+                        async_std::task::sleep(core::time::Duration::from_micros(num_us)).await;
+                    }
+
+                    counter.fetch_add(1, atomic::Ordering::SeqCst);
+                }));
+            }
+
+            // Stop the test as soon as one executor is finished, as only one executor will
+            // actually detect the limit and the others will be sleeping.
+            let _ = finished_rx.next().await.unwrap();
+            assert_eq!(counter.load(atomic::Ordering::SeqCst), NUM_TASKS);
+        })
+    }
+}

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -313,18 +313,20 @@ pub struct StartConfig<'a, TPlat: Platform> {
     /// This parameter is necessary in order to prevent users from using up too much memory within
     /// the client.
     pub max_parallel_requests: NonZeroU32,
+
+    /// Maximum number of subscriptions that can be processed simultaneously.
+    ///
+    /// In combination with [`Config::max_parallel_requests`], this can increase or decrease the
+    /// priority of updating subscriptions compared to answering requests.
+    pub max_parallel_subscription_updates: NonZeroU32,
 }
 
 impl ServicePrototype {
     /// Consumes this prototype and starts the service through [`StartConfig::tasks_executor`].
     pub fn start<TPlat: Platform>(self, mut config: StartConfig<'_, TPlat>) {
-        // Channel used in the background in order to spawn new tasks scoped to the background.
-        let (new_child_tasks_tx, new_child_tasks_rx) = mpsc::unbounded();
-
         let background = Arc::new(Background {
             log_target: self.log_target.clone(),
             requests_subscriptions: self.requests_subscriptions,
-            new_child_tasks_tx: Mutex::new(new_child_tasks_tx),
             chain_name: config.chain_spec.name().to_owned(),
             chain_ty: config.chain_spec.chain_type().to_owned(),
             chain_is_live: config.chain_spec.has_live_network(),
@@ -360,10 +362,11 @@ impl ServicePrototype {
         // This background task is abortable through the `background_abort` handle.
         (config.tasks_executor)(self.log_target, {
             let max_parallel_requests = config.max_parallel_requests;
+            let max_parallel_subscription_updates = config.max_parallel_subscription_updates;
             future::Abortable::new(
                 async move {
                     background
-                        .run(new_child_tasks_rx, max_parallel_requests)
+                        .run(max_parallel_requests, max_parallel_subscription_updates)
                         .await
                 },
                 self.background_abort_registration,
@@ -424,9 +427,6 @@ struct Background<TPlat: Platform> {
     /// Only requests that are valid JSON-RPC are insert into the state machine. However, requests
     /// can try to call an unknown method, or have invalid parameters.
     requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions>,
-
-    /// Whenever a task is sent on this channel, an executor runs it to completion.
-    new_child_tasks_tx: Mutex<mpsc::UnboundedSender<future::BoxFuture<'static, ()>>>,
 
     /// Name of the chain, as found in the chain specification.
     chain_name: String,
@@ -627,8 +627,8 @@ impl<TPlat: Platform> Background<TPlat> {
     /// This should only ever be called once for each service.
     async fn run(
         self: Arc<Self>,
-        mut new_child_tasks_rx: mpsc::UnboundedReceiver<future::BoxFuture<'static, ()>>,
         max_parallel_requests: NonZeroU32,
+        max_parallel_subscription_updates: NonZeroU32,
     ) -> ! {
         // The body of this function consists in building a list of tasks, then running them.
         let mut tasks = stream::FuturesUnordered::new();
@@ -643,6 +643,24 @@ impl<TPlat: Platform> Background<TPlat> {
                 async move {
                     loop {
                         me.handle_request().await;
+
+                        // We yield once between each request in order to politely let other tasks
+                        // do some work and not monopolize the CPU.
+                        TPlat::yield_after_cpu_intensive().await;
+                    }
+                }
+                .boxed(),
+            );
+        }
+
+        // A certain number of tasks (`max_parallel_subscription_updates`) are dedicated to
+        // processing subscriptions-related tasks after they wake up.
+        for _ in 0..max_parallel_subscription_updates.get() {
+            let me = self.clone();
+            tasks.push(
+                async move {
+                    loop {
+                        me.requests_subscriptions.run_subscription_task().await;
 
                         // We yield once between each request in order to politely let other tasks
                         // do some work and not monopolize the CPU.
@@ -739,17 +757,8 @@ impl<TPlat: Platform> Background<TPlat> {
         });
 
         // Now that `tasks` is full, we start running them forever.
-        // The `new_child_tasks_rx` channel is also polled, in order to be able to spawn new
-        // tasks.
-        // TODO: consider removing this `new_child_tasks_rx` mechanism, in order to be guaranteed a fixed number of tasks
         loop {
-            futures::select! {
-                () = tasks.select_next_some() => {},
-                task = new_child_tasks_rx.next() => {
-                    let task = task.unwrap();
-                    tasks.push(task);
-                }
-            }
+            tasks.next().await;
         }
     }
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -316,8 +316,8 @@ pub struct StartConfig<'a, TPlat: Platform> {
 
     /// Maximum number of subscriptions that can be processed simultaneously.
     ///
-    /// In combination with [`Config::max_parallel_requests`], this can increase or decrease the
-    /// priority of updating subscriptions compared to answering requests.
+    /// In combination with [`StartConfig::max_parallel_requests`], this can increase or decrease
+    /// the priority of updating subscriptions compared to answering requests.
     pub max_parallel_subscription_updates: NonZeroU32,
 }
 

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -23,7 +23,6 @@ use crate::{platform::Platform, runtime_service, sync_service};
 
 use alloc::{
     borrow::ToOwned as _,
-    boxed::Box,
     format,
     string::{String, ToString as _},
     sync::Arc,
@@ -409,11 +408,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(task.boxed())
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_follow`].
@@ -1170,11 +1166,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_storage`].
@@ -1432,11 +1425,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_body`].
@@ -1658,11 +1648,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_header`].

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -408,8 +408,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_follow`].
@@ -1166,8 +1165,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_storage`].
@@ -1425,8 +1423,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_body`].
@@ -1648,8 +1645,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_header`].

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -555,8 +555,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeFinalizedHeads`].
@@ -695,8 +694,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeNewHeads`].
@@ -835,8 +833,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::chain_unsubscribeAllHeads`].
@@ -1597,8 +1594,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::state_subscribeStorage`].
@@ -1946,7 +1942,6 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 }

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -23,7 +23,6 @@ use crate::runtime_service;
 
 use alloc::{
     borrow::ToOwned as _,
-    boxed::Box,
     format,
     string::{String, ToString as _},
     sync::Arc,
@@ -556,11 +555,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeFinalizedHeads`].
@@ -699,11 +695,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeNewHeads`].
@@ -842,11 +835,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::chain_unsubscribeAllHeads`].
@@ -1607,11 +1597,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::state_subscribeStorage`].
@@ -1959,10 +1946,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 }

--- a/light-base/src/json_rpc_service/transactions.rs
+++ b/light-base/src/json_rpc_service/transactions.rs
@@ -21,7 +21,7 @@ use super::{Background, Platform, SubscriptionMessage};
 
 use crate::transactions_service;
 
-use alloc::{borrow::ToOwned as _, boxed::Box, str, string::ToString as _, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, str, string::ToString as _, sync::Arc, vec::Vec};
 use core::sync::atomic;
 use futures::{
     channel::{mpsc, oneshot},
@@ -520,11 +520,8 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.new_child_tasks_tx
-            .lock()
-            .await
-            .unbounded_send(Box::pin(task))
-            .unwrap();
+        self.requests_subscriptions
+            .add_subscription_task(task.boxed());
     }
 
     /// Handles a call to [`methods::MethodCall::transaction_unstable_unwatch`].

--- a/light-base/src/json_rpc_service/transactions.rs
+++ b/light-base/src/json_rpc_service/transactions.rs
@@ -520,8 +520,7 @@ impl<TPlat: Platform> Background<TPlat> {
             }
         };
 
-        self.requests_subscriptions
-            .add_subscription_task(task.boxed());
+        self.requests_subscriptions.add_subscription_task(task);
     }
 
     /// Handles a call to [`methods::MethodCall::transaction_unstable_unwatch`].

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -844,6 +844,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                     genesis_block_hash,
                     genesis_block_state_root,
                     max_parallel_requests: NonZeroU32::new(24).unwrap(),
+                    max_parallel_subscription_updates: NonZeroU32::new(8).unwrap(),
                 })
             };
 


### PR DESCRIPTION
Next step in https://github.com/smol-dot/smoldot/issues/291

This PR adds to the `requests_subscriptions` state machine a queue of tasks. When a subscription is started, its corresponding task is added to the queue. Then, in parallel, some tasks run the subscriptions tasks.

This have the advantage of guaranteeing that the subscriptions tasks do not have higher priority than processing new requests.

The next step will be to merge `start_subscription` with `add_subscription_task` and other things.

Surprisingly, I couldn't find a good library in the ecosystem that does what the `executor` module does, so I wrote an executor myself. Even though it uses unsafe code, I'm very confident in the code of that executor, and the test basically covers every situation.
