### PR TITLE
Use AtomicUsize instead of AtomicU64 in the executor

### DIFF
--- a/lib/src/json_rpc/requests_subscriptions/executor.rs
+++ b/lib/src/json_rpc/requests_subscriptions/executor.rs
@@ -180,7 +180,7 @@ struct Waker {
     /// Because the value in `NotPolling` is an index within a slab, and that the values in the
     /// slab are more than 1 byte in size, the index can't ever reach `usize::max_value()`. It
     /// is therefore safe to use `-1` and `-2` are dummy values (and even if it wasn't, we'd have
-    /// a logic error and not an undefined behaviour).
+    /// a logic error and not an undefined behavior).
     state: atomic::AtomicUsize,
 }
 


### PR DESCRIPTION
`AtomicUsize` is guaranteed to be available on all platforms, contrary to `AtomicU64`.
This also leads to more simple code.

I had initially used `AtomicU64` in order to be sure to not accidentally reach the dummy `-1` and `-2` values, but that is actually impossible.