### PR TITLE
Fix bug in NodeJS TCP writable bytes

### DIFF
--- a/wasm-node/javascript/src/index-nodejs.ts
+++ b/wasm-node/javascript/src/index-nodejs.ts
@@ -204,8 +204,9 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
             // The bytes queued using `socket.write` and where `write` has returned false have now
             // been sent. Notify the API that it can write more data.
             if (socket.destroyed) return;
+            const val = drainingBytes.num;
             drainingBytes.num = 0;
-            config.onWritableBytes(drainingBytes.num);
+            config.onWritableBytes(val);
         });
 
         return {


### PR DESCRIPTION
We set the value to 0 before reporting the value, so we report 0 :facepalm: 

This change wasn't released yet, so no need for a CHANGELOG entry.