### PR TITLE
Remove the `recursion_limit` attributes

### DIFF
--- a/full-node/src/main.rs
+++ b/full-node/src/main.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![recursion_limit = "1024"]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(unused_crate_dependencies)]
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -65,7 +65,6 @@
 // TODO: talk about the fact that a randomness environment is assumed?
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
-#![recursion_limit = "512"]
 #![deny(rustdoc::broken_intra_doc_links)]
 // TODO: the `unused_crate_dependencies` lint is disabled because of dev-dependencies, see <https://github.com/rust-lang/rust/issues/95513>
 // #![deny(unused_crate_dependencies)]


### PR DESCRIPTION
I don't remember why there were put in the first place.