### PR TITLE
Implement Clone on VirtualMachinePrototype and remove Module

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -279,7 +279,6 @@ impl HostVmPrototype {
         let runtime_version = runtime_version::find_embedded_runtime_version(&module)
             .ok()
             .flatten(); // TODO: return error instead of using `ok()`? unclear
-        let module = vm::Module::new(module, config.exec_hint).map_err(NewErr::InvalidWasm)?;
 
         // Initialize the virtual machine.
         // Each symbol requested by the Wasm runtime will be put in `registered_functions`. Later,
@@ -288,7 +287,8 @@ impl HostVmPrototype {
         let (mut vm_proto, registered_functions) = {
             let mut registered_functions = Vec::new();
             let vm_proto = vm::VirtualMachinePrototype::new(
-                &module,
+                module,
+                config.exec_hint,
                 // This closure is called back for each function that the runtime imports.
                 |mod_name, f_name, signature| {
                     if mod_name != "env" {
@@ -3637,9 +3637,6 @@ pub enum NewErr {
     /// Error in the format of the runtime code.
     #[display(fmt = "{_0}")]
     BadFormat(ModuleFormatError),
-    /// Error while compiling the WebAssembly code.
-    #[display(fmt = "{_0}")]
-    InvalidWasm(vm::ModuleError),
     /// Error while initializing the virtual machine.
     #[display(fmt = "{_0}")]
     VirtualMachine(vm::NewErr),

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -241,6 +241,7 @@ pub struct Config<TModule> {
 /// > **Note**: This struct implements `Clone`. Cloning a [`HostVmPrototype`] allocates memory
 /// >           necessary for the clone to run.
 // TODO: this behaviour ^ interacts with zero-ing memory when resetting from a vm to a prototype; figure out and clarify
+#[derive(Clone)]
 pub struct HostVmPrototype {
     /// Original module used to instantiate the prototype.
     ///
@@ -523,21 +524,6 @@ impl HostVmPrototype {
                 allocator,
             },
         })
-    }
-}
-
-impl Clone for HostVmPrototype {
-    fn clone(&self) -> Self {
-        // The `from_module` function returns an error if the format of the module is invalid.
-        // Since we have successfully called `from_module` with that same `module` earlier, it
-        // is assumed that errors cannot happen.
-        Self::from_module(
-            self.module.clone(),
-            self.heap_pages,
-            self.allow_unresolved_imports,
-            self.runtime_version.clone(),
-        )
-        .unwrap()
     }
 }
 
@@ -3472,6 +3458,7 @@ impl fmt::Debug for EndStorageTransaction {
     }
 }
 
+#[derive(Clone)]
 enum FunctionImport {
     Resolved(HostFunction),
     Unresolved { module: String, name: String },

--- a/lib/src/executor/host/tests/initialization.rs
+++ b/lib/src/executor/host/tests/initialization.rs
@@ -31,7 +31,7 @@ fn invalid_wasm() {
             heap_pages: HeapPages::new(1024),
             module: &module_bytes,
         }) {
-            Err(NewErr::InvalidWasm(_)) => {}
+            Err(NewErr::VirtualMachine(vm::NewErr::InvalidWasm(_))) => {}
             _ => panic!(),
         }
     }

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -101,10 +101,14 @@ impl Module {
     }
 }
 
+/// > **Note**: This struct implements `Clone`. Cloning a [`VirtualMachinePrototype`] allocates
+/// >           memory necessary for the clone to run.
+#[derive(Clone)]
 pub struct VirtualMachinePrototype {
     inner: VirtualMachinePrototypeInner,
 }
 
+#[derive(Clone)]
 enum VirtualMachinePrototypeInner {
     #[cfg(all(target_arch = "x86_64", feature = "std"))]
     Jit(jit::JitPrototype),

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -233,6 +233,20 @@ impl InterpreterPrototype {
     }
 }
 
+impl Clone for InterpreterPrototype {
+    fn clone(&self) -> Self {
+        // `from_base_components` is deterministic: either it errors all the time or it never
+        // errors. Since we've called it before and it didn't error, we know that it will also
+        // not error.
+        // The only exception is `NewErr::CouldntAllocateMemory`, but lack of memory is always an
+        // acceptable reason to panic.
+        InterpreterPrototype::from_base_components(BaseComponents {
+            module: self.base_components.module.clone(),
+            resolved_imports: self.base_components.resolved_imports.clone(),
+        }).unwrap()
+    }
+}
+
 impl fmt::Debug for InterpreterPrototype {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("InterpreterPrototype").finish()

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -18,34 +18,12 @@
 //! Implements the API documented [in the parent module](..).
 
 use super::{
-    ExecOutcome, GlobalValueErr, HeapPages, ModuleError, NewErr, OutOfBoundsError, RunErr,
-    Signature, StartErr, Trap, ValueType, WasmValue,
+    ExecOutcome, GlobalValueErr, HeapPages, NewErr, OutOfBoundsError, RunErr, Signature, StartErr,
+    Trap, ValueType, WasmValue,
 };
 
-use alloc::{borrow::ToOwned as _, string::ToString as _, sync::Arc, vec::Vec};
+use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 use core::fmt;
-
-/// See [`super::Module`].
-#[derive(Clone)]
-pub struct Module {
-    // Note: an `Arc` is used in order to expose the same API as wasmtime does. If in the future
-    // wasmtime happened to no longer use internal reference counting, this `Arc` should be
-    // removed.
-    inner: Arc<wasmi::Module>,
-}
-
-impl Module {
-    /// See [`super::Module::new`].
-    pub fn new(module_bytes: impl AsRef<[u8]>) -> Result<Self, ModuleError> {
-        let engine = wasmi::Engine::default(); // TODO: investigate config
-        let module = wasmi::Module::new(&engine, module_bytes.as_ref())
-            .map_err(|err| ModuleError(err.to_string()))?;
-
-        Ok(Module {
-            inner: Arc::new(module),
-        })
-    }
-}
 
 /// See [`super::VirtualMachinePrototype`].
 pub struct InterpreterPrototype {
@@ -73,11 +51,15 @@ struct BaseComponents {
 impl InterpreterPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
-        module: &Module,
+        module_bytes: impl AsRef<[u8]>,
         mut symbols: impl FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
-        let mut resolved_imports = Vec::with_capacity(module.inner.imports().len());
-        for import in module.inner.imports() {
+        let engine = wasmi::Engine::default(); // TODO: investigate config
+        let module = wasmi::Module::new(&engine, module_bytes.as_ref())
+            .map_err(|err| NewErr::InvalidWasm(err.to_string()))?;
+
+        let mut resolved_imports = Vec::with_capacity(module.imports().len());
+        for import in module.imports() {
             match import.ty() {
                 wasmi::ExternType::Func(func_type) => {
                     // Note that if `Signature::try_from` fails, a `UnresolvedFunctionImport` is
@@ -108,7 +90,7 @@ impl InterpreterPrototype {
         }
 
         Self::from_base_components(BaseComponents {
-            module: module.inner.clone(),
+            module: Arc::new(module),
             resolved_imports,
         })
     }
@@ -243,7 +225,8 @@ impl Clone for InterpreterPrototype {
         InterpreterPrototype::from_base_components(BaseComponents {
             module: self.base_components.module.clone(),
             resolved_imports: self.base_components.resolved_imports.clone(),
-        }).unwrap()
+        })
+        .unwrap()
     }
 }
 

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -356,6 +356,20 @@ impl JitPrototype {
     }
 }
 
+impl Clone for JitPrototype {
+    fn clone(&self) -> Self {
+        // `from_base_components` is deterministic: either it errors all the time or it never
+        // errors. Since we've called it before and it didn't error, we know that it will also
+        // not error.
+        // The only exception is `NewErr::CouldntAllocateMemory`, but lack of memory is always an
+        // acceptable reason to panic.
+        JitPrototype::from_base_components(BaseComponents {
+            module: self.base_components.module.clone(),
+            resolved_imports: self.base_components.resolved_imports.clone(),
+        }).unwrap()
+    }
+}
+
 impl fmt::Debug for JitPrototype {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("JitPrototype").finish()

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -18,8 +18,8 @@
 //! Implements the API documented [in the parent module](..).
 
 use super::{
-    ExecOutcome, GlobalValueErr, HeapPages, ModuleError, NewErr, OutOfBoundsError, RunErr,
-    Signature, StartErr, Trap, ValueType, WasmValue,
+    ExecOutcome, GlobalValueErr, HeapPages, NewErr, OutOfBoundsError, RunErr, Signature, StartErr,
+    Trap, ValueType, WasmValue,
 };
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
@@ -33,34 +33,6 @@ use core::{
 use std::sync::Mutex;
 
 use futures::{task, FutureExt as _};
-
-/// See [`super::Module`].
-#[derive(Clone)]
-pub struct Module {
-    inner: wasmtime::Module,
-}
-
-impl Module {
-    /// See [`super::Module::new`].
-    pub fn new(module_bytes: impl AsRef<[u8]>) -> Result<Self, ModuleError> {
-        let mut config = wasmtime::Config::new();
-        config.cranelift_nan_canonicalization(true);
-        config.cranelift_opt_level(wasmtime::OptLevel::Speed);
-        config.async_support(true);
-        // The default value of `wasm_backtrace_details` is `Environment`, which reads the
-        // `WASMTIME_BACKTRACE_DETAILS` environment variable to determine whether or not to keep
-        // debug info. However we don't want any of the behaviour of our code to rely on any
-        // environment variables whatsoever. Whether to use `Enable` or `Disable` below isn't
-        // very important, so long as it is not `Environment`.
-        config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
-        let engine = wasmtime::Engine::new(&config).map_err(|err| ModuleError(err.to_string()))?;
-
-        let inner = wasmtime::Module::from_binary(&engine, module_bytes.as_ref())
-            .map_err(|err| ModuleError(err.to_string()))?;
-
-        Ok(Module { inner })
-    }
-}
 
 /// See [`super::VirtualMachinePrototype`].
 pub struct JitPrototype {
@@ -93,13 +65,29 @@ struct BaseComponents {
 impl JitPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
-        module: &Module,
+        module_bytes: impl AsRef<[u8]>,
         mut symbols: impl FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
+        let mut config = wasmtime::Config::new();
+        config.cranelift_nan_canonicalization(true);
+        config.cranelift_opt_level(wasmtime::OptLevel::Speed);
+        config.async_support(true);
+        // The default value of `wasm_backtrace_details` is `Environment`, which reads the
+        // `WASMTIME_BACKTRACE_DETAILS` environment variable to determine whether or not to keep
+        // debug info. However we don't want any of the behaviour of our code to rely on any
+        // environment variables whatsoever. Whether to use `Enable` or `Disable` below isn't
+        // very important, so long as it is not `Environment`.
+        config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
+        let engine =
+            wasmtime::Engine::new(&config).map_err(|err| NewErr::InvalidWasm(err.to_string()))?;
+
+        let module = wasmtime::Module::from_binary(&engine, module_bytes.as_ref())
+            .map_err(|err| NewErr::InvalidWasm(err.to_string()))?;
+
         // Building the list of imports that the Wasm VM is able to use.
         let resolved_imports = {
-            let mut imports = Vec::with_capacity(module.inner.imports().len());
-            for import in module.inner.imports() {
+            let mut imports = Vec::with_capacity(module.imports().len());
+            for import in module.imports() {
                 match import.ty() {
                     wasmtime::ExternType::Func(func_type) => {
                         // Note that if `Signature::try_from` fails, a `UnresolvedFunctionImport` is
@@ -134,7 +122,7 @@ impl JitPrototype {
         };
 
         Self::from_base_components(BaseComponents {
-            module: module.inner.clone(),
+            module,
             resolved_imports,
         })
     }
@@ -366,7 +354,8 @@ impl Clone for JitPrototype {
         JitPrototype::from_base_components(BaseComponents {
             module: self.base_components.module.clone(),
             resolved_imports: self.base_components.resolved_imports.clone(),
-        }).unwrap()
+        })
+        .unwrap()
     }
 }
 


### PR DESCRIPTION
At the moment, you need to create a `Module`, then can use this `Module` to create a `VirtualMachinePrototype`.

Rather than doing that, this PR proposes that `VirtualMachinePrototype` is made clonable.

This in my opinion makes things more clear and simple on an API level.
