### PR TITLE
Rename StorageDiff to TrieDiff

### DIFF
--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -119,12 +119,12 @@ pub struct Success {
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
     /// List of changes to the storage main trie that the block performs.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
     /// Cache used for calculating the main trie root of the new block.
     pub main_trie_root_calculation_cache: calculate_root::CalculationCache,
     /// Concatenation of all the log messages printed by the runtime.
@@ -481,8 +481,8 @@ enum Stage {
 pub struct InherentExtrinsics {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::StorageDiff,
-    offchain_storage_changes: storage_diff::StorageDiff,
+    storage_main_trie_changes: storage_diff::TrieDiff,
+    offchain_storage_changes: storage_diff::TrieDiff,
     main_trie_root_calculation_cache: calculate_root::CalculationCache,
 }
 
@@ -545,8 +545,8 @@ impl InherentExtrinsics {
 pub struct ApplyExtrinsic {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::StorageDiff,
-    offchain_storage_changes: storage_diff::StorageDiff,
+    storage_main_trie_changes: storage_diff::TrieDiff,
+    offchain_storage_changes: storage_diff::TrieDiff,
     main_trie_root_calculation_cache: calculate_root::CalculationCache,
 }
 

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -845,13 +845,13 @@ pub enum BodyVerifyStep2<T> {
         /// been modified. Contains the new runtime.
         new_runtime: Option<host::HostVmPrototype>,
         /// List of changes to the storage main trie that the block performs.
-        storage_main_trie_changes: storage_diff::StorageDiff,
+        storage_main_trie_changes: storage_diff::TrieDiff,
         /// State trie version indicated by the runtime. All the storage changes indicated by
         /// [`BodyVerifyStep2::Finished::storage_main_trie_changes`] should store this version
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.
-        offchain_storage_changes: storage_diff::StorageDiff,
+        offchain_storage_changes: storage_diff::TrieDiff,
         /// Cache of calculation for the storage trie of the best block.
         /// Pass this value to [`BodyVerifyRuntimeRequired::resume`] when verifying a children of
         /// this block in order to considerably speed up the verification.

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -67,11 +67,11 @@ pub struct Config<'a, TParams> {
 
     /// Initial state of [`Success::storage_main_trie_changes`]. The changes made during this
     /// execution will be pushed over the value in this field.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
 
     /// Initial state of [`Success::offchain_storage_changes`]. The changes made during this
     /// execution will be pushed over the value in this field.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
 
     /// Maximum log level of the runtime.
     ///
@@ -119,12 +119,12 @@ pub struct Success {
     /// initialization.
     pub virtual_machine: SuccessVirtualMachine,
     /// List of changes to the storage main trie that the block performs.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
     /// Cache used for calculating the main trie root.
     pub main_trie_root_calculation_cache: calculate_root::CalculationCache,
     /// Concatenation of all the log messages printed by the runtime.
@@ -613,7 +613,7 @@ struct Inner {
     vm: host::HostVm,
 
     /// Pending changes to the top storage trie that this execution performs.
-    main_trie_changes: storage_diff::StorageDiff,
+    main_trie_changes: storage_diff::TrieDiff,
 
     /// Contains pending storage reverts if and only if we're within a storage transaction.
     /// When changes are applied to [`Inner::main_trie_changes`], the reverse operation is
@@ -629,7 +629,7 @@ struct Inner {
     state_trie_version: TrieEntryVersion,
 
     /// Pending changes to the off-chain storage that this execution performs.
-    offchain_storage_changes: storage_diff::StorageDiff,
+    offchain_storage_changes: storage_diff::TrieDiff,
 
     /// Cache passed by the user. Always `Some` except when we are currently calculating the trie
     /// state root.

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2120,14 +2120,14 @@ pub struct BlockFull {
     pub body: Vec<Vec<u8>>,
 
     /// Changes to the storage made by this block compared to its parent.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`BlockFull::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
 }
 
 pub struct HeaderVerify<TRq, TSrc, TBl> {

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -160,7 +160,7 @@ struct OptimisticSyncInner<TRq, TSrc, TBl> {
     /// The `BTreeMap`'s keys are storage keys, and its values are new values or `None` if the
     /// value has been erased from the storage.
     /// Each entry is associated with the state version of the runtime at the time of the write.
-    best_to_finalized_storage_diff: storage_diff::StorageDiff<TrieEntryVersion>,
+    best_to_finalized_storage_diff: storage_diff::TrieDiff<TrieEntryVersion>,
 
     /// Compiled runtime code of the best block. `None` if it is the same as
     /// [`OptimisticSyncInner::finalized_runtime`].
@@ -267,14 +267,14 @@ pub struct BlockFull {
     pub body: Vec<Vec<u8>>,
 
     /// Changes to the storage made by this block compared to its parent.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`BlockFull::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
 }
 
 impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
@@ -300,7 +300,7 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
             inner: Box::new(OptimisticSyncInner {
                 finalized_chain_information: blocks_tree_config,
                 finalized_runtime: config.full.map(|f| f.finalized_runtime),
-                best_to_finalized_storage_diff: storage_diff::StorageDiff::empty(),
+                best_to_finalized_storage_diff: storage_diff::TrieDiff::empty(),
                 best_runtime: None,
                 main_trie_root_calculation_cache: None,
                 sources: HashMap::with_capacity_and_hasher(

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -333,8 +333,8 @@ pub fn validate_transaction(
                 }
                 .scale_encoding(config.block_number_bytes),
                 main_trie_root_calculation_cache: None,
-                storage_main_trie_changes: storage_diff::StorageDiff::empty(),
-                offchain_storage_changes: storage_diff::StorageDiff::empty(),
+                storage_main_trie_changes: storage_diff::TrieDiff::empty(),
+                offchain_storage_changes: storage_diff::TrieDiff::empty(),
                 max_log_level: config.max_log_level,
             });
 
@@ -370,8 +370,8 @@ pub fn validate_transaction(
                     &header::hash_from_scale_encoded_header(config.scale_encoded_header),
                 ),
                 main_trie_root_calculation_cache: None,
-                storage_main_trie_changes: storage_diff::StorageDiff::empty(),
-                offchain_storage_changes: storage_diff::StorageDiff::empty(),
+                storage_main_trie_changes: storage_diff::TrieDiff::empty(),
+                offchain_storage_changes: storage_diff::TrieDiff::empty(),
                 max_log_level: config.max_log_level,
             });
 

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -123,14 +123,14 @@ pub struct Success {
     pub consensus: SuccessConsensus,
 
     /// List of changes to the storage main trie that the block performs.
-    pub storage_main_trie_changes: storage_diff::StorageDiff,
+    pub storage_main_trie_changes: storage_diff::TrieDiff,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::StorageDiff,
+    pub offchain_storage_changes: storage_diff::TrieDiff,
 
     /// Cache used for calculating the main trie root.
     pub main_trie_root_calculation_cache: calculate_root::CalculationCache,
@@ -661,9 +661,9 @@ impl StorageNextKey {
 #[must_use]
 pub struct RuntimeCompilation {
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::StorageDiff,
+    storage_main_trie_changes: storage_diff::TrieDiff,
     state_trie_version: TrieEntryVersion,
-    offchain_storage_changes: storage_diff::StorageDiff,
+    offchain_storage_changes: storage_diff::TrieDiff,
     main_trie_root_calculation_cache: calculate_root::CalculationCache,
     logs: String,
     heap_pages: vm::HeapPages,


### PR DESCRIPTION
Step towards https://github.com/smol-dot/smoldot/issues/166

We want to keep the existing `StorageDiff`, but it will only represent the diff between a trie and another rather than between the entire chain state and another.