### PR TITLE
Rename "top trie" to "main trie" everywhere

### DIFF
--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -161,7 +161,7 @@ impl ConsensusService {
                     .unwrap()
                     .number;
                     let finalized_block_storage: Vec<(Vec<u8>, Vec<u8>, u8)> = database
-                        .finalized_block_storage_top_trie(&finalized_block_hash)
+                        .finalized_block_storage_main_trie(&finalized_block_hash)
                         .unwrap();
                     // TODO: we copy all entries; it could be more optimal to have a custom implementation of FromIterator that directly does the conversion?
                     let finalized_block_storage = finalized_block_storage
@@ -692,7 +692,7 @@ impl SyncBackground {
                         .unwrap(),
                     parent_runtime,
                     block_body_capacity: 0, // TODO: could be set to the size of the tx pool
-                    top_trie_root_calculation_cache: None, // TODO: pretty important for performances
+                    main_trie_root_calculation_cache: None, // TODO: pretty important for performances
                     max_log_level: 0,
                 })
             };
@@ -1233,7 +1233,7 @@ impl SyncBackground {
                                     .full
                                     .as_ref()
                                     .unwrap()
-                                    .storage_top_trie_changes
+                                    .storage_main_trie_changes
                                     .diff_iter_unordered()
                                 {
                                     if let Some(value) = value {
@@ -1348,7 +1348,7 @@ async fn database_blocks(
                         .full
                         .as_ref()
                         .unwrap()
-                        .storage_top_trie_changes
+                        .storage_main_trie_changes
                         .diff_iter_unordered()
                         .map(|(k, v, ())| (k, v)),
                     u8::from(block.full.as_ref().unwrap().state_trie_version),

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -220,7 +220,7 @@ impl AuthoringStart {
             parent_hash: config.parent_hash,
             parent_number: config.parent_number,
             parent_runtime: config.parent_runtime,
-            top_trie_root_calculation_cache: config.top_trie_root_calculation_cache,
+            main_trie_root_calculation_cache: config.main_trie_root_calculation_cache,
             block_body_capacity: config.block_body_capacity,
             consensus_digest_log_item: match self.consensus {
                 WaitSlotConsensus::Aura(slot) => {
@@ -271,7 +271,7 @@ pub struct AuthoringStartConfig<'a> {
 
     /// Optional cache corresponding to the storage trie root hash calculation coming from the
     /// parent block verification.
-    pub top_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
+    pub main_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
 
     /// Capacity to reserve for the number of extrinsics. Should be higher than the approximate
     /// number of extrinsics that are going to be applied.

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -86,7 +86,7 @@ pub struct Config<'a> {
 
     /// Optional cache corresponding to the storage trie root hash calculation coming from the
     /// parent block verification.
-    pub top_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
+    pub main_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
 
     /// Capacity to reserve for the number of extrinsics. Should be higher than the approximate
     /// number of extrinsics that are going to be applied.
@@ -118,15 +118,15 @@ pub struct Success {
     pub body: Vec<Vec<u8>>,
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
-    /// List of changes to the storage top trie that the block performs.
-    pub storage_top_trie_changes: storage_diff::StorageDiff,
+    /// List of changes to the storage main trie that the block performs.
+    pub storage_main_trie_changes: storage_diff::StorageDiff,
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`Success::storage_top_trie_changes`] should store this version alongside with them.
+    /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: storage_diff::StorageDiff,
-    /// Cache used for calculating the top trie root of the new block.
-    pub top_trie_root_calculation_cache: calculate_root::CalculationCache,
+    /// Cache used for calculating the main trie root of the new block.
+    pub main_trie_root_calculation_cache: calculate_root::CalculationCache,
     /// Concatenation of all the log messages printed by the runtime.
     pub logs: String,
 }
@@ -190,8 +190,8 @@ pub fn build_block(config: Config) -> BlockBuild {
             }
             .scale_encoding(config.block_number_bytes)
         },
-        top_trie_root_calculation_cache: config.top_trie_root_calculation_cache,
-        storage_top_trie_changes: Default::default(),
+        main_trie_root_calculation_cache: config.main_trie_root_calculation_cache,
+        storage_main_trie_changes: Default::default(),
         offchain_storage_changes: Default::default(),
         max_log_level: config.max_log_level,
     });
@@ -295,9 +295,9 @@ impl BlockBuild {
                     return BlockBuild::InherentExtrinsics(InherentExtrinsics {
                         shared,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        storage_main_trie_changes: success.storage_main_trie_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
-                        top_trie_root_calculation_cache: success.top_trie_root_calculation_cache,
+                        main_trie_root_calculation_cache: success.main_trie_root_calculation_cache,
                     });
                 }
 
@@ -327,10 +327,10 @@ impl BlockBuild {
                         virtual_machine: success.virtual_machine.into_prototype(),
                         function_to_call: "BlockBuilder_apply_extrinsic",
                         parameter: iter::once(extrinsic),
-                        top_trie_root_calculation_cache: Some(
-                            success.top_trie_root_calculation_cache,
+                        main_trie_root_calculation_cache: Some(
+                            success.main_trie_root_calculation_cache,
                         ),
-                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        storage_main_trie_changes: success.storage_main_trie_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
                         max_log_level: shared.max_log_level,
                     });
@@ -347,9 +347,9 @@ impl BlockBuild {
                     return BlockBuild::ApplyExtrinsic(ApplyExtrinsic {
                         shared,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        storage_main_trie_changes: success.storage_main_trie_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
-                        top_trie_root_calculation_cache: success.top_trie_root_calculation_cache,
+                        main_trie_root_calculation_cache: success.main_trie_root_calculation_cache,
                     });
                 }
 
@@ -417,10 +417,10 @@ impl BlockBuild {
                         resume: ApplyExtrinsic {
                             shared,
                             parent_runtime: success.virtual_machine.into_prototype(),
-                            storage_top_trie_changes: success.storage_top_trie_changes,
+                            storage_main_trie_changes: success.storage_main_trie_changes,
                             offchain_storage_changes: success.offchain_storage_changes,
-                            top_trie_root_calculation_cache: success
-                                .top_trie_root_calculation_cache,
+                            main_trie_root_calculation_cache: success
+                                .main_trie_root_calculation_cache,
                         },
                     };
                 }
@@ -435,10 +435,10 @@ impl BlockBuild {
                         scale_encoded_header,
                         body: shared.block_body,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        storage_main_trie_changes: success.storage_main_trie_changes,
                         state_trie_version: success.state_trie_version,
                         offchain_storage_changes: success.offchain_storage_changes,
-                        top_trie_root_calculation_cache: success.top_trie_root_calculation_cache,
+                        main_trie_root_calculation_cache: success.main_trie_root_calculation_cache,
                         logs: shared.logs,
                     }));
                 }
@@ -481,9 +481,9 @@ enum Stage {
 pub struct InherentExtrinsics {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_top_trie_changes: storage_diff::StorageDiff,
+    storage_main_trie_changes: storage_diff::StorageDiff,
     offchain_storage_changes: storage_diff::StorageDiff,
-    top_trie_root_calculation_cache: calculate_root::CalculationCache,
+    main_trie_root_calculation_cache: calculate_root::CalculationCache,
 }
 
 impl InherentExtrinsics {
@@ -525,8 +525,8 @@ impl InherentExtrinsics {
                     .map(either::Left)
                     .chain(encoded_list.map(either::Right))
             },
-            top_trie_root_calculation_cache: Some(self.top_trie_root_calculation_cache),
-            storage_top_trie_changes: self.storage_top_trie_changes,
+            main_trie_root_calculation_cache: Some(self.main_trie_root_calculation_cache),
+            storage_main_trie_changes: self.storage_main_trie_changes,
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });
@@ -545,9 +545,9 @@ impl InherentExtrinsics {
 pub struct ApplyExtrinsic {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_top_trie_changes: storage_diff::StorageDiff,
+    storage_main_trie_changes: storage_diff::StorageDiff,
     offchain_storage_changes: storage_diff::StorageDiff,
-    top_trie_root_calculation_cache: calculate_root::CalculationCache,
+    main_trie_root_calculation_cache: calculate_root::CalculationCache,
 }
 
 impl ApplyExtrinsic {
@@ -559,8 +559,8 @@ impl ApplyExtrinsic {
             virtual_machine: self.parent_runtime,
             function_to_call: "BlockBuilder_apply_extrinsic",
             parameter: iter::once(&extrinsic),
-            top_trie_root_calculation_cache: Some(self.top_trie_root_calculation_cache),
-            storage_top_trie_changes: self.storage_top_trie_changes,
+            main_trie_root_calculation_cache: Some(self.main_trie_root_calculation_cache),
+            storage_main_trie_changes: self.storage_main_trie_changes,
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });
@@ -583,8 +583,8 @@ impl ApplyExtrinsic {
             virtual_machine: self.parent_runtime,
             function_to_call: "BlockBuilder_finalize_block",
             parameter: iter::empty::<&[u8]>(),
-            top_trie_root_calculation_cache: Some(self.top_trie_root_calculation_cache),
-            storage_top_trie_changes: self.storage_top_trie_changes,
+            main_trie_root_calculation_cache: Some(self.main_trie_root_calculation_cache),
+            storage_main_trie_changes: self.storage_main_trie_changes,
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -40,7 +40,7 @@ fn block_building_works() {
         consensus_digest_log_item: super::ConfigPreRuntime::Aura(crate::header::AuraPreDigest {
             slot_number: 1234u64,
         }),
-        top_trie_root_calculation_cache: None,
+        main_trie_root_calculation_cache: None,
         max_log_level: 0,
     });
 

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -598,10 +598,10 @@ impl<T> VerifyContext<T> {
                 BodyVerifyStep2::Finished {
                     parent_runtime: success.parent_runtime,
                     new_runtime: success.new_runtime,
-                    storage_top_trie_changes: success.storage_top_trie_changes,
+                    storage_main_trie_changes: success.storage_main_trie_changes,
                     state_trie_version: success.state_trie_version,
                     offchain_storage_changes: success.offchain_storage_changes,
-                    top_trie_root_calculation_cache: success.top_trie_root_calculation_cache,
+                    main_trie_root_calculation_cache: success.main_trie_root_calculation_cache,
                     insert: BodyInsert {
                         context: self,
                         is_new_best,
@@ -731,17 +731,17 @@ impl<T> BodyVerifyRuntimeRequired<T> {
     /// `parent_runtime` must be a Wasm virtual machine containing the runtime code of the parent
     /// block.
     ///
-    /// The value of `top_trie_root_calculation_cache` can be the one provided by the
+    /// The value of `main_trie_root_calculation_cache` can be the one provided by the
     /// [`BodyVerifyStep2::Finished`] variant when the parent block has been verified. `None` can
     /// be passed if this information isn't available.
     ///
-    /// While `top_trie_root_calculation_cache` is optional, providing a value will considerably
+    /// While `main_trie_root_calculation_cache` is optional, providing a value will considerably
     /// speed up the calculation.
     pub fn resume(
         self,
         parent_runtime: host::HostVmPrototype,
         block_body: impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone,
-        top_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
+        main_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
     ) -> BodyVerifyStep2<T> {
         let parent_block_header = if let Some(parent_tree_index) = self.context.parent_tree_index {
             &self
@@ -808,7 +808,7 @@ impl<T> BodyVerifyRuntimeRequired<T> {
             block_number_bytes: self.context.chain.block_number_bytes,
             parent_block_header: parent_block_header.into(),
             block_body,
-            top_trie_root_calculation_cache,
+            main_trie_root_calculation_cache,
             max_log_level: 0,
         });
 
@@ -840,14 +840,14 @@ pub enum BodyVerifyStep2<T> {
     Finished {
         /// Value that was passed to [`BodyVerifyRuntimeRequired::resume`].
         parent_runtime: host::HostVmPrototype,
-        /// Contains `Some` if and only if [`BodyVerifyStep2::Finished::storage_top_trie_changes`]
+        /// Contains `Some` if and only if [`BodyVerifyStep2::Finished::storage_main_trie_changes`]
         /// contains a change in the `:code` or `:heappages` keys, indicating that the runtime has
         /// been modified. Contains the new runtime.
         new_runtime: Option<host::HostVmPrototype>,
-        /// List of changes to the storage top trie that the block performs.
-        storage_top_trie_changes: storage_diff::StorageDiff,
+        /// List of changes to the storage main trie that the block performs.
+        storage_main_trie_changes: storage_diff::StorageDiff,
         /// State trie version indicated by the runtime. All the storage changes indicated by
-        /// [`BodyVerifyStep2::Finished::storage_top_trie_changes`] should store this version
+        /// [`BodyVerifyStep2::Finished::storage_main_trie_changes`] should store this version
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.
@@ -855,7 +855,7 @@ pub enum BodyVerifyStep2<T> {
         /// Cache of calculation for the storage trie of the best block.
         /// Pass this value to [`BodyVerifyRuntimeRequired::resume`] when verifying a children of
         /// this block in order to considerably speed up the verification.
-        top_trie_root_calculation_cache: calculate_root::CalculationCache,
+        main_trie_root_calculation_cache: calculate_root::CalculationCache,
         /// Use to insert the block in the chain.
         insert: BodyInsert<T>,
     },

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS blocks_body(
 /*
 Storage at the highest block that is considered finalized.
 */
-CREATE TABLE IF NOT EXISTS finalized_storage_top_trie(
+CREATE TABLE IF NOT EXISTS finalized_storage_main_trie(
     key BLOB NOT NULL PRIMARY KEY,
     value BLOB NOT NULL,
     trie_entry_version INTEGER NOT NULL
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS finalized_storage_top_trie(
 /*
 For non-finalized blocks (i.e. blocks that descend from the finalized block), contains changes
 that this block performs on the storage.
-When a block gets finalized, these changes get merged into `finalized_storage_top_trie`.
+When a block gets finalized, these changes get merged into `finalized_storage_main_trie`.
 */
 CREATE TABLE IF NOT EXISTS non_finalized_changes(
     hash BLOB NOT NULL,
@@ -276,7 +276,7 @@ impl DatabaseEmpty {
         chain_information: impl Into<chain_information::ChainInformationRef<'a>>,
         finalized_block_body: impl ExactSizeIterator<Item = &'a [u8]>,
         finalized_block_justification: Option<Vec<u8>>,
-        finalized_block_storage_top_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8])> + Clone,
+        finalized_block_storage_main_trie_entries: impl Iterator<Item = (&'a [u8], &'a [u8])> + Clone,
         finalized_block_state_version: u8,
     ) -> Result<SqliteFullDatabase, AccessError> {
         let chain_information = chain_information.into();
@@ -296,9 +296,9 @@ impl DatabaseEmpty {
         {
             let mut statement = self
                 .database
-                .prepare("INSERT INTO finalized_storage_top_trie(key, value, trie_entry_version) VALUES(?, ?, ?)")
+                .prepare("INSERT INTO finalized_storage_main_trie(key, value, trie_entry_version) VALUES(?, ?, ?)")
                 .unwrap();
-            for (key, value) in finalized_block_storage_top_trie_entries {
+            for (key, value) in finalized_block_storage_main_trie_entries {
                 statement = statement
                     .bind(1, key)
                     .unwrap()

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -743,8 +743,10 @@ impl Inner {
                         .unwrap()
                         .storage_value_update(key.as_ref(), true);
 
-                    let current_value =
-                        self.main_trie_changes.diff_get(key.as_ref()).map(|(v, _)| v);
+                    let current_value = self
+                        .main_trie_changes
+                        .diff_get(key.as_ref())
+                        .map(|(v, _)| v);
                     if let Some(current_value) = current_value {
                         let mut current_value = current_value.unwrap_or_default().to_vec();
                         append_to_storage_value(&mut current_value, req.value().as_ref());

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -62,12 +62,12 @@ pub struct Config<'a, TParams> {
     pub parameter: TParams,
 
     /// Optional cache of the trie root calculation to use. Must match the state of the storage at
-    /// the start of the call, including [`Config::storage_top_trie_changes`].
-    pub top_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
+    /// the start of the call, including [`Config::storage_main_trie_changes`].
+    pub main_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
 
-    /// Initial state of [`Success::storage_top_trie_changes`]. The changes made during this
+    /// Initial state of [`Success::storage_main_trie_changes`]. The changes made during this
     /// execution will be pushed over the value in this field.
-    pub storage_top_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::StorageDiff,
 
     /// Initial state of [`Success::offchain_storage_changes`]. The changes made during this
     /// execution will be pushed over the value in this field.
@@ -98,12 +98,12 @@ pub fn run(
             .virtual_machine
             .run_vectored(config.function_to_call, config.parameter)?
             .into(),
-        top_trie_changes: config.storage_top_trie_changes,
+        main_trie_changes: config.storage_main_trie_changes,
         state_trie_version,
-        top_trie_transaction_revert: Vec::new(),
+        main_trie_transaction_revert: Vec::new(),
         offchain_storage_changes: config.offchain_storage_changes,
-        top_trie_root_calculation_cache: Some(
-            config.top_trie_root_calculation_cache.unwrap_or_default(),
+        main_trie_root_calculation_cache: Some(
+            config.main_trie_root_calculation_cache.unwrap_or_default(),
         ),
         root_calculation: None,
         logs: String::new(),
@@ -118,15 +118,15 @@ pub struct Success {
     /// Contains the output value of the runtime, and the virtual machine that was passed at
     /// initialization.
     pub virtual_machine: SuccessVirtualMachine,
-    /// List of changes to the storage top trie that the block performs.
-    pub storage_top_trie_changes: storage_diff::StorageDiff,
+    /// List of changes to the storage main trie that the block performs.
+    pub storage_main_trie_changes: storage_diff::StorageDiff,
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`Success::storage_top_trie_changes`] should store this version alongside with them.
+    /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: storage_diff::StorageDiff,
-    /// Cache used for calculating the top trie root.
-    pub top_trie_root_calculation_cache: calculate_root::CalculationCache,
+    /// Cache used for calculating the main trie root.
+    pub main_trie_root_calculation_cache: calculate_root::CalculationCache,
     /// Concatenation of all the log messages printed by the runtime.
     pub logs: String,
 }
@@ -284,7 +284,7 @@ impl StorageGet {
                         let mut value = value.map(|(v, _)| v).unwrap_or_default();
                         append_to_storage_value(&mut value, req.value().as_ref());
                         self.inner
-                            .top_trie_changes
+                            .main_trie_changes
                             .diff_insert(key.as_ref().to_vec(), value, ());
                     }
                     _ => unreachable!(),
@@ -341,7 +341,7 @@ impl PrefixKeys {
         match self.inner.vm {
             host::HostVm::ExternalStorageClearPrefix(req) => {
                 // TODO: use prefix_remove_update once optimized and fixed to account for removal count limit
-                //top_trie_root_calculation_cache.prefix_remove_update(storage_key);
+                //main_trie_root_calculation_cache.prefix_remove_update(storage_key);
 
                 // Grab the maximum number of keys to remove, and initialize a counter for the
                 // number of keys removed so far.
@@ -355,7 +355,7 @@ impl PrefixKeys {
 
                 let mut after_overlay = self
                     .inner
-                    .top_trie_changes
+                    .main_trie_changes
                     .storage_prefix_keys_ordered(&prefix, keys)
                     .peekable();
 
@@ -386,21 +386,21 @@ impl PrefixKeys {
 
                 for key in keys_to_remove {
                     self.inner
-                        .top_trie_root_calculation_cache
+                        .main_trie_root_calculation_cache
                         .as_mut()
                         .unwrap()
                         .storage_value_update(&key, false);
 
                     let previous_value = self
                         .inner
-                        .top_trie_changes
+                        .main_trie_changes
                         .diff_insert_erase(key.clone(), ())
                         .map(|(v, _)| v);
 
-                    if let Some(top_trie_transaction_revert) =
-                        self.inner.top_trie_transaction_revert.last_mut()
+                    if let Some(main_trie_transaction_revert) =
+                        self.inner.main_trie_transaction_revert.last_mut()
                     {
-                        if let Entry::Vacant(entry) = top_trie_transaction_revert.entry(key) {
+                        if let Entry::Vacant(entry) = main_trie_transaction_revert.entry(key) {
                             entry.insert(previous_value);
                         }
                     }
@@ -417,14 +417,14 @@ impl PrefixKeys {
                     let mut list = keys
                         .filter(|v| {
                             self.inner
-                                .top_trie_changes
+                                .main_trie_changes
                                 .diff_get(v.as_ref())
                                 .map_or(true, |(v, _)| v.is_some())
                         })
                         .map(|v| v.as_ref().to_vec())
                         .collect::<HashSet<_, fnv::FnvBuildHasher>>();
                     // TODO: slow to iterate over everything?
-                    for (key, value, ()) in self.inner.top_trie_changes.diff_iter_unordered() {
+                    for (key, value, ()) in self.inner.main_trie_changes.diff_iter_unordered() {
                         if value.is_none() {
                             continue;
                         }
@@ -495,7 +495,7 @@ impl NextKey {
                         req_key.as_ref()
                     };
                     self.inner
-                        .top_trie_changes
+                        .main_trie_changes
                         .storage_next_key(requested_key, key)
                 };
 
@@ -613,15 +613,15 @@ struct Inner {
     vm: host::HostVm,
 
     /// Pending changes to the top storage trie that this execution performs.
-    top_trie_changes: storage_diff::StorageDiff,
+    main_trie_changes: storage_diff::StorageDiff,
 
     /// Contains pending storage reverts if and only if we're within a storage transaction.
-    /// When changes are applied to [`Inner::top_trie_changes`], the reverse operation is
+    /// When changes are applied to [`Inner::main_trie_changes`], the reverse operation is
     /// added here.
     ///
     /// When the storage transaction ends, either this hash map is entirely discarded (to commit
-    /// changes), or applied to [`Inner::top_trie_changes`] (to revert).
-    top_trie_transaction_revert:
+    /// changes), or applied to [`Inner::main_trie_changes`] (to revert).
+    main_trie_transaction_revert:
         Vec<HashMap<Vec<u8>, Option<Option<Vec<u8>>>, fnv::FnvBuildHasher>>,
 
     /// State trie version indicated by the runtime. All the storage changes that are performed
@@ -633,7 +633,7 @@ struct Inner {
 
     /// Cache passed by the user. Always `Some` except when we are currently calculating the trie
     /// state root.
-    top_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
+    main_trie_root_calculation_cache: Option<calculate_root::CalculationCache>,
 
     /// Trie root calculation in progress.
     root_calculation: Option<calculate_root::RootMerkleValueCalculation>,
@@ -665,11 +665,11 @@ impl Inner {
                 host::HostVm::Finished(finished) => {
                     return RuntimeHostVm::Finished(Ok(Success {
                         virtual_machine: SuccessVirtualMachine(finished),
-                        storage_top_trie_changes: self.top_trie_changes,
+                        storage_main_trie_changes: self.main_trie_changes,
                         state_trie_version: self.state_trie_version,
                         offchain_storage_changes: self.offchain_storage_changes,
-                        top_trie_root_calculation_cache: self
-                            .top_trie_root_calculation_cache
+                        main_trie_root_calculation_cache: self
+                            .main_trie_root_calculation_cache
                             .unwrap(),
                         logs: self.logs,
                     }));
@@ -686,7 +686,7 @@ impl Inner {
                                 continue;
                             }
                         };
-                        self.top_trie_changes.diff_get(key.as_ref())
+                        self.main_trie_changes.diff_get(key.as_ref())
                     };
 
                     if let Some((overlay, _)) = search {
@@ -700,24 +700,24 @@ impl Inner {
                 host::HostVm::ExternalStorageSet(req) => {
                     // TODO: this is a dummy implementation and child tries are not implemented properly
                     if let host::StorageKey::MainTrie { key } = req.key() {
-                        self.top_trie_root_calculation_cache
+                        self.main_trie_root_calculation_cache
                             .as_mut()
                             .unwrap()
                             .storage_value_update(key.as_ref(), req.value().is_some());
 
                         let previous_value = if let Some(value) = req.value() {
-                            self.top_trie_changes
+                            self.main_trie_changes
                                 .diff_insert(key.as_ref(), value.as_ref(), ())
                         } else {
-                            self.top_trie_changes.diff_insert_erase(key.as_ref(), ())
+                            self.main_trie_changes.diff_insert_erase(key.as_ref(), ())
                         }
                         .map(|(v, ())| v);
 
-                        if let Some(top_trie_transaction_revert) =
-                            self.top_trie_transaction_revert.last_mut()
+                        if let Some(main_trie_transaction_revert) =
+                            self.main_trie_transaction_revert.last_mut()
                         {
                             if let Entry::Vacant(entry) =
-                                top_trie_transaction_revert.entry(key.as_ref().to_vec())
+                                main_trie_transaction_revert.entry(key.as_ref().to_vec())
                             {
                                 entry.insert(previous_value);
                             }
@@ -738,25 +738,25 @@ impl Inner {
                         }
                     };
 
-                    self.top_trie_root_calculation_cache
+                    self.main_trie_root_calculation_cache
                         .as_mut()
                         .unwrap()
                         .storage_value_update(key.as_ref(), true);
 
                     let current_value =
-                        self.top_trie_changes.diff_get(key.as_ref()).map(|(v, _)| v);
+                        self.main_trie_changes.diff_get(key.as_ref()).map(|(v, _)| v);
                     if let Some(current_value) = current_value {
                         let mut current_value = current_value.unwrap_or_default().to_vec();
                         append_to_storage_value(&mut current_value, req.value().as_ref());
                         let previous_value = self
-                            .top_trie_changes
+                            .main_trie_changes
                             .diff_insert(key.as_ref().to_vec(), current_value, ())
                             .map(|(v, _)| v);
-                        if let Some(top_trie_transaction_revert) =
-                            self.top_trie_transaction_revert.last_mut()
+                        if let Some(main_trie_transaction_revert) =
+                            self.main_trie_transaction_revert.last_mut()
                         {
                             if let Entry::Vacant(entry) =
-                                top_trie_transaction_revert.entry(key.as_ref().to_vec())
+                                main_trie_transaction_revert.entry(key.as_ref().to_vec())
                             {
                                 entry.insert(previous_value);
                             }
@@ -794,13 +794,13 @@ impl Inner {
 
                     if self.root_calculation.is_none() {
                         self.root_calculation = Some(calculate_root::root_merkle_value(Some(
-                            self.top_trie_root_calculation_cache.take().unwrap(),
+                            self.main_trie_root_calculation_cache.take().unwrap(),
                         )));
                     }
 
                     match self.root_calculation.take().unwrap() {
                         calculate_root::RootMerkleValueCalculation::Finished { hash, cache } => {
-                            self.top_trie_root_calculation_cache = Some(cache);
+                            self.main_trie_root_calculation_cache = Some(cache);
                             self.vm = req.resume(Some(&hash));
                         }
                         calculate_root::RootMerkleValueCalculation::AllKeys(keys) => {
@@ -813,7 +813,7 @@ impl Inner {
                             self.vm = req.into();
                             // TODO: allocating a Vec, meh
                             if let Some((overlay, ())) = self
-                                .top_trie_changes
+                                .main_trie_changes
                                 .diff_get(&value_request.key().collect::<Vec<_>>())
                             {
                                 self.root_calculation = Some(
@@ -898,31 +898,31 @@ impl Inner {
                 }
 
                 host::HostVm::StartStorageTransaction(tx) => {
-                    self.top_trie_transaction_revert.push(Default::default());
+                    self.main_trie_transaction_revert.push(Default::default());
                     self.vm = tx.resume();
                 }
 
                 host::HostVm::EndStorageTransaction { resume, rollback } => {
                     // The inner implementation guarantees that a storage transaction can only
                     // end if it has earlier been started.
-                    debug_assert!(!self.top_trie_transaction_revert.is_empty());
-                    let last = self.top_trie_transaction_revert.pop().unwrap();
+                    debug_assert!(!self.main_trie_transaction_revert.is_empty());
+                    let last = self.main_trie_transaction_revert.pop().unwrap();
 
                     if rollback {
                         for (key, value) in last {
                             if let Some(value) = value {
                                 if let Some(value) = value {
-                                    let _ = self.top_trie_changes.diff_insert(key, value, ());
+                                    let _ = self.main_trie_changes.diff_insert(key, value, ());
                                 } else {
-                                    let _ = self.top_trie_changes.diff_insert_erase(key, ());
+                                    let _ = self.main_trie_changes.diff_insert_erase(key, ());
                                 }
                             } else {
-                                let _ = self.top_trie_changes.diff_remove(&key);
+                                let _ = self.main_trie_changes.diff_remove(&key);
                             }
                         }
 
                         // TODO: very slow; do this properly
-                        self.top_trie_root_calculation_cache = Some(Default::default());
+                        self.main_trie_root_calculation_cache = Some(Default::default());
                     }
 
                     self.vm = resume.resume();

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2120,10 +2120,10 @@ pub struct BlockFull {
     pub body: Vec<Vec<u8>>,
 
     /// Changes to the storage made by this block compared to its parent.
-    pub storage_top_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::StorageDiff,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`BlockFull::storage_top_trie_changes`] should store this version alongside with them.
+    /// [`BlockFull::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
@@ -2337,7 +2337,7 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                                 full: b.full.map(|b| BlockFull {
                                     body: b.body,
                                     offchain_storage_changes: b.offchain_storage_changes,
-                                    storage_top_trie_changes: b.storage_top_trie_changes,
+                                    storage_main_trie_changes: b.storage_main_trie_changes,
                                     state_trie_version: b.state_trie_version,
                                 }),
                             })

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -332,8 +332,8 @@ pub fn validate_transaction(
                     digest: header::DigestRef::empty(),
                 }
                 .scale_encoding(config.block_number_bytes),
-                top_trie_root_calculation_cache: None,
-                storage_top_trie_changes: storage_diff::StorageDiff::empty(),
+                main_trie_root_calculation_cache: None,
+                storage_main_trie_changes: storage_diff::StorageDiff::empty(),
                 offchain_storage_changes: storage_diff::StorageDiff::empty(),
                 max_log_level: config.max_log_level,
             });
@@ -369,8 +369,8 @@ pub fn validate_transaction(
                     config.source,
                     &header::hash_from_scale_encoded_header(config.scale_encoded_header),
                 ),
-                top_trie_root_calculation_cache: None,
-                storage_top_trie_changes: storage_diff::StorageDiff::empty(),
+                main_trie_root_calculation_cache: None,
+                storage_main_trie_changes: storage_diff::StorageDiff::empty(),
                 offchain_storage_changes: storage_diff::StorageDiff::empty(),
                 max_log_level: config.max_log_level,
             });
@@ -459,10 +459,10 @@ impl Query {
                             iter::once(info.scale_encoded_transaction),
                             info.transaction_source,
                         ),
-                        storage_top_trie_changes: success.storage_top_trie_changes,
+                        storage_main_trie_changes: success.storage_main_trie_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
-                        top_trie_root_calculation_cache: Some(
-                            success.top_trie_root_calculation_cache,
+                        main_trie_root_calculation_cache: Some(
+                            success.main_trie_root_calculation_cache,
                         ),
                         max_log_level: 0,
                     });

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -1612,8 +1612,8 @@ impl<TPlat: Platform> Background<TPlat> {
             virtual_machine,
             function_to_call,
             parameter: call_parameters,
-            top_trie_root_calculation_cache: None,
-            storage_top_trie_changes: Default::default(),
+            main_trie_root_calculation_cache: None,
+            storage_main_trie_changes: Default::default(),
             offchain_storage_changes: Default::default(),
             max_log_level: 0,
         }) {

--- a/light-base/src/json_rpc_service/chain_head.rs
+++ b/light-base/src/json_rpc_service/chain_head.rs
@@ -198,9 +198,9 @@ impl<TPlat: Platform> Background<TPlat> {
                             virtual_machine,
                             function_to_call: &function_to_call,
                             parameter: iter::once(&call_parameters.0),
-                            top_trie_root_calculation_cache: None,
+                            main_trie_root_calculation_cache: None,
                             offchain_storage_changes: Default::default(),
-                            storage_top_trie_changes: Default::default(),
+                            storage_main_trie_changes: Default::default(),
                             max_log_level: 0,
                         }) {
                             Err((error, prototype)) => {


### PR DESCRIPTION
Unsubstantial.

Renames "top trie" to "main trie", as this is a more uniform and less confusing terminology.
