### PR TITLE
Enable some Wasm features during the build

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add an arbitrary limit to the size of unprocessed networking packets, in order to avoid DoS attacks. This limit is necessary in order to bypass limitations in the networking APIs exposed by browsers. ([#312](https://github.com/smol-dot/smoldot/pull/312))
 - Rename `/webrtc` to `/webrtc-direct` in multiaddresses, in accordance with the rest of the libp2p ecosystem. ([#326](https://github.com/smol-dot/smoldot/pull/326))
 - Improved the ganularity of the tasks that handle JSON-RPC requests and libp2p connections. Smoldot now yields more often to the browser, reducing the chances and the severity of freezes during the rendering of the web page. ([#349](https://github.com/smol-dot/smoldot/pull/349))
+- Smoldot is now compiled with the `bulk-memory-operations` and `sign-extensions-ops` WebAssembly features enabled. This is expected to considerably speed up its execution. The minimum version required to run smoldot is now Chrome 75, Firefox 79, NodeJS v12.5, and Deno v0.4. ([#356](https://github.com/smol-dot/smoldot/pull/356))
 
 ### Fixed
 

--- a/wasm-node/javascript/prepare.mjs
+++ b/wasm-node/javascript/prepare.mjs
@@ -64,10 +64,16 @@ child_process.execSync(
 
 // The important step in this script is running `cargo build --target wasm32-wasi` on the Rust
 // code. This generates a `wasm` file in `target/wasm32-wasi`.
+// Some optional Wasm features are enabled during the compilation in order to speed up the
+// execution of smoldot.
+// Use `rustc --print target-features --target wasm32-wasi` to see the list of target features.
+// See <https://webassembly.org/roadmap/> to know which version of which engine supports which
+// feature.
+// See also the issue: <https://github.com/smol-dot/smoldot/issues/350>
 child_process.execSync(
     "cargo +" + rustVersion + " build --package smoldot-light-wasm --target wasm32-wasi --no-default-features " +
     (buildProfile == 'debug' ? '' : ("--profile " + buildProfile)),
-    { 'stdio': 'inherit' }
+    { 'stdio': 'inherit', 'env': { 'RUSTFLAGS': '-C target-feature=+bulk-memory,+sign-ext', ...process.env } }
 );
 
 // The code below will write a variable number of files to the `src/instance/autogen` directory.

--- a/wasm-node/javascript/prepare.mjs
+++ b/wasm-node/javascript/prepare.mjs
@@ -66,6 +66,10 @@ child_process.execSync(
 // code. This generates a `wasm` file in `target/wasm32-wasi`.
 // Some optional Wasm features are enabled during the compilation in order to speed up the
 // execution of smoldot.
+// Note that this doesn't enable these features in the Rust standard library (which comes
+// precompiled), but the missing optimizations shouldn't be too much of a problem. The Rust
+// standard library could be compiled with these features using the `-Z build-std` flag, but at
+// the time of the writing of this comment this would require an unstable version of Rust.
 // Use `rustc --print target-features --target wasm32-wasi` to see the list of target features.
 // See <https://webassembly.org/roadmap/> to know which version of which engine supports which
 // feature.


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/350

This PR enables the `bulk-memory` and `signext` Wasm features.
They are supported by all engines listed on https://webassembly.org/roadmap/.
The minimum NodeJS version would be 12.5, which is very old.
