### PR TITLE
More powerful subscriptions in `requests_subscriptions`

### DIFF
--- a/lib/src/json_rpc/requests_subscriptions/tests.rs
+++ b/lib/src/json_rpc/requests_subscriptions/tests.rs
@@ -23,7 +23,7 @@ use core::num::NonZeroU32;
 #[test]
 fn clients_limit_adjustement() {
     futures::executor::block_on(async move {
-        let req_sub = RequestsSubscriptions::new(Config {
+        let req_sub = RequestsSubscriptions::<()>::new(Config {
             max_clients: 2,
             max_requests_per_client: NonZeroU32::new(5).unwrap(),
             max_subscriptions_per_client: 5,

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -149,7 +149,7 @@ pub struct Frontend {
     /// State machine holding all the clients, requests, and subscriptions.
     ///
     /// Shared with the [`Background`].
-    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions>,
+    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions<SubscriptionMessage>>,
 
     /// Identifier of the unique client within the [`Frontend::requests_subscriptions`].
     client_id: requests_subscriptions::ClientId,
@@ -247,7 +247,7 @@ pub struct ServicePrototype {
     /// State machine holding all the clients, requests, and subscriptions.
     ///
     /// Shared with the [`Background`].
-    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions>,
+    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions<SubscriptionMessage>>,
 
     /// Target to use when emitting logs.
     log_target: String,
@@ -426,7 +426,7 @@ struct Background<TPlat: Platform> {
     ///
     /// Only requests that are valid JSON-RPC are insert into the state machine. However, requests
     /// can try to call an unknown method, or have invalid parameters.
-    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions>,
+    requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions<SubscriptionMessage>>,
 
     /// Name of the chain, as found in the chain specification.
     chain_name: String,

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -61,11 +61,7 @@ use core::{
     sync::atomic,
     time::Duration,
 };
-use futures::{
-    channel::{mpsc, oneshot},
-    lock::Mutex,
-    prelude::*,
-};
+use futures::{lock::Mutex, prelude::*};
 use hashbrown::HashMap;
 use smoldot::{
     chain::fork_tree,
@@ -470,19 +466,9 @@ struct Background<TPlat: Platform> {
     /// connected.
     next_subscription_id: atomic::AtomicU64,
 
-    /// For each active subscription (the key), an abort handle and the id of the subscription in
-    /// the state machine. The abort handle is linked to the task dedicated to handling that
-    /// subscription.
-    subscriptions: Mutex<
-        HashMap<
-            String,
-            (
-                Arc<Mutex<mpsc::Sender<(SubscriptionMessage, oneshot::Sender<()>)>>>,
-                requests_subscriptions::SubscriptionId,
-            ),
-            fnv::FnvBuildHasher,
-        >,
-    >,
+    /// For each active subscription (the key), the id of the subscription in the state machine.
+    subscriptions:
+        Mutex<HashMap<String, requests_subscriptions::SubscriptionId, fnv::FnvBuildHasher>>,
 
     /// If `true`, we have already printed a warning about usage of the legacy JSON-RPC API. This
     /// flag prevents printing this message multiple times.

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -200,10 +200,6 @@ impl<TPlat: Platform> Background<TPlat> {
                                 confirmation_sender,
                             ))) => {
                                 me.requests_subscriptions
-                                    .stop_subscription(&state_machine_subscription)
-                                    .await;
-
-                                me.requests_subscriptions
                                     .respond(
                                         &stop_state_machine_request_id,
                                         methods::Response::chainHead_unstable_stopCall(())
@@ -388,9 +384,6 @@ impl<TPlat: Platform> Background<TPlat> {
 
                 me.requests_subscriptions
                     .push_notification(&state_machine_subscription, final_notif)
-                    .await;
-                me.requests_subscriptions
-                    .stop_subscription(&state_machine_subscription)
                     .await;
                 let _ = me.subscriptions.lock().await.remove(&subscription_id);
             }
@@ -890,10 +883,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             _,
                         )) => {
                             me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
-                            me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,
                                     methods::Response::chainHead_unstable_unfollow(())
@@ -1139,9 +1128,6 @@ impl<TPlat: Platform> Background<TPlat> {
                         .to_json_call_object_parameters(None),
                     )
                     .await;
-                me.requests_subscriptions
-                    .stop_subscription(&state_machine_subscription)
-                    .await;
             }
         });
     }
@@ -1351,10 +1337,6 @@ impl<TPlat: Platform> Background<TPlat> {
                                     confirmation_sender,
                                 ))) => {
                                     me.requests_subscriptions
-                                        .stop_subscription(&state_machine_subscription)
-                                        .await;
-
-                                    me.requests_subscriptions
                                         .respond(
                                             &stop_state_machine_request_id,
                                             methods::Response::chainHead_unstable_stopBody(())
@@ -1388,9 +1370,6 @@ impl<TPlat: Platform> Background<TPlat> {
 
                 me.requests_subscriptions
                     .set_queued_notification(&state_machine_subscription, 0, response)
-                    .await;
-                me.requests_subscriptions
-                    .stop_subscription(&state_machine_subscription)
                     .await;
                 let _ = me.subscriptions.lock().await.remove(&subscription_id);
             }
@@ -1573,10 +1552,6 @@ impl<TPlat: Platform> Background<TPlat> {
                                 confirmation_sender,
                             ))) => {
                                 me.requests_subscriptions
-                                    .stop_subscription(&state_machine_subscription)
-                                    .await;
-
-                                me.requests_subscriptions
                                     .respond(
                                         &stop_state_machine_request_id,
                                         methods::Response::chainHead_unstable_stopBody(())
@@ -1603,9 +1578,6 @@ impl<TPlat: Platform> Background<TPlat> {
 
                 me.requests_subscriptions
                     .set_queued_notification(&state_machine_subscription, 0, response)
-                    .await;
-                me.requests_subscriptions
-                    .stop_subscription(&state_machine_subscription)
                     .await;
                 let _ = me.subscriptions.lock().await.remove(&subscription_id);
             }

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -131,7 +131,7 @@ impl<TPlat: Platform> Background<TPlat> {
             let function_to_call = function_to_call.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
             async move {
-                let state_machine_subscription = match me
+                let (state_machine_subscription, messages_tx, mut messages_rx) = match me
                     .requests_subscriptions
                     .start_subscription(&state_machine_request_id, 1)
                     .await
@@ -159,8 +159,6 @@ impl<TPlat: Platform> Background<TPlat> {
                     .next_subscription_id
                     .fetch_add(1, atomic::Ordering::Relaxed)
                     .to_string();
-
-                let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
                 me.subscriptions.lock().await.insert(
                     subscription_id.clone(),
@@ -418,7 +416,7 @@ impl<TPlat: Platform> Background<TPlat> {
         state_machine_request_id: &requests_subscriptions::RequestId,
         runtime_updates: bool,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 16)
             .await
@@ -455,8 +453,6 @@ impl<TPlat: Platform> Background<TPlat> {
                 None,
             )
         };
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         let (subscription_id, initial_notifications, mut subscription_state) = {
             let subscription_id = self
@@ -1270,7 +1266,7 @@ impl<TPlat: Platform> Background<TPlat> {
             return;
         }
 
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 1)
             .await
@@ -1298,8 +1294,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),
@@ -1503,7 +1497,7 @@ impl<TPlat: Platform> Background<TPlat> {
         network_config: methods::NetworkConfig,
         block_number: Option<u64>,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(&state_machine_request_id, 1)
             .await
@@ -1531,8 +1525,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -524,10 +524,6 @@ impl<TPlat: Platform> Background<TPlat> {
                                 confirmation_sender,
                             ))) => {
                                 me.requests_subscriptions
-                                    .stop_subscription(&state_machine_subscription)
-                                    .await;
-
-                                me.requests_subscriptions
                                     .respond(
                                         &stop_state_machine_request_id,
                                         methods::Response::chain_unsubscribeAllHeads(true)
@@ -659,10 +655,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             _,
                         )) => {
                             me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
-                            me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,
                                     methods::Response::chain_unsubscribeFinalizedHeads(true)
@@ -792,10 +784,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             )),
                             _,
                         )) => {
-                            me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
                             me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,
@@ -1525,10 +1513,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             _,
                         )) => {
                             me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
-                            me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,
                                     methods::Response::state_unsubscribeRuntimeVersion(true)
@@ -1851,10 +1835,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             )),
                             _,
                         )) => {
-                            me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
                             me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -371,7 +371,7 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 16)
             .await
@@ -399,8 +399,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),
@@ -567,7 +565,7 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 1)
             .await
@@ -595,8 +593,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),
@@ -709,7 +705,7 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 1)
             .await
@@ -737,8 +733,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),
@@ -1457,7 +1451,7 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 1)
             .await
@@ -1485,8 +1479,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),
@@ -1746,7 +1738,7 @@ impl<TPlat: Platform> Background<TPlat> {
         state_machine_request_id: &requests_subscriptions::RequestId,
         list: Vec<methods::HexString>,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 1)
             .await
@@ -1774,8 +1766,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -371,29 +371,30 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
-            .requests_subscriptions
-            .start_subscription(state_machine_request_id, 16)
-            .await
-        {
-            Ok(v) => v,
-            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                self.requests_subscriptions
-                    .respond(
-                        state_machine_request_id,
-                        json_rpc::parse::build_error_response(
-                            request_id,
-                            json_rpc::parse::ErrorResponse::ServerError(
-                                -32000,
-                                "Too many active subscriptions",
+        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
+            match self
+                .requests_subscriptions
+                .start_subscription(state_machine_request_id, 16)
+                .await
+            {
+                Ok(v) => v,
+                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                    self.requests_subscriptions
+                        .respond(
+                            state_machine_request_id,
+                            json_rpc::parse::build_error_response(
+                                request_id,
+                                json_rpc::parse::ErrorResponse::ServerError(
+                                    -32000,
+                                    "Too many active subscriptions",
+                                ),
+                                None,
                             ),
-                            None,
-                        ),
-                    )
-                    .await;
-                return;
-            }
-        };
+                        )
+                        .await;
+                    return;
+                }
+            };
 
         let subscription_id = self
             .next_subscription_id
@@ -408,8 +409,7 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        // Spawn a separate task for the subscription.
-        let task = {
+        subscription_start.start({
             let me = self.clone();
             let request_id = request_id.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
@@ -554,9 +554,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     }
                 }
             }
-        };
-
-        self.requests_subscriptions.add_subscription_task(task);
+        });
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeFinalizedHeads`].
@@ -565,29 +563,30 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
-            .requests_subscriptions
-            .start_subscription(state_machine_request_id, 1)
-            .await
-        {
-            Ok(v) => v,
-            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                self.requests_subscriptions
-                    .respond(
-                        state_machine_request_id,
-                        json_rpc::parse::build_error_response(
-                            request_id,
-                            json_rpc::parse::ErrorResponse::ServerError(
-                                -32000,
-                                "Too many active subscriptions",
+        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
+            match self
+                .requests_subscriptions
+                .start_subscription(state_machine_request_id, 1)
+                .await
+            {
+                Ok(v) => v,
+                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                    self.requests_subscriptions
+                        .respond(
+                            state_machine_request_id,
+                            json_rpc::parse::build_error_response(
+                                request_id,
+                                json_rpc::parse::ErrorResponse::ServerError(
+                                    -32000,
+                                    "Too many active subscriptions",
+                                ),
+                                None,
                             ),
-                            None,
-                        ),
-                    )
-                    .await;
-                return;
-            }
-        };
+                        )
+                        .await;
+                    return;
+                }
+            };
 
         let subscription_id = self
             .next_subscription_id
@@ -608,8 +607,7 @@ impl<TPlat: Platform> Background<TPlat> {
             stream::once(future::ready(finalized_block_header)).chain(finalized_blocks_subscription)
         };
 
-        // Spawn a separate task for the subscription.
-        let task = {
+        subscription_start.start({
             let me = self.clone();
             let request_id = request_id.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
@@ -694,9 +692,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     }
                 }
             }
-        };
-
-        self.requests_subscriptions.add_subscription_task(task);
+        });
     }
 
     /// Handles a call to [`methods::MethodCall::chain_subscribeNewHeads`].
@@ -705,29 +701,30 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
-            .requests_subscriptions
-            .start_subscription(state_machine_request_id, 1)
-            .await
-        {
-            Ok(v) => v,
-            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                self.requests_subscriptions
-                    .respond(
-                        state_machine_request_id,
-                        json_rpc::parse::build_error_response(
-                            request_id,
-                            json_rpc::parse::ErrorResponse::ServerError(
-                                -32000,
-                                "Too many active subscriptions",
+        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
+            match self
+                .requests_subscriptions
+                .start_subscription(state_machine_request_id, 1)
+                .await
+            {
+                Ok(v) => v,
+                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                    self.requests_subscriptions
+                        .respond(
+                            state_machine_request_id,
+                            json_rpc::parse::build_error_response(
+                                request_id,
+                                json_rpc::parse::ErrorResponse::ServerError(
+                                    -32000,
+                                    "Too many active subscriptions",
+                                ),
+                                None,
                             ),
-                            None,
-                        ),
-                    )
-                    .await;
-                return;
-            }
-        };
+                        )
+                        .await;
+                    return;
+                }
+            };
 
         let subscription_id = self
             .next_subscription_id
@@ -748,8 +745,7 @@ impl<TPlat: Platform> Background<TPlat> {
             stream::once(future::ready(block_header)).chain(blocks_subscription)
         };
 
-        // Spawn a separate task for the subscription.
-        let task = {
+        subscription_start.start({
             let me = self.clone();
             let request_id = request_id.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
@@ -834,9 +830,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     }
                 }
             }
-        };
-
-        self.requests_subscriptions.add_subscription_task(task);
+        });
     }
 
     /// Handles a call to [`methods::MethodCall::chain_unsubscribeAllHeads`].
@@ -1451,29 +1445,30 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
-            .requests_subscriptions
-            .start_subscription(state_machine_request_id, 1)
-            .await
-        {
-            Ok(v) => v,
-            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                self.requests_subscriptions
-                    .respond(
-                        state_machine_request_id,
-                        json_rpc::parse::build_error_response(
-                            request_id,
-                            json_rpc::parse::ErrorResponse::ServerError(
-                                -32000,
-                                "Too many active subscriptions",
+        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
+            match self
+                .requests_subscriptions
+                .start_subscription(state_machine_request_id, 1)
+                .await
+            {
+                Ok(v) => v,
+                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                    self.requests_subscriptions
+                        .respond(
+                            state_machine_request_id,
+                            json_rpc::parse::build_error_response(
+                                request_id,
+                                json_rpc::parse::ErrorResponse::ServerError(
+                                    -32000,
+                                    "Too many active subscriptions",
+                                ),
+                                None,
                             ),
-                            None,
-                        ),
-                    )
-                    .await;
-                return;
-            }
-        };
+                        )
+                        .await;
+                    return;
+                }
+            };
 
         let subscription_id = self
             .next_subscription_id
@@ -1488,7 +1483,7 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        let task = {
+        subscription_start.start({
             let me = self.clone();
             let request_id = request_id.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
@@ -1595,9 +1590,7 @@ impl<TPlat: Platform> Background<TPlat> {
                     }
                 }
             }
-        };
-
-        self.requests_subscriptions.add_subscription_task(task);
+        });
     }
 
     /// Handles a call to [`methods::MethodCall::state_subscribeStorage`].
@@ -1738,29 +1731,30 @@ impl<TPlat: Platform> Background<TPlat> {
         state_machine_request_id: &requests_subscriptions::RequestId,
         list: Vec<methods::HexString>,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
-            .requests_subscriptions
-            .start_subscription(state_machine_request_id, 1)
-            .await
-        {
-            Ok(v) => v,
-            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                self.requests_subscriptions
-                    .respond(
-                        state_machine_request_id,
-                        json_rpc::parse::build_error_response(
-                            request_id,
-                            json_rpc::parse::ErrorResponse::ServerError(
-                                -32000,
-                                "Too many active subscriptions",
+        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
+            match self
+                .requests_subscriptions
+                .start_subscription(state_machine_request_id, 1)
+                .await
+            {
+                Ok(v) => v,
+                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                    self.requests_subscriptions
+                        .respond(
+                            state_machine_request_id,
+                            json_rpc::parse::build_error_response(
+                                request_id,
+                                json_rpc::parse::ErrorResponse::ServerError(
+                                    -32000,
+                                    "Too many active subscriptions",
+                                ),
+                                None,
                             ),
-                            None,
-                        ),
-                    )
-                    .await;
-                return;
-            }
-        };
+                        )
+                        .await;
+                    return;
+                }
+            };
 
         let subscription_id = self
             .next_subscription_id
@@ -1873,8 +1867,7 @@ impl<TPlat: Platform> Background<TPlat> {
             )
         };
 
-        // Spawn a separate task for the subscription.
-        let task = {
+        subscription_start.start({
             let me = self.clone();
             let request_id = request_id.to_owned();
             let state_machine_request_id = state_machine_request_id.clone();
@@ -1944,8 +1937,6 @@ impl<TPlat: Platform> Background<TPlat> {
                     }
                 }
             }
-        };
-
-        self.requests_subscriptions.add_subscription_task(task);
+        });
     }
 }

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -35,11 +35,7 @@ use core::{
     sync::atomic,
     time::Duration,
 };
-use futures::{
-    channel::{mpsc, oneshot},
-    lock::{Mutex, MutexGuard},
-    prelude::*,
-};
+use futures::{lock::MutexGuard, prelude::*};
 use smoldot::{
     header,
     informant::HashDisplay,
@@ -371,43 +367,39 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
-            match self
-                .requests_subscriptions
-                .start_subscription(state_machine_request_id, 16)
-                .await
-            {
-                Ok(v) => v,
-                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                    self.requests_subscriptions
-                        .respond(
-                            state_machine_request_id,
-                            json_rpc::parse::build_error_response(
-                                request_id,
-                                json_rpc::parse::ErrorResponse::ServerError(
-                                    -32000,
-                                    "Too many active subscriptions",
-                                ),
-                                None,
+        let (state_machine_subscription, mut messages_rx, subscription_start) = match self
+            .requests_subscriptions
+            .start_subscription(state_machine_request_id, 16)
+            .await
+        {
+            Ok(v) => v,
+            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                self.requests_subscriptions
+                    .respond(
+                        state_machine_request_id,
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(
+                                -32000,
+                                "Too many active subscriptions",
                             ),
-                        )
-                        .await;
-                    return;
-                }
-            };
+                            None,
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
 
         let subscription_id = self
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
 
-        self.subscriptions.lock().await.insert(
-            subscription_id.clone(),
-            (
-                Arc::new(Mutex::new(messages_tx)),
-                state_machine_subscription.clone(),
-            ),
-        );
+        self.subscriptions
+            .lock()
+            .await
+            .insert(subscription_id.clone(), state_machine_subscription.clone());
 
         subscription_start.start({
             let me = self.clone();
@@ -563,43 +555,39 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
-            match self
-                .requests_subscriptions
-                .start_subscription(state_machine_request_id, 1)
-                .await
-            {
-                Ok(v) => v,
-                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                    self.requests_subscriptions
-                        .respond(
-                            state_machine_request_id,
-                            json_rpc::parse::build_error_response(
-                                request_id,
-                                json_rpc::parse::ErrorResponse::ServerError(
-                                    -32000,
-                                    "Too many active subscriptions",
-                                ),
-                                None,
+        let (state_machine_subscription, mut messages_rx, subscription_start) = match self
+            .requests_subscriptions
+            .start_subscription(state_machine_request_id, 1)
+            .await
+        {
+            Ok(v) => v,
+            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                self.requests_subscriptions
+                    .respond(
+                        state_machine_request_id,
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(
+                                -32000,
+                                "Too many active subscriptions",
                             ),
-                        )
-                        .await;
-                    return;
-                }
-            };
+                            None,
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
 
         let subscription_id = self
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
 
-        self.subscriptions.lock().await.insert(
-            subscription_id.clone(),
-            (
-                Arc::new(Mutex::new(messages_tx)),
-                state_machine_subscription.clone(),
-            ),
-        );
+        self.subscriptions
+            .lock()
+            .await
+            .insert(subscription_id.clone(), state_machine_subscription.clone());
 
         let mut blocks_list = {
             let (finalized_block_header, finalized_blocks_subscription) =
@@ -701,43 +689,39 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
-            match self
-                .requests_subscriptions
-                .start_subscription(state_machine_request_id, 1)
-                .await
-            {
-                Ok(v) => v,
-                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                    self.requests_subscriptions
-                        .respond(
-                            state_machine_request_id,
-                            json_rpc::parse::build_error_response(
-                                request_id,
-                                json_rpc::parse::ErrorResponse::ServerError(
-                                    -32000,
-                                    "Too many active subscriptions",
-                                ),
-                                None,
+        let (state_machine_subscription, mut messages_rx, subscription_start) = match self
+            .requests_subscriptions
+            .start_subscription(state_machine_request_id, 1)
+            .await
+        {
+            Ok(v) => v,
+            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                self.requests_subscriptions
+                    .respond(
+                        state_machine_request_id,
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(
+                                -32000,
+                                "Too many active subscriptions",
                             ),
-                        )
-                        .await;
-                    return;
-                }
-            };
+                            None,
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
 
         let subscription_id = self
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
 
-        self.subscriptions.lock().await.insert(
-            subscription_id.clone(),
-            (
-                Arc::new(Mutex::new(messages_tx)),
-                state_machine_subscription.clone(),
-            ),
-        );
+        self.subscriptions
+            .lock()
+            .await
+            .insert(subscription_id.clone(), state_machine_subscription.clone());
 
         let mut blocks_list = {
             let (block_header, blocks_subscription) =
@@ -844,27 +828,19 @@ impl<TPlat: Platform> Background<TPlat> {
         // The task dedicated to this subscription will receive the message, send a response to
         // the JSON-RPC client, then shut down.
         let stop_message_received = {
-            let sender = self
-                .subscriptions
-                .lock()
-                .await
-                .get(&subscription)
-                .map(|(tx, _)| tx.clone());
+            let state_machine_sub_id = self.subscriptions.lock().await.get(&subscription).cloned();
 
-            if let Some(sender) = sender {
-                let (tx, rx) = oneshot::channel();
-                let _ = sender
-                    .lock()
-                    .await
-                    .send((
+            if let Some(state_machine_sub_id) = state_machine_sub_id {
+                self.requests_subscriptions
+                    .subscription_send(
+                        &state_machine_sub_id,
                         SubscriptionMessage::StopIfAllHeads {
                             stop_state_machine_request_id: state_machine_request_id.clone(),
                             stop_request_id: request_id.to_owned(),
                         },
-                        tx,
-                    ))
-                    .await;
-                rx.await.is_ok()
+                    )
+                    .await
+                    .is_ok()
             } else {
                 false
             }
@@ -895,27 +871,19 @@ impl<TPlat: Platform> Background<TPlat> {
         // The task dedicated to this subscription will receive the message, send a response to
         // the JSON-RPC client, then shut down.
         let stop_message_received = {
-            let sender = self
-                .subscriptions
-                .lock()
-                .await
-                .get(&subscription)
-                .map(|(tx, _)| tx.clone());
+            let state_machine_sub_id = self.subscriptions.lock().await.get(&subscription).cloned();
 
-            if let Some(sender) = sender {
-                let (tx, rx) = oneshot::channel();
-                let _ = sender
-                    .lock()
-                    .await
-                    .send((
+            if let Some(state_machine_sub_id) = state_machine_sub_id {
+                self.requests_subscriptions
+                    .subscription_send(
+                        &state_machine_sub_id,
                         SubscriptionMessage::StopIfFinalizedHeads {
                             stop_state_machine_request_id: state_machine_request_id.clone(),
                             stop_request_id: request_id.to_owned(),
                         },
-                        tx,
-                    ))
-                    .await;
-                rx.await.is_ok()
+                    )
+                    .await
+                    .is_ok()
             } else {
                 false
             }
@@ -946,27 +914,19 @@ impl<TPlat: Platform> Background<TPlat> {
         // The task dedicated to this subscription will receive the message, send a response to
         // the JSON-RPC client, then shut down.
         let stop_message_received = {
-            let sender = self
-                .subscriptions
-                .lock()
-                .await
-                .get(&subscription)
-                .map(|(tx, _)| tx.clone());
+            let state_machine_sub_id = self.subscriptions.lock().await.get(&subscription).cloned();
 
-            if let Some(sender) = sender {
-                let (tx, rx) = oneshot::channel();
-                let _ = sender
-                    .lock()
-                    .await
-                    .send((
+            if let Some(state_machine_sub_id) = state_machine_sub_id {
+                self.requests_subscriptions
+                    .subscription_send(
+                        &state_machine_sub_id,
                         SubscriptionMessage::StopIfNewHeads {
                             stop_state_machine_request_id: state_machine_request_id.clone(),
                             stop_request_id: request_id.to_owned(),
                         },
-                        tx,
-                    ))
-                    .await;
-                rx.await.is_ok()
+                    )
+                    .await
+                    .is_ok()
             } else {
                 false
             }
@@ -1445,43 +1405,39 @@ impl<TPlat: Platform> Background<TPlat> {
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
-            match self
-                .requests_subscriptions
-                .start_subscription(state_machine_request_id, 1)
-                .await
-            {
-                Ok(v) => v,
-                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                    self.requests_subscriptions
-                        .respond(
-                            state_machine_request_id,
-                            json_rpc::parse::build_error_response(
-                                request_id,
-                                json_rpc::parse::ErrorResponse::ServerError(
-                                    -32000,
-                                    "Too many active subscriptions",
-                                ),
-                                None,
+        let (state_machine_subscription, mut messages_rx, subscription_start) = match self
+            .requests_subscriptions
+            .start_subscription(state_machine_request_id, 1)
+            .await
+        {
+            Ok(v) => v,
+            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                self.requests_subscriptions
+                    .respond(
+                        state_machine_request_id,
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(
+                                -32000,
+                                "Too many active subscriptions",
                             ),
-                        )
-                        .await;
-                    return;
-                }
-            };
+                            None,
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
 
         let subscription_id = self
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
 
-        self.subscriptions.lock().await.insert(
-            subscription_id.clone(),
-            (
-                Arc::new(Mutex::new(messages_tx)),
-                state_machine_subscription.clone(),
-            ),
-        );
+        self.subscriptions
+            .lock()
+            .await
+            .insert(subscription_id.clone(), state_machine_subscription.clone());
 
         subscription_start.start({
             let me = self.clone();
@@ -1634,27 +1590,19 @@ impl<TPlat: Platform> Background<TPlat> {
         // The task dedicated to this subscription will receive the message, send a response to
         // the JSON-RPC client, then shut down.
         let stop_message_received = {
-            let sender = self
-                .subscriptions
-                .lock()
-                .await
-                .get(subscription)
-                .map(|(tx, _)| tx.clone());
+            let state_machine_sub_id = self.subscriptions.lock().await.get(subscription).cloned();
 
-            if let Some(sender) = sender {
-                let (tx, rx) = oneshot::channel();
-                let _ = sender
-                    .lock()
-                    .await
-                    .send((
+            if let Some(state_machine_sub_id) = state_machine_sub_id {
+                self.requests_subscriptions
+                    .subscription_send(
+                        &state_machine_sub_id,
                         SubscriptionMessage::StopIfRuntimeSpec {
                             stop_state_machine_request_id: state_machine_request_id.clone(),
                             stop_request_id: request_id.to_owned(),
                         },
-                        tx,
-                    ))
-                    .await;
-                rx.await.is_ok()
+                    )
+                    .await
+                    .is_ok()
             } else {
                 false
             }
@@ -1685,27 +1633,19 @@ impl<TPlat: Platform> Background<TPlat> {
         // The task dedicated to this subscription will receive the message, send a response to
         // the JSON-RPC client, then shut down.
         let stop_message_received = {
-            let sender = self
-                .subscriptions
-                .lock()
-                .await
-                .get(subscription)
-                .map(|(tx, _)| tx.clone());
+            let state_machine_sub_id = self.subscriptions.lock().await.get(subscription).cloned();
 
-            if let Some(sender) = sender {
-                let (tx, rx) = oneshot::channel();
-                let _ = sender
-                    .lock()
-                    .await
-                    .send((
+            if let Some(state_machine_sub_id) = state_machine_sub_id {
+                self.requests_subscriptions
+                    .subscription_send(
+                        &state_machine_sub_id,
                         SubscriptionMessage::StopIfStorage {
                             stop_state_machine_request_id: state_machine_request_id.clone(),
                             stop_request_id: request_id.to_owned(),
                         },
-                        tx,
-                    ))
-                    .await;
-                rx.await.is_ok()
+                    )
+                    .await
+                    .is_ok()
             } else {
                 false
             }
@@ -1731,43 +1671,39 @@ impl<TPlat: Platform> Background<TPlat> {
         state_machine_request_id: &requests_subscriptions::RequestId,
         list: Vec<methods::HexString>,
     ) {
-        let (state_machine_subscription, messages_tx, mut messages_rx, subscription_start) =
-            match self
-                .requests_subscriptions
-                .start_subscription(state_machine_request_id, 1)
-                .await
-            {
-                Ok(v) => v,
-                Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
-                    self.requests_subscriptions
-                        .respond(
-                            state_machine_request_id,
-                            json_rpc::parse::build_error_response(
-                                request_id,
-                                json_rpc::parse::ErrorResponse::ServerError(
-                                    -32000,
-                                    "Too many active subscriptions",
-                                ),
-                                None,
+        let (state_machine_subscription, mut messages_rx, subscription_start) = match self
+            .requests_subscriptions
+            .start_subscription(state_machine_request_id, 1)
+            .await
+        {
+            Ok(v) => v,
+            Err(requests_subscriptions::StartSubscriptionError::LimitReached) => {
+                self.requests_subscriptions
+                    .respond(
+                        state_machine_request_id,
+                        json_rpc::parse::build_error_response(
+                            request_id,
+                            json_rpc::parse::ErrorResponse::ServerError(
+                                -32000,
+                                "Too many active subscriptions",
                             ),
-                        )
-                        .await;
-                    return;
-                }
-            };
+                            None,
+                        ),
+                    )
+                    .await;
+                return;
+            }
+        };
 
         let subscription_id = self
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
 
-        self.subscriptions.lock().await.insert(
-            subscription_id.clone(),
-            (
-                Arc::new(Mutex::new(messages_tx)),
-                state_machine_subscription.clone(),
-            ),
-        );
+        self.subscriptions
+            .lock()
+            .await
+            .insert(subscription_id.clone(), state_machine_subscription.clone());
 
         // Build a stream of `methods::StorageChangeSet` items to send back to the user.
         let storage_updates = {

--- a/light-base/src/json_rpc_service/state_chain.rs
+++ b/light-base/src/json_rpc_service/state_chain.rs
@@ -410,18 +410,21 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        self.requests_subscriptions
-            .respond(
-                state_machine_request_id,
-                methods::Response::chain_subscribeAllHeads((&subscription_id).into())
-                    .to_json_response(request_id),
-            )
-            .await;
-
         // Spawn a separate task for the subscription.
         let task = {
             let me = self.clone();
+            let request_id = request_id.to_owned();
+            let state_machine_request_id = state_machine_request_id.clone();
+
             async move {
+                me.requests_subscriptions
+                    .respond(
+                        &state_machine_request_id,
+                        methods::Response::chain_subscribeAllHeads((&subscription_id).into())
+                            .to_json_response(&request_id),
+                    )
+                    .await;
+
                 'main_sub_loop: loop {
                     let mut new_blocks = {
                         // The buffer size should be large enough so that, if the CPU is busy, it
@@ -603,14 +606,6 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        self.requests_subscriptions
-            .respond(
-                state_machine_request_id,
-                methods::Response::chain_subscribeFinalizedHeads((&subscription_id).into())
-                    .to_json_response(request_id),
-            )
-            .await;
-
         let mut blocks_list = {
             let (finalized_block_header, finalized_blocks_subscription) =
                 sub_utils::subscribe_finalized(&self.runtime_service).await;
@@ -620,7 +615,18 @@ impl<TPlat: Platform> Background<TPlat> {
         // Spawn a separate task for the subscription.
         let task = {
             let me = self.clone();
+            let request_id = request_id.to_owned();
+            let state_machine_request_id = state_machine_request_id.clone();
+
             async move {
+                me.requests_subscriptions
+                    .respond(
+                        &state_machine_request_id,
+                        methods::Response::chain_subscribeFinalizedHeads((&subscription_id).into())
+                            .to_json_response(&request_id),
+                    )
+                    .await;
+
                 loop {
                     match future::select(blocks_list.next(), messages_rx.next()).await {
                         future::Either::Left((None, _)) => {
@@ -742,14 +748,6 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        self.requests_subscriptions
-            .respond(
-                state_machine_request_id,
-                methods::Response::chain_subscribeNewHeads((&subscription_id).into())
-                    .to_json_response(request_id),
-            )
-            .await;
-
         let mut blocks_list = {
             let (block_header, blocks_subscription) =
                 sub_utils::subscribe_best(&self.runtime_service).await;
@@ -759,7 +757,18 @@ impl<TPlat: Platform> Background<TPlat> {
         // Spawn a separate task for the subscription.
         let task = {
             let me = self.clone();
+            let request_id = request_id.to_owned();
+            let state_machine_request_id = state_machine_request_id.clone();
+
             async move {
+                me.requests_subscriptions
+                    .respond(
+                        &state_machine_request_id,
+                        methods::Response::chain_subscribeNewHeads((&subscription_id).into())
+                            .to_json_response(&request_id),
+                    )
+                    .await;
+
                 loop {
                     match future::select(blocks_list.next(), messages_rx.next()).await {
                         future::Either::Left((None, _)) => {
@@ -1487,17 +1496,19 @@ impl<TPlat: Platform> Background<TPlat> {
             ),
         );
 
-        self.requests_subscriptions
-            .respond(
-                state_machine_request_id,
-                methods::Response::state_subscribeRuntimeVersion((&subscription_id).into())
-                    .to_json_response(request_id),
-            )
-            .await;
-
         let task = {
             let me = self.clone();
+            let request_id = request_id.to_owned();
+            let state_machine_request_id = state_machine_request_id.clone();
             async move {
+                me.requests_subscriptions
+                    .respond(
+                        &state_machine_request_id,
+                        methods::Response::state_subscribeRuntimeVersion((&subscription_id).into())
+                            .to_json_response(&request_id),
+                    )
+                    .await;
+
                 let (current_spec, spec_changes) =
                     sub_utils::subscribe_runtime_version(&me.runtime_service).await;
                 let spec_changes = stream::iter(iter::once(current_spec)).chain(spec_changes);
@@ -1729,7 +1740,7 @@ impl<TPlat: Platform> Background<TPlat> {
     }
 
     /// Handles a call to [`methods::MethodCall::state_subscribeStorage`].
-    pub(super) async fn subscribe_storage(
+    async fn subscribe_storage(
         self: &Arc<Self>,
         request_id: &str,
         state_machine_request_id: &requests_subscriptions::RequestId,
@@ -1773,14 +1784,6 @@ impl<TPlat: Platform> Background<TPlat> {
                 state_machine_subscription.clone(),
             ),
         );
-
-        self.requests_subscriptions
-            .respond(
-                state_machine_request_id,
-                methods::Response::state_subscribeStorage((&subscription_id).into())
-                    .to_json_response(request_id),
-            )
-            .await;
 
         // Build a stream of `methods::StorageChangeSet` items to send back to the user.
         let storage_updates = {
@@ -1883,7 +1886,18 @@ impl<TPlat: Platform> Background<TPlat> {
         // Spawn a separate task for the subscription.
         let task = {
             let me = self.clone();
+            let request_id = request_id.to_owned();
+            let state_machine_request_id = state_machine_request_id.clone();
+
             async move {
+                me.requests_subscriptions
+                    .respond(
+                        &state_machine_request_id,
+                        methods::Response::state_subscribeStorage((&subscription_id).into())
+                            .to_json_response(&request_id),
+                    )
+                    .await;
+
                 futures::pin_mut!(storage_updates);
 
                 loop {

--- a/light-base/src/json_rpc_service/transactions.rs
+++ b/light-base/src/json_rpc_service/transactions.rs
@@ -145,7 +145,7 @@ impl<TPlat: Platform> Background<TPlat> {
         transaction: methods::HexString,
         is_legacy: bool,
     ) {
-        let state_machine_subscription = match self
+        let (state_machine_subscription, messages_tx, mut messages_rx) = match self
             .requests_subscriptions
             .start_subscription(state_machine_request_id, 16)
             .await
@@ -173,8 +173,6 @@ impl<TPlat: Platform> Background<TPlat> {
             .next_subscription_id
             .fetch_add(1, atomic::Ordering::Relaxed)
             .to_string();
-
-        let (messages_tx, mut messages_rx) = mpsc::channel(0);
 
         self.subscriptions.lock().await.insert(
             subscription_id.clone(),

--- a/light-base/src/json_rpc_service/transactions.rs
+++ b/light-base/src/json_rpc_service/transactions.rs
@@ -228,10 +228,6 @@ impl<TPlat: Platform> Background<TPlat> {
                                         confirmation_sender,
                                     )) => {
                                         me.requests_subscriptions
-                                            .stop_subscription(&state_machine_subscription)
-                                            .await;
-
-                                        me.requests_subscriptions
                                             .respond(
                                                 &stop_state_machine_request_id,
                                                 methods::Response::author_unwatchExtrinsic(true)
@@ -259,10 +255,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             _,
                         )) if !is_legacy => {
                             me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
-                            me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,
                                     methods::Response::transaction_unstable_unwatch(())
@@ -283,10 +275,6 @@ impl<TPlat: Platform> Background<TPlat> {
                             )),
                             _,
                         )) if is_legacy => {
-                            me.requests_subscriptions
-                                .stop_subscription(&state_machine_subscription)
-                                .await;
-
                             me.requests_subscriptions
                                 .respond(
                                     &stop_state_machine_request_id,


### PR DESCRIPTION
Continuation of https://github.com/smol-dot/smoldot/issues/291

This PR attempts to simplify how subscriptions are implemented in the high-level code by moving some logic to `requests_subscriptions`:

- Each subscription within `RequestsSubscriptions` now has a task associated to it.
- Sending a message to a subscription task is now done with a function on `RequestsSubscriptions`.
- Subscriptions are automatically cleaned up when a subscription task is destroyed, instead of manually.

