### PR TITLE
"Flatten" the tasks in the light client

### DIFF
--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -265,7 +265,7 @@ pub struct ServicePrototype {
     max_parallel_subscription_updates: NonZeroU32,
 
     /// List of abort handles. When tasks are spawned, each handle is associated with a task, so
-    /// that they are all abortable. See [`Frontend::background_aborts`].
+    /// that they can all be aborted. See [`Frontend::background_aborts`].
     background_abort_registrations: Vec<future::AbortRegistration>,
 }
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -43,7 +43,7 @@ use crate::{
     network_service, platform::Platform, runtime_service, sync_service, transactions_service,
 };
 
-use alloc::{boxed::Box, format, string::String, sync::Arc};
+use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::num::NonZeroU32;
 use futures::prelude::*;
 use smoldot::{
@@ -73,6 +73,18 @@ pub struct Config {
     /// This parameter is necessary in order to prevent users from using up too much memory within
     /// the client.
     pub max_subscriptions: u32,
+
+    /// Maximum number of JSON-RPC requests that can be processed simultaneously.
+    ///
+    /// This parameter is necessary in order to prevent users from using up too much memory within
+    /// the client.
+    pub max_parallel_requests: NonZeroU32,
+
+    /// Maximum number of subscriptions that can be processed simultaneously.
+    ///
+    /// In combination with [`StartConfig::max_parallel_requests`], this can increase or decrease
+    /// the priority of updating subscriptions compared to answering requests.
+    pub max_parallel_subscription_updates: NonZeroU32,
 }
 
 /// Creates a new JSON-RPC service with the given configuration.
@@ -94,19 +106,35 @@ pub fn service(config: Config) -> (Frontend, ServicePrototype) {
 
     let log_target = format!("json-rpc-{}", config.log_name);
 
-    let (background_abort, background_abort_registration) = future::AbortHandle::new_pair();
+    // We are later going to spawn a bunch of tasks. Each task is associated with an "abort
+    // handle" that makes it possible to later abort it. We calculate here the number of handles
+    // that are necessary.
+    // This calculation must be in sync with the part of the code that spawns the tasks. Assertions
+    // are there in order to make sure that this is the case.
+    let num_handles =
+        config.max_parallel_requests.get() + config.max_parallel_subscription_updates.get() + 1;
+
+    let mut background_aborts = Vec::with_capacity(usize::try_from(num_handles).unwrap());
+    let mut background_abort_registrations = Vec::with_capacity(background_aborts.capacity());
+    for _ in 0..num_handles {
+        let (abort, reg) = future::AbortHandle::new_pair();
+        background_aborts.push(abort);
+        background_abort_registrations.push(reg);
+    }
 
     let frontend = Frontend {
         log_target: log_target.clone(),
         requests_subscriptions: requests_subscriptions.clone(),
         client_id,
-        background_abort: Arc::new(background_abort),
+        background_aborts: Arc::from(background_aborts),
     };
 
     let prototype = ServicePrototype {
-        background_abort_registration,
+        background_abort_registrations,
         log_target,
         requests_subscriptions,
+        max_parallel_requests: config.max_parallel_requests,
+        max_parallel_subscription_updates: config.max_parallel_subscription_updates,
     };
 
     (frontend, prototype)
@@ -132,9 +160,9 @@ pub struct Frontend {
     /// Target to use when emitting logs.
     log_target: String,
 
-    /// Handle to abort the background task that holds and processes the
+    /// Handles to abort the background tasks that hold and process the
     /// [`Frontend::requests_subscriptions`].
-    background_abort: Arc<future::AbortHandle>,
+    background_aborts: Arc<[future::AbortHandle]>,
 }
 
 impl Frontend {
@@ -211,8 +239,10 @@ impl Drop for Frontend {
     fn drop(&mut self) {
         // Call `abort()` if this was the last instance of the `Arc<AbortHandle>` (and thus the
         // last instance of `Frontend`).
-        if let Some(background_abort) = Arc::get_mut(&mut self.background_abort) {
-            background_abort.abort();
+        if let Some(background_aborts) = Arc::get_mut(&mut self.background_aborts) {
+            for background_abort in background_aborts {
+                background_abort.abort();
+            }
         }
     }
 }
@@ -228,7 +258,15 @@ pub struct ServicePrototype {
     /// Target to use when emitting logs.
     log_target: String,
 
-    background_abort_registration: future::AbortRegistration,
+    /// Value obtained through [`Config::max_parallel_requests`].
+    max_parallel_requests: NonZeroU32,
+
+    /// Value obtained through [`Config::max_parallel_subscription_updates`].
+    max_parallel_subscription_updates: NonZeroU32,
+
+    /// List of abort handles. When tasks are spawned, each handle is associated with a task, so
+    /// that they are all abortable. See [`Frontend::background_aborts`].
+    background_abort_registrations: Vec<future::AbortRegistration>,
 }
 
 /// Configuration for a JSON-RPC service.
@@ -280,18 +318,6 @@ pub struct StartConfig<'a, TPlat: Platform> {
     /// >           expensive. We prefer to require this value from the upper layer instead, as
     /// >           it is most likely needed anyway.
     pub genesis_block_state_root: [u8; 32],
-
-    /// Maximum number of JSON-RPC requests that can be processed simultaneously.
-    ///
-    /// This parameter is necessary in order to prevent users from using up too much memory within
-    /// the client.
-    pub max_parallel_requests: NonZeroU32,
-
-    /// Maximum number of subscriptions that can be processed simultaneously.
-    ///
-    /// In combination with [`StartConfig::max_parallel_requests`], this can increase or decrease
-    /// the priority of updating subscriptions compared to answering requests.
-    pub max_parallel_subscription_updates: NonZeroU32,
 }
 
 impl ServicePrototype {
@@ -303,22 +329,12 @@ impl ServicePrototype {
             &config,
         );
 
-        // Spawns the background task that actually runs the logic of that JSON-RPC service.
-        // This background task is abortable through the `background_abort` handle.
-        (config.tasks_executor)(self.log_target, {
-            let max_parallel_requests = config.max_parallel_requests;
-            let max_parallel_subscription_updates = config.max_parallel_subscription_updates;
-            future::Abortable::new(
-                async move {
-                    background
-                        .run(max_parallel_requests, max_parallel_subscription_updates)
-                        .await
-                },
-                self.background_abort_registration,
-            )
-            .map(|_| ())
-            .boxed()
-        });
+        background.start_tasks(
+            &mut config.tasks_executor,
+            self.max_parallel_requests,
+            self.max_parallel_subscription_updates,
+            self.background_abort_registrations,
+        );
     }
 }
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -323,7 +323,7 @@ pub struct StartConfig<'a, TPlat: Platform> {
 impl ServicePrototype {
     /// Consumes this prototype and starts the service through [`StartConfig::tasks_executor`].
     pub fn start<TPlat: Platform>(self, config: StartConfig<'_, TPlat>) {
-        background::Background::start(
+        background::start(
             self.log_target.clone(),
             self.requests_subscriptions.clone(),
             config,

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -82,7 +82,7 @@ pub struct Config {
 
     /// Maximum number of subscriptions that can be processed simultaneously.
     ///
-    /// In combination with [`StartConfig::max_parallel_requests`], this can increase or decrease
+    /// In combination with [`Config::max_parallel_requests`], this can increase or decrease
     /// the priority of updating subscriptions compared to answering requests.
     pub max_parallel_subscription_updates: NonZeroU32,
 }
@@ -150,7 +150,7 @@ pub fn service(config: Config) -> (Frontend, ServicePrototype) {
 pub struct Frontend {
     /// State machine holding all the clients, requests, and subscriptions.
     ///
-    /// Shared with the [`background::Background`].
+    /// Shared with the [`background`].
     requests_subscriptions:
         Arc<requests_subscriptions::RequestsSubscriptions<background::SubscriptionMessage>>,
 
@@ -251,7 +251,7 @@ impl Drop for Frontend {
 pub struct ServicePrototype {
     /// State machine holding all the clients, requests, and subscriptions.
     ///
-    /// Shared with the [`background::Background`].
+    /// Shared with the [`background`].
     requests_subscriptions:
         Arc<requests_subscriptions::RequestsSubscriptions<background::SubscriptionMessage>>,
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -322,19 +322,15 @@ pub struct StartConfig<'a, TPlat: Platform> {
 
 impl ServicePrototype {
     /// Consumes this prototype and starts the service through [`StartConfig::tasks_executor`].
-    pub fn start<TPlat: Platform>(self, mut config: StartConfig<'_, TPlat>) {
-        let background = background::Background::new(
+    pub fn start<TPlat: Platform>(self, config: StartConfig<'_, TPlat>) {
+        background::Background::start(
             self.log_target.clone(),
             self.requests_subscriptions.clone(),
-            &config,
-        );
-
-        background.start_tasks(
-            &mut config.tasks_executor,
+            config,
             self.max_parallel_requests,
             self.max_parallel_subscription_updates,
             self.background_abort_registrations,
-        );
+        )
     }
 }
 

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -23,6 +23,7 @@ use super::StartConfig;
 
 use alloc::{
     borrow::ToOwned as _,
+    format,
     string::{String, ToString as _},
     sync::Arc,
     vec::Vec,
@@ -254,51 +255,62 @@ impl<TPlat: Platform> Background<TPlat> {
         })
     }
 
-    /// Runs the background task forever.
+    /// Spawns the tasks that the background requires.
     ///
     /// This should only ever be called once for each service.
-    pub(super) async fn run(
+    pub(super) fn start_tasks(
         self: Arc<Self>,
+        spawner: &mut (dyn FnMut(String, future::BoxFuture<'static, ()>) + Send),
         max_parallel_requests: NonZeroU32,
         max_parallel_subscription_updates: NonZeroU32,
-    ) -> ! {
-        // The body of this function consists in building a list of tasks, then running them.
-        let mut tasks = stream::FuturesUnordered::new();
+        background_abort_registrations: Vec<future::AbortRegistration>,
+    ) {
+        let mut background_abort_registrations = background_abort_registrations.into_iter();
 
         // A certain number of tasks (`max_parallel_requests`) are dedicated to pulling requests
         // from the inner state machine and processing them.
         // Each task can only process one request at a time, which is why we spawn one task per
         // desired level of parallelism.
-        for _ in 0..max_parallel_requests.get() {
+        for n in 0..max_parallel_requests.get() {
             let me = self.clone();
-            tasks.push(
-                async move {
-                    loop {
-                        me.handle_request().await;
+            spawner(
+                format!("{}-requests-{}", self.log_target, n),
+                future::Abortable::new(
+                    async move {
+                        loop {
+                            me.handle_request().await;
 
-                        // We yield once between each request in order to politely let other tasks
-                        // do some work and not monopolize the CPU.
-                        TPlat::yield_after_cpu_intensive().await;
-                    }
-                }
+                            // We yield once between each request in order to politely let other tasks
+                            // do some work and not monopolize the CPU.
+                            TPlat::yield_after_cpu_intensive().await;
+                        }
+                    },
+                    background_abort_registrations.next().unwrap(),
+                )
+                .map(|_: Result<(), _>| ())
                 .boxed(),
             );
         }
 
         // A certain number of tasks (`max_parallel_subscription_updates`) are dedicated to
         // processing subscriptions-related tasks after they wake up.
-        for _ in 0..max_parallel_subscription_updates.get() {
+        for n in 0..max_parallel_subscription_updates.get() {
             let me = self.clone();
-            tasks.push(
-                async move {
-                    loop {
-                        me.requests_subscriptions.run_subscription_task().await;
+            spawner(
+                format!("{}-subscriptions-{}", self.log_target, n),
+                future::Abortable::new(
+                    async move {
+                        loop {
+                            me.requests_subscriptions.run_subscription_task().await;
 
-                        // We yield once between each request in order to politely let other tasks
-                        // do some work and not monopolize the CPU.
-                        TPlat::yield_after_cpu_intensive().await;
-                    }
-                }
+                            // We yield once between each request in order to politely let other tasks
+                            // do some work and not monopolize the CPU.
+                            TPlat::yield_after_cpu_intensive().await;
+                        }
+                    },
+                    background_abort_registrations.next().unwrap(),
+                )
+                .map(|_: Result<(), _>| ())
                 .boxed(),
             );
         }
@@ -307,91 +319,95 @@ impl<TPlat: Platform> Background<TPlat> {
         // service.
         // TODO: this is actually racy, as a block subscription task could report a new block to a client, and then client can query it, before this block has been been added to the cache
         // TODO: extract to separate function
-        tasks.push({
+        spawner(format!("{}-cache-populate", self.log_target), {
             let me = self.clone();
-            async move {
-                loop {
-                    let mut cache = me.cache.lock().await;
-
-                    // Subscribe to new runtime service blocks in order to push them in the
-                    // cache as soon as they are available.
-                    // The buffer size should be large enough so that, if the CPU is busy, it
-                    // doesn't become full before the execution of this task resumes.
-                    // The maximum number of pinned block is ignored, as this maximum is a way to
-                    // avoid malicious behaviors. This code is by definition not considered
-                    // malicious.
-                    let mut subscribe_all = me
-                        .runtime_service
-                        .subscribe_all(
-                            "json-rpc-blocks-cache",
-                            32,
-                            NonZeroUsize::new(usize::max_value()).unwrap(),
-                        )
-                        .await;
-
-                    cache.subscription_id = Some(subscribe_all.new_blocks.id());
-                    cache.recent_pinned_blocks.clear();
-                    debug_assert!(cache.recent_pinned_blocks.cap().get() >= 1);
-
-                    let finalized_block_hash = header::hash_from_scale_encoded_header(
-                        &subscribe_all.finalized_block_scale_encoded_header,
-                    );
-                    cache.recent_pinned_blocks.put(
-                        finalized_block_hash,
-                        subscribe_all.finalized_block_scale_encoded_header,
-                    );
-
-                    for block in subscribe_all.non_finalized_blocks_ancestry_order {
-                        if cache.recent_pinned_blocks.len()
-                            == cache.recent_pinned_blocks.cap().get()
-                        {
-                            let (hash, _) = cache.recent_pinned_blocks.pop_lru().unwrap();
-                            subscribe_all.new_blocks.unpin_block(&hash).await;
-                        }
-
-                        let hash =
-                            header::hash_from_scale_encoded_header(&block.scale_encoded_header);
-                        cache
-                            .recent_pinned_blocks
-                            .put(hash, block.scale_encoded_header);
-                    }
-
-                    drop(cache);
-
+            future::Abortable::new(
+                async move {
                     loop {
-                        let notification = subscribe_all.new_blocks.next().await;
-                        match notification {
-                            Some(runtime_service::Notification::Block(block)) => {
-                                let mut cache = me.cache.lock().await;
+                        let mut cache = me.cache.lock().await;
 
-                                if cache.recent_pinned_blocks.len()
-                                    == cache.recent_pinned_blocks.cap().get()
-                                {
-                                    let (hash, _) = cache.recent_pinned_blocks.pop_lru().unwrap();
-                                    subscribe_all.new_blocks.unpin_block(&hash).await;
-                                }
+                        // Subscribe to new runtime service blocks in order to push them in the
+                        // cache as soon as they are available.
+                        // The buffer size should be large enough so that, if the CPU is busy, it
+                        // doesn't become full before the execution of this task resumes.
+                        // The maximum number of pinned block is ignored, as this maximum is a way to
+                        // avoid malicious behaviors. This code is by definition not considered
+                        // malicious.
+                        let mut subscribe_all = me
+                            .runtime_service
+                            .subscribe_all(
+                                "json-rpc-blocks-cache",
+                                32,
+                                NonZeroUsize::new(usize::max_value()).unwrap(),
+                            )
+                            .await;
 
-                                let hash = header::hash_from_scale_encoded_header(
-                                    &block.scale_encoded_header,
-                                );
-                                cache
-                                    .recent_pinned_blocks
-                                    .put(hash, block.scale_encoded_header);
+                        cache.subscription_id = Some(subscribe_all.new_blocks.id());
+                        cache.recent_pinned_blocks.clear();
+                        debug_assert!(cache.recent_pinned_blocks.cap().get() >= 1);
+
+                        let finalized_block_hash = header::hash_from_scale_encoded_header(
+                            &subscribe_all.finalized_block_scale_encoded_header,
+                        );
+                        cache.recent_pinned_blocks.put(
+                            finalized_block_hash,
+                            subscribe_all.finalized_block_scale_encoded_header,
+                        );
+
+                        for block in subscribe_all.non_finalized_blocks_ancestry_order {
+                            if cache.recent_pinned_blocks.len()
+                                == cache.recent_pinned_blocks.cap().get()
+                            {
+                                let (hash, _) = cache.recent_pinned_blocks.pop_lru().unwrap();
+                                subscribe_all.new_blocks.unpin_block(&hash).await;
                             }
-                            Some(runtime_service::Notification::Finalized { .. })
-                            | Some(runtime_service::Notification::BestBlockChanged { .. }) => {}
-                            None => break,
+
+                            let hash =
+                                header::hash_from_scale_encoded_header(&block.scale_encoded_header);
+                            cache
+                                .recent_pinned_blocks
+                                .put(hash, block.scale_encoded_header);
+                        }
+
+                        drop(cache);
+
+                        loop {
+                            let notification = subscribe_all.new_blocks.next().await;
+                            match notification {
+                                Some(runtime_service::Notification::Block(block)) => {
+                                    let mut cache = me.cache.lock().await;
+
+                                    if cache.recent_pinned_blocks.len()
+                                        == cache.recent_pinned_blocks.cap().get()
+                                    {
+                                        let (hash, _) =
+                                            cache.recent_pinned_blocks.pop_lru().unwrap();
+                                        subscribe_all.new_blocks.unpin_block(&hash).await;
+                                    }
+
+                                    let hash = header::hash_from_scale_encoded_header(
+                                        &block.scale_encoded_header,
+                                    );
+                                    cache
+                                        .recent_pinned_blocks
+                                        .put(hash, block.scale_encoded_header);
+                                }
+                                Some(runtime_service::Notification::Finalized { .. })
+                                | Some(runtime_service::Notification::BestBlockChanged {
+                                    ..
+                                }) => {}
+                                None => break,
+                            }
                         }
                     }
-                }
-            }
+                },
+                background_abort_registrations.next().unwrap(),
+            )
+            .map(|_: Result<(), _>| ())
             .boxed()
         });
 
-        // Now that `tasks` is full, we start running them forever.
-        loop {
-            tasks.next().await;
-        }
+        debug_assert!(background_abort_registrations.next().is_none());
     }
 
     /// Pulls one request from the inner state machine, and processes it.

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -820,6 +820,8 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                 log_name: log_name.clone(), // TODO: add a way to differentiate multiple different json-rpc services under the same chain
                 max_pending_requests: NonZeroU32::new(128).unwrap(),
                 max_subscriptions: 1024, // Note: the PolkadotJS UI is very heavy in terms of subscriptions.
+                max_parallel_requests: NonZeroU32::new(24).unwrap(),
+                max_parallel_subscription_updates: NonZeroU32::new(8).unwrap(),
             });
 
             let spawn_new_task = self.spawn_new_task.clone();
@@ -843,8 +845,6 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                     system_version,
                     genesis_block_hash,
                     genesis_block_state_root,
-                    max_parallel_requests: NonZeroU32::new(24).unwrap(),
-                    max_parallel_subscription_updates: NonZeroU32::new(8).unwrap(),
                 })
             };
 


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/pull/345

The light client spawns various tasks that are run in the background.
It also creates two `FuturesUnordered` (one in the networking service and one in the JSON-RPC service), pushes tasks to it, and then spawns a background task that runs this `FuturesUnordered`.
In other words, there's a "hierarchy" of tasks: the tasks spawned in the background, and the tasks that are run by tasks spawned in the background.

The advantage of doing so and the reason why this was done so is that the "second level" of the "hierarchy" doesn't have the same priority as the "first layer". The first layer contains important tasks, and the second layer the less important ones.

Unfortunately, the `FuturesUnordered` doesn't work well when it comes to yielding. It's only after tasks have yielded twice that the `FuturesUnordered` yields. Because the wasm node implements background tasks with a `FuturesUnordered` as well, this means that all tasks have to yield a total of 4 times in order to "actually" yield to the browser/NodeJS/Deno.
At the moment, yielding [is implemented by sleeping twice](https://github.com/tomaka/smoldot/blob/5fe31382e7fc1f04f18b3953830a49120eeceddb/wasm-node/rust/src/platform.rs#L90-L97), for exactly this reason.

See https://github.com/rust-lang/futures-rs/issues/2053 for a discussion about this.

In order to solve that problem, this PR removes the layers of hierarchy. This means that all tasks now have the same execution priority, which isn't great in the absolute but in practice isn't a problem. If we need to restore priority levels, I think a better solution is to add a parameter when spawning a background task indicating the priority.
