### PR TITLE
Reimplement transactions as a stack and not through revert operations

### DIFF
--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -75,6 +75,7 @@ use core::{fmt, iter};
 ///
 /// If the storage's content is modified, you **must** call the appropriate methods to invalidate
 /// entries. Otherwise, the trie root calculation will yield an incorrect result.
+#[derive(Clone)]
 pub struct CalculationCache {
     /// Structure of the trie.
     /// If `Some`, the structure is either fully conforming to the trie.
@@ -82,7 +83,7 @@ pub struct CalculationCache {
 }
 
 /// Custom data stored in each node in [`CalculationCache::structure`].
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct CacheEntry {
     merkle_value: Option<trie_node::MerkleValueOutput>,
 }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add an arbitrary limit to the size of unprocessed networking packets, in order to avoid DoS attacks. This limit is necessary in order to bypass limitations in the networking APIs exposed by browsers. ([#312](https://github.com/smol-dot/smoldot/pull/312))
 - Rename `/webrtc` to `/webrtc-direct` in multiaddresses, in accordance with the rest of the libp2p ecosystem. ([#326](https://github.com/smol-dot/smoldot/pull/326))
 
+### Fixed
+
+- Fix runtime transactions not being handled properly when multiple transactions are stacked.
+
 ## 1.0.0 - 2022-03-12
 
 ### Fixed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Fix runtime transactions not being handled properly when multiple transactions are stacked.
+- Fix runtime transactions not being handled properly when multiple transactions are stacked. ([#335](https://github.com/smol-dot/smoldot/pull/335))
 
 ## 1.0.0 - 2022-03-12
 


### PR DESCRIPTION
Fix https://github.com/smol-dot/smoldot/issues/327

Instead of implementing transactions by keeping track of what to revert, we now now keep a stack of overlays that are merged into each other.

This also solves a TODO item here we would entirely clear the cache if a transaction is rolled back, which clearly isn't great.

Should be tested by syncing a lot of Polkadot before merging.

