### PR TITLE
Considerably clean up the Yamux implementation

### DIFF
--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -529,7 +529,6 @@ where
                             None => (&mut [], &mut []),
                         },
                     );
-                    debug_assert!(_read <= unencrypted_bytes_to_extract);
                     read_write.advance_write(written);
                 }
             }

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -811,11 +811,12 @@ where
                 )));
 
         // TODO: we add some bytes due to the length prefix, this is a bit hacky as we should ask this information from the substream
-        self.inner.yamux.reserve_window(
+        self.inner.yamux.add_remote_window(
             substream_id,
             u64::try_from(self.inner.request_protocols[protocol_index].max_response_size)
                 .unwrap_or(u64::max_value())
-                .saturating_add(64),
+                .saturating_add(64)
+                .saturating_sub(yamux::NEW_SUBSTREAMS_FRAME_SIZE),
         );
 
         Ok(SubstreamId(SubstreamIdInner::SingleStream(substream_id)))

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -257,7 +257,7 @@ where
                 // TODO: only do that for notification substreams? because for requests we already set the value to the maximum when the substream is created
                 self.inner
                     .yamux
-                    .add_remote_window(substream_id, u64::try_from(num_read).unwrap());
+                    .add_remote_window_saturating(substream_id, u64::try_from(num_read).unwrap());
 
                 if let Some(event) = event {
                     return Ok((self, Some(event)));
@@ -811,7 +811,7 @@ where
                 )));
 
         // TODO: we add some bytes due to the length prefix, this is a bit hacky as we should ask this information from the substream
-        self.inner.yamux.add_remote_window(
+        self.inner.yamux.add_remote_window_saturating(
             substream_id,
             u64::try_from(self.inner.request_protocols[protocol_index].max_response_size)
                 .unwrap_or(u64::max_value())

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -60,7 +60,7 @@ use super::{
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use core::{
     fmt,
-    num::NonZeroUsize,
+    num::{NonZeroU32, NonZeroUsize},
     ops::{Add, Sub},
     time::Duration,
 };
@@ -1116,6 +1116,7 @@ impl ConnectionPrototype {
             is_initiator: self.encryption.is_initiator(),
             capacity: 64, // TODO: ?
             randomness_seed: randomness.sample(rand::distributions::Standard),
+            max_out_data_frame_size: NonZeroU32::new(8192).unwrap(), // TODO: make configurable?
             max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
             max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
         });

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -1116,6 +1116,7 @@ impl ConnectionPrototype {
             is_initiator: self.encryption.is_initiator(),
             capacity: 64, // TODO: ?
             randomness_seed: randomness.sample(rand::distributions::Standard),
+            max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
         });
 
         let outgoing_pings = yamux.open_substream(Some(substream::Substream::ping_out(

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -506,7 +506,8 @@ where
                 // Extract outgoing data that is buffered within yamux.
                 // TODO: don't allocate an intermediary buffer, but instead pass them directly to the encryption
                 let mut buffers = Vec::with_capacity(32);
-                while let Some(buffer) = self.inner.yamux.extract_next(unencrypted_bytes_to_extract) {
+                while let Some(buffer) = self.inner.yamux.extract_next(unencrypted_bytes_to_extract)
+                {
                     let buffer = buffer.as_ref();
                     unencrypted_bytes_to_extract -= buffer.len();
                     buffers.push(buffer.to_vec()); // TODO: copy

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -1116,6 +1116,7 @@ impl ConnectionPrototype {
             is_initiator: self.encryption.is_initiator(),
             capacity: 64, // TODO: ?
             randomness_seed: randomness.sample(rand::distributions::Standard),
+            max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
             max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
         });
 

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1412,7 +1412,7 @@ impl<T> Yamux<T> {
                             };
                         return Some(either::Left(out));
                     } else {
-                        let to_add = encoded_header_remains_to_write.to_vec();
+                        let to_add = encoded_header_remains_to_write[..size_bytes].to_vec();
                         *header_already_sent += u8::try_from(size_bytes).unwrap();
                         debug_assert!(*header_already_sent < 12);
                         return Some(either::Right(write_queue::VecWithOffset(to_add, 0)));

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -47,8 +47,6 @@
 
 // TODO: write example
 
-// TODO: the code of this module is rather complicated; either simplify it or write a lot of tests, including fuzzing tests
-
 use crate::util::SipHasherBuild;
 
 use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
@@ -434,8 +432,7 @@ impl<T> Yamux<T> {
             // identifier are possible if the software runs for a very long time.
             // Rather than naively incrementing the id by two and assuming that no substream with
             // this ID exists, the code below properly handles wrapping around and ignores IDs
-            // already in use .
-            // TODO: simply skill whole connection if overflow
+            // already in use.
             let id_attempt = self.inner.next_outbound_substream;
             self.inner.next_outbound_substream = {
                 let mut id = self.inner.next_outbound_substream.get();

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -756,7 +756,8 @@ impl<T> Yamux<T> {
             _ => panic!("send_goaway called multiple times"),
         }
 
-        // If the remote is currently opening a substream, automatically reject it.
+        // If the remote is currently opening a substream, ignore it. The remote understands when
+        // receiving the GoAway that the substream has been rejected.
         if let Incoming::PendingIncomingSubstream {
             substream_id,
             data_frame_size,
@@ -1272,10 +1273,9 @@ impl<T> Yamux<T> {
                                 matches!(decoded_header, header::DecodedYamuxHeader::Data { .. });
 
                             // If we have queued or sent a GoAway frame, then the substream is
-                            // automatically rejected.
+                            // ignored. The remote understands when receiving the GoAway that the
+                            // substream has been rejected.
                             if !matches!(self.inner.outgoing_goaway, OutgoingGoAway::NotRequired) {
-                                self.inner.rsts_to_send.push_back(stream_id);
-
                                 self.inner.incoming = if !is_data {
                                     Incoming::Header(arrayvec::ArrayVec::new())
                                 } else {

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -801,6 +801,7 @@ impl<T> Yamux<T> {
     ///
     /// All follow-up requests for new substreams from the remote are automatically rejected.
     /// [`IncomingDataDetail::IncomingSubstream`] events can no longer happen.
+    ///
     pub fn send_goaway(&mut self, code: GoAwayErrorCode) -> Result<(), SendGoAwayError> {
         match self.inner.outgoing_goaway {
             OutgoingGoAway::NotRequired => {
@@ -1782,9 +1783,7 @@ impl<T> Yamux<T> {
     /// the substream is either accepted or rejected. This function should thus be called as
     /// soon as possible.
     ///
-    /// # Panic
-    ///
-    /// Panics if no incoming substream is currently pending.
+    /// Returns an error if no incoming substream is currently pending.
     ///
     pub fn accept_pending_substream(
         &mut self,
@@ -1847,9 +1846,7 @@ impl<T> Yamux<T> {
     /// the substream is either accepted or rejected. This function should thus be called as
     /// soon as possible.
     ///
-    /// # Panic
-    ///
-    /// Panics if no incoming substream is currently pending.
+    /// Returns an error if no incoming substream is currently pending.
     ///
     pub fn reject_pending_substream(&mut self) -> Result<(), PendingSubstreamError> {
         match self.inner.incoming {

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1049,8 +1049,11 @@ impl<T> Yamux<T> {
                             });
                         }
                         header::DecodedYamuxHeader::GoAway { error_code } => {
+                            if self.inner.received_goaway.is_some() {
+                                return Err(Error::MultipleGoAways);
+                            }
+
                             self.inner.incoming = Incoming::Header(arrayvec::ArrayVec::new());
-                            // TODO: error if we have received one in the past before?
                             self.inner.received_goaway = Some(error_code);
 
                             let mut reset_substreams =
@@ -1926,6 +1929,8 @@ pub enum Error {
     ExpectedAck,
     /// The remote sent an ACK flag but shouldn't have.
     UnexpectedAck,
+    /// Received multiple GoAway frames.
+    MultipleGoAways,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -572,7 +572,7 @@ impl<T> Yamux<T> {
     /// > **Note**: It is only possible to add more bytes to the window and not set or reduce this
     /// >           number of bytes, and it is also not possible to obtain the number of bytes the
     /// >           remote is allowed. That's because it would be ambiguous whether bytes possibly
-    /// >           in the receive queue should be counted or not.
+    /// >           in the send or receive queue should be counted or not.
     ///
     /// # Panic
     ///

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -45,8 +45,6 @@
 //! on the logic of the higher-level protocols. Failing to do so might lead to potential DoS
 //! attack vectors.
 
-// TODO: write example
-
 use crate::util::SipHasherBuild;
 
 use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
@@ -107,6 +105,7 @@ pub struct Config {
     pub max_simultaneous_rst_substreams: NonZeroUsize,
 }
 
+/// Yamux state machine. See [the module-level documentation](..) for more information.
 pub struct Yamux<T> {
     /// The actual fields are wrapped in a `Box` because the `Yamux` object is moved around pretty
     /// often.

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1212,6 +1212,9 @@ impl<T> Yamux<T> {
                             // always keep traces of old substreams, we have no way to know whether
                             // this is the case or not.
                             let Some(s) = self.inner.substreams.get_mut(&stream_id) else { continue };
+                            if !matches!(s.state, SubstreamState::Healthy { .. }) {
+                                continue;
+                            }
 
                             let _was_inserted = self.inner.dead_substreams.insert(stream_id);
                             debug_assert!(_was_inserted);

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -390,7 +390,7 @@ impl<T> Yamux<T> {
     ///
     pub fn open_substream(&mut self, user_data: T) -> SubstreamId {
         // It is forbidden to open new substreams if a `GoAway` frame has been received.
-        assert!(self.inner.received_goaway.is_none());
+        assert!(self.inner.received_goaway.is_none(), "can't open substream after goaway");
 
         // Make sure that the `loop` below can finish.
         assert!(

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1504,7 +1504,11 @@ impl<T> Yamux<T> {
     /// >           however, this would be rather sub-optimal considering that buffers to send out
     /// >           are already stored in their final form in the state machine.
     pub fn extract_next(&'_ mut self, size_bytes: usize) -> Option<impl AsRef<[u8]> + '_> {
-        while size_bytes != 0 {
+        if size_bytes == 0 {
+            return None;
+        }
+
+        loop {
             match self.inner.outgoing {
                 Outgoing::Header {
                     ref mut header,

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1583,9 +1583,10 @@ impl<T> Yamux<T> {
                             SubstreamState::Healthy {
                                 write_queue,
                                 local_write_close: local_write,
+                                allowed_window,
                                 ..
                             } => {
-                                !write_queue.is_empty()
+                                (*allowed_window != 0 && !write_queue.is_empty())
                                     || matches!(local_write, SubstreamStateLocalWrite::FinDesired)
                             }
                             _ => false,
@@ -1605,6 +1606,7 @@ impl<T> Yamux<T> {
                                 u32::try_from(pending_len).unwrap_or(u32::max_value()),
                                 u32::try_from(*allowed_window).unwrap_or(u32::max_value()),
                             );
+                            debug_assert_ne!(len_out, 0);
                             let len_out_usize = usize::try_from(len_out).unwrap();
                             *allowed_window -= u64::from(len_out);
                             let syn_ack_flag = !*first_message_queued;

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1048,7 +1048,6 @@ impl<T> Yamux<T> {
                         }
                     };
 
-                    // Handle any message other than data or window size.
                     match decoded_header {
                         header::DecodedYamuxHeader::PingRequest { opaque_value } => {
                             // Ping. In order to queue the pong message, the outgoing queue must

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1238,6 +1238,7 @@ impl<T> Yamux<T> {
 
                             // Remote has sent a SYN flag. A new substream is to be opened.
                             match self.inner.substreams.get(&stream_id) {
+                                None => {}
                                 Some(Substream {
                                     state:
                                         SubstreamState::Healthy {
@@ -1246,10 +1247,8 @@ impl<T> Yamux<T> {
                                             ..
                                         },
                                     ..
-                                }) => {
-                                    return Err(Error::UnexpectedSyn(stream_id));
-                                }
-                                Some(Substream {
+                                })
+                                | Some(Substream {
                                     state: SubstreamState::Reset,
                                     ..
                                 }) => {
@@ -1263,8 +1262,9 @@ impl<T> Yamux<T> {
                                 Some(Substream {
                                     state: SubstreamState::Healthy { .. },
                                     ..
-                                })
-                                | None => {}
+                                }) => {
+                                    return Err(Error::UnexpectedSyn(stream_id));
+                                }
                             }
 
                             // When receiving a new substream, we might have to potentially queue

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -99,7 +99,8 @@ struct YamuxInner<T> {
     /// that it is returned by [`Yamux::dead_substreams`].
     dead_substreams: hashbrown::HashSet<NonZeroU32, SipHasherBuild>,
 
-    /// Number of substreams within [`Yamux::substreams`] whose [`Substream::inbound`] is `true`.
+    /// Number of substreams within [`YamuxInner::substreams`] whose [`Substream::inbound`] is
+    /// `true`.
     num_inbound: usize,
 
     /// `Some` if a `GoAway` frame has been received in the past.
@@ -195,7 +196,7 @@ enum Incoming {
     /// A header referring to a new substream has been received. The reception of any further data
     /// is blocked waiting for the API user to accept or reject this substream.
     ///
-    /// Note that [`Yamux::outgoing`] must always be [`Outgoing::Idle`], in order to give the
+    /// Note that [`YamuxInner::outgoing`] must always be [`Outgoing::Idle`], in order to give the
     /// possibility to send back a RST frame for the new substream.
     PendingIncomingSubstream {
         /// Identifier of the pending substream.
@@ -252,10 +253,10 @@ enum OutgoingGoAway {
     NotRequired,
 
     /// API user has asked to send a `GoAway` frame. This frame hasn't been queued into
-    /// [`Yamux::outgoing`] yet.
+    /// [`YamuxInner::outgoing`] yet.
     Required(GoAwayErrorCode),
 
-    /// A `GoAway` frame has been queued into [`Yamux::outgoing`] in the past.
+    /// A `GoAway` frame has been queued into [`YamuxInner::outgoing`] in the past.
     Queued,
 
     /// A `GoAway` frame has been extracted through [`Yamux::extract_next`].

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -544,6 +544,11 @@ impl<T> Yamux<T> {
     /// Adds `bytes` to the number of bytes the remote is allowed to send at once in the next
     /// packet.
     ///
+    /// The counter saturates if its maximum is reached. This could cause stalls if the
+    /// remote sends more data than the maximum. However, the number of bytes is stored in a `u64`,
+    /// the remote would have to send 2^64 bytes in order to reach this situation, making it
+    /// basically impossible.
+    ///
     /// > **Note**: When a substream has just been opened or accepted, it starts with an initial
     /// >           window of [`NEW_SUBSTREAMS_FRAME_SIZE`].
     ///
@@ -556,8 +561,7 @@ impl<T> Yamux<T> {
     ///
     /// Panics if the [`SubstreamId`] is invalid.
     ///
-    // TODO: properly define behavior in case of overflow?
-    pub fn add_remote_window(&mut self, substream_id: SubstreamId, bytes: u64) {
+    pub fn add_remote_window_saturating(&mut self, substream_id: SubstreamId, bytes: u64) {
         if let SubstreamState::Healthy {
             remote_window_pending_increase,
             ..

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1923,7 +1923,7 @@ impl<'a, T> ExtractOut<'a, T> {
                                 *local_write = SubstreamStateLocalWrite::FinQueued;
                                 if *remote_write_closed {
                                     let _was_inserted = self.yamux.inner.dead_substreams.insert(id);
-                                    debug_assert!(!_was_inserted);
+                                    debug_assert!(_was_inserted);
                                 }
                             }
                             self.yamux

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1266,6 +1266,7 @@ impl<T> Yamux<T> {
                             // rejection message later.
                             // If it is not the case, we simply leave the header there and prevent
                             // any further data from being read.
+                            // TODO: could deadlock if the write buffer is very small
                             if !matches!(self.inner.outgoing, Outgoing::Idle) {
                                 break;
                             }

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -33,12 +33,12 @@
 //! Call [`Yamux::incoming_data`] when data is available on the socket. This function parses
 //! the received data, updates the internal state machine, and possibly returns an
 //! [`IncomingDataDetail`].
-//! Call [`Yamux::extract_out`] when the remote is ready to accept more data.
+//! Call [`Yamux::extract_next`] when the remote is ready to accept more data.
 //!
 //! The generic parameter of [`Yamux`] is an opaque "user data" associated to each substream.
 //!
 //! When [`Yamux::write`] is called, the buffer of data to send out is stored within the
-//! [`Yamux`] object. This data will then be progressively returned by [`Yamux::extract_out`].
+//! [`Yamux`] object. This data will then be progressively returned by [`Yamux::extract_next`].
 //!
 //! It is the responsibility of the user to enforce a bound to the amount of enqueued data, as
 //! the [`Yamux`] itself doesn't enforce any limit. Enforcing such a bound must be done based
@@ -263,7 +263,7 @@ enum OutgoingGoAway {
     /// A `GoAway` frame has been queued into [`Yamux::outgoing`] in the past.
     Queued,
 
-    /// A `GoAway` frame has been extracted through [`Yamux::extract_out`].
+    /// A `GoAway` frame has been extracted through [`Yamux::extract_next`].
     Sent,
 }
 
@@ -286,7 +286,7 @@ enum OutgoingSubstreamData {
 }
 
 /// Maximum number of simultaneous outgoing pings allowed.
-const MAX_PINGS: usize = 100000;
+pub const MAX_PINGS: usize = 100000;
 
 impl<T> Yamux<T> {
     /// Initializes a new Yamux state machine.
@@ -744,13 +744,13 @@ impl<T> Yamux<T> {
     /// Returns `true` if [`Yamux::send_goaway`] has been called in the past.
     ///
     /// In other words, returns `true` if a `GoAway` frame has been either queued for sending
-    /// (and is available through [`Yamux::extract_out`]) or has already been sent out.
+    /// (and is available through [`Yamux::extract_next`]) or has already been sent out.
     pub fn goaway_queued_or_sent(&self) -> bool {
         !matches!(self.inner.outgoing_goaway, OutgoingGoAway::NotRequired)
     }
 
     /// Returns `true` if [`Yamux::send_goaway`] has been called in the past and that this
-    /// `GoAway` frame has been extracted through [`Yamux::extract_out`].
+    /// `GoAway` frame has been extracted through [`Yamux::extract_next`].
     pub fn goaway_sent(&self) -> bool {
         matches!(self.inner.outgoing_goaway, OutgoingGoAway::Sent)
     }

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -37,9 +37,8 @@
 //!
 //! The generic parameter of [`Yamux`] is an opaque "user data" associated to each substream.
 //!
-//! When [`SubstreamMut::write`] is called, the buffer of data to send out is stored within the
-//! [`Yamux`] object. This data will then be progressively returned by
-//! [`Yamux::extract_out`].
+//! When [`Yamux::write`] is called, the buffer of data to send out is stored within the
+//! [`Yamux`] object. This data will then be progressively returned by [`Yamux::extract_out`].
 //!
 //! It is the responsibility of the user to enforce a bound to the amount of enqueued data, as
 //! the [`Yamux`] itself doesn't enforce any limit. Enforcing such a bound must be done based
@@ -545,9 +544,9 @@ impl<T> Yamux<T> {
         }
     }
 
-    /// Similar to [`SubstreamMut::add_remote_window`], but sets the number of allowed bytes to
-    /// be at least this value. In other words, if this method was to be twice with the same
-    /// parameter, the second call would have no effect.
+    /// Similar to [`Yamux::add_remote_window`], but sets the number of allowed bytes to be at
+    /// least this value. In other words, if this method was to be twice with the same parameter,
+    /// the second call would have no effect.
     ///
     /// # Panic
     ///
@@ -594,7 +593,7 @@ impl<T> Yamux<T> {
     }
 
     /// Returns `false` if the remote has closed their writing side of this substream, or if
-    /// [`SubstreamMut::reset`] has been called on this substream, or if the substream has been
+    /// [`Yamux::reset`] has been called on this substream, or if the substream has been
     /// reset by the remote.
     ///
     /// # Panic
@@ -609,8 +608,8 @@ impl<T> Yamux<T> {
             } if !remote_write_closed)
     }
 
-    /// Returns `false` if [`SubstreamMut::close`] or [`SubstreamMut::reset`] has been called on
-    /// this substream, or if the remote has .
+    /// Returns `false` if [`Yamux::close`] or [`Yamux::reset`] has been called on this substream,
+    /// or if the remote has .
     ///
     /// # Panic
     ///
@@ -635,9 +634,9 @@ impl<T> Yamux<T> {
     /// # Panic
     ///
     /// Panics if the [`SubstreamId`] is invalid.
-    /// Panics if the local writing side is already closed, which can happen if
-    /// [`SubstreamMut::close`] has already been called on this substream or if the remote has
-    /// reset the substream in the past.
+    /// Panics if the local writing side is already closed, which can happen if [`Yamux::close`]
+    /// has already been called on this substream or if the remote has reset the substream in the
+    /// past.
     ///
     // TODO: doc obsolete
     pub fn close(&mut self, substream_id: SubstreamId) {
@@ -662,9 +661,9 @@ impl<T> Yamux<T> {
     /// # Panic
     ///
     /// Panics if the [`SubstreamId`] is invalid.
-    /// Panics if the local writing side is already closed, which can happen if
-    /// [`SubstreamMut::close`] has already been called on this substream or if the remote has
-    /// reset the substream in the past.
+    /// Panics if the local writing side is already closed, which can happen if [`Yamux::close`]
+    /// has already been called on this substream or if the remote has reset the substream in the
+    /// past.
     ///
     pub fn reset(&mut self, substream_id: SubstreamId) {
         // Add an entry to the list of RST headers to send to the remote.

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -85,8 +85,8 @@ pub struct Config {
     ///
     /// A higher value increases the variance of the latency of the data sent on the substreams,
     /// which is undesirable. A lower value increases the overhead of the Yamux protocol. This
-    /// overhead is equal to `1200 / (max_out_data_frame_size + 12)` %, for example setting
-    /// `max_out_data_frame_size` to 24 incurs a 33% overhead.
+    /// overhead is equal to `1200 / (max_out_data_frame_size + 12)` per cent, for example setting
+    /// `max_out_data_frame_size` to 24 incurs a `33%` overhead.
     ///
     /// The "best" value depends on the bandwidth speed of the underlying connection, and is thus
     /// impossible to tell.
@@ -582,9 +582,13 @@ impl<T> Yamux<T> {
     /// packet.
     ///
     /// The counter saturates if its maximum is reached. This could cause stalls if the
-    /// remote sends more data than the maximum. However, the number of bytes is stored in a `u64`,
-    /// the remote would have to send 2^64 bytes in order to reach this situation, making it
-    /// basically impossible.
+    /// remote sends a ton of data. However, given that the number of bytes is stored in a `u64`,
+    /// the remote would have to send at least  `2^64` bytes in order to reach this situation,
+    /// making it basically impossible.
+    ///
+    /// It is, furthermore, a bad idea to increase this counter by an immense number ahead of
+    /// time, as the remote can shut down the connection if its own counter overflows. The way
+    /// this counter is supposed to be used is in a "streaming" way.
     ///
     /// > **Note**: When a substream has just been opened or accepted, it starts with an initial
     /// >           window of [`NEW_SUBSTREAMS_FRAME_SIZE`].
@@ -2007,7 +2011,7 @@ pub enum Error {
     ExpectedAck,
     /// The remote sent an ACK flag but shouldn't have.
     UnexpectedAck,
-    /// Received multiple GoAway frames.
+    /// Received multiple `GoAway` frames.
     MultipleGoAways,
 }
 

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -413,7 +413,7 @@ impl<T> Yamux<T> {
 
         let substream_id = self.inner.next_outbound_substream.clone();
 
-        self.inner.next_outbound_substream = match self.inner.next_outbound_substream.checked_add(1)
+        self.inner.next_outbound_substream = match self.inner.next_outbound_substream.checked_add(2)
         {
             Some(new_id) => new_id,
             None => return Err(OpenSubstreamError::NoFreeSubstreamId),

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1148,12 +1148,14 @@ impl<T> Yamux<T> {
                             rst: true,
                             ack,
                             stream_id,
+                            length,
                             ..
                         }
                         | header::DecodedYamuxHeader::Window {
                             rst: true,
                             ack,
                             stream_id,
+                            length,
                             ..
                         } => {
                             // Frame with the `RST` flag set. Destroy the substream.
@@ -1161,7 +1163,9 @@ impl<T> Yamux<T> {
                             // Sending a `RST` flag and data together is a weird corner case and
                             // is difficult to handle. It is unclear whether it is allowed at all.
                             // We thus consider it as invalid.
-                            if matches!(decoded_header, header::DecodedYamuxHeader::Data { .. }) {
+                            if matches!(decoded_header, header::DecodedYamuxHeader::Data { .. })
+                                && length != 0
+                            {
                                 return Err(Error::DataWithRst);
                             }
 

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -498,17 +498,18 @@ impl<T> Yamux<T> {
             .inner
             .substreams
             .get_mut(&substream_id.0)
-            .unwrap_or_else(|| panic!());
+            .unwrap_or_else(|| panic!("invalid substream"));
         match &mut substream.state {
             SubstreamState::Reset => {}
             SubstreamState::Healthy {
-                local_write_close: local_write,
+                local_write_close: SubstreamStateLocalWrite::Open,
                 write_queue,
                 ..
             } => {
-                if matches!(local_write, SubstreamStateLocalWrite::Open) {
-                    write_queue.push_back(data);
-                }
+                write_queue.push_back(data);
+            }
+            SubstreamState::Healthy { .. } => {
+                panic!("write after close")
             }
         }
     }

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1126,23 +1126,20 @@ impl<T> Yamux<T> {
                             rst: true,
                             ack,
                             stream_id,
-                            length,
                             ..
                         }
                         | header::DecodedYamuxHeader::Window {
                             rst: true,
                             ack,
                             stream_id,
-                            length,
                             ..
                         } => {
                             // Frame with the `RST` flag set. Destroy the substream.
 
-                            // It is invalid to have the `RST` flag set and data at the same time.
-                            // TODO: why is it invalid?
-                            if matches!(decoded_header, header::DecodedYamuxHeader::Data { .. })
-                                && length != 0
-                            {
+                            // Sending a `RST` flag and data together is a weird corner case and
+                            // is difficult to handle. It is unclear whether it is allowed at all.
+                            // We thus consider it as invalid.
+                            if matches!(decoded_header, header::DecodedYamuxHeader::Data { .. }) {
                                 return Err(Error::DataWithRst);
                             }
 

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -351,7 +351,7 @@ mod tests {
         assert!(super::decode_yamux_header(&[2, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2, 65]).is_err());
     }
 
-    macro_rules! check_encode_reendoces {
+    macro_rules! check_encode_redecodes {
         ($payload:expr) => {{
             let payload = $payload;
             assert_eq!(
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn encode_data() {
         for _ in 0..500 {
-            check_encode_reendoces!(super::DecodedYamuxHeader::Data {
+            check_encode_redecodes!(super::DecodedYamuxHeader::Data {
                 syn: rand::random(),
                 ack: rand::random(),
                 fin: rand::random(),
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn encode_window() {
         for _ in 0..500 {
-            check_encode_reendoces!(super::DecodedYamuxHeader::Window {
+            check_encode_redecodes!(super::DecodedYamuxHeader::Window {
                 syn: rand::random(),
                 ack: rand::random(),
                 fin: rand::random(),
@@ -391,26 +391,26 @@ mod tests {
 
     #[test]
     fn encode_ping() {
-        check_encode_reendoces!(super::DecodedYamuxHeader::PingRequest {
+        check_encode_redecodes!(super::DecodedYamuxHeader::PingRequest {
             opaque_value: rand::random(),
         });
 
-        check_encode_reendoces!(super::DecodedYamuxHeader::PingResponse {
+        check_encode_redecodes!(super::DecodedYamuxHeader::PingResponse {
             opaque_value: rand::random(),
         });
     }
 
     #[test]
     fn encode_goaway() {
-        check_encode_reendoces!(super::DecodedYamuxHeader::GoAway {
+        check_encode_redecodes!(super::DecodedYamuxHeader::GoAway {
             error_code: super::GoAwayErrorCode::NormalTermination,
         });
 
-        check_encode_reendoces!(super::DecodedYamuxHeader::GoAway {
+        check_encode_redecodes!(super::DecodedYamuxHeader::GoAway {
             error_code: super::GoAwayErrorCode::ProtocolError,
         });
 
-        check_encode_reendoces!(super::DecodedYamuxHeader::GoAway {
+        check_encode_redecodes!(super::DecodedYamuxHeader::GoAway {
             error_code: super::GoAwayErrorCode::InternalError,
         });
     }

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -160,7 +160,7 @@ pub fn encode(header: &DecodedYamuxHeader) -> [u8; 12] {
 }
 
 /// Decodes a Yamux header.
-pub fn decode_yamux_header(bytes: &[u8]) -> Result<DecodedYamuxHeader, YamuxHeaderDecodeError> {
+pub fn decode_yamux_header(bytes: &[u8; 12]) -> Result<DecodedYamuxHeader, YamuxHeaderDecodeError> {
     match nom::combinator::all_consuming(nom::combinator::complete(decode))(bytes) {
         Ok((_, h)) => Ok(h),
         Err(nom::Err::Incomplete(_)) => unreachable!(),
@@ -348,12 +348,5 @@ mod tests {
     fn version_check() {
         assert!(super::decode_yamux_header(&[0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2, 65]).is_ok());
         assert!(super::decode_yamux_header(&[2, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2, 65]).is_err());
-    }
-
-    #[test]
-    fn length_check() {
-        assert!(super::decode_yamux_header(&[0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2, 65]).is_ok());
-        assert!(super::decode_yamux_header(&[0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2, 65, 0]).is_err());
-        assert!(super::decode_yamux_header(&[0, 0, 0, 1, 0, 0, 0, 15, 0, 0, 2]).is_err());
     }
 }

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -18,7 +18,7 @@
 #![cfg(test)]
 
 use super::{Config, Error, GoAwayErrorCode, IncomingDataDetail, Yamux};
-use core::num::NonZeroUsize;
+use core::{cmp, num::NonZeroUsize};
 
 #[test]
 fn bad_header_data() {
@@ -26,6 +26,7 @@ fn bad_header_data() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -54,6 +55,7 @@ fn not_immediate_data_send_when_opening_substream() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -67,6 +69,7 @@ fn syn_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -88,6 +91,7 @@ fn extract_bytes_one_by_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -110,6 +114,7 @@ fn inject_bytes_one_by_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -146,6 +151,7 @@ fn ack_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -187,6 +193,7 @@ fn rst_sent_when_rejecting() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -218,6 +225,7 @@ fn max_simultaneous_rst_substreams() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(16).unwrap(),
     });
 
@@ -253,6 +261,7 @@ fn invalid_inbound_substream_id() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -279,6 +288,7 @@ fn substream_opened_twice() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -311,6 +321,7 @@ fn substream_opened_back_after_rst() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -350,6 +361,7 @@ fn substream_opened_back_after_graceful_closing() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -420,6 +432,7 @@ fn missing_ack() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -459,6 +472,7 @@ fn multiple_acks() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -501,6 +515,7 @@ fn multiple_writes_combined_into_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -528,6 +543,7 @@ fn close_before_syn_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -551,6 +567,7 @@ fn write_after_close_illegal() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -569,6 +586,7 @@ fn credits_exceeded_checked_before_data_is_received() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -606,6 +624,7 @@ fn credits_exceeded_checked_at_the_syn() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -641,6 +660,7 @@ fn data_coming_with_the_syn_taken_into_account() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -679,6 +699,7 @@ fn add_remote_window_works() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -727,6 +748,7 @@ fn add_remote_window_doesnt_immediately_raise_limit() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -768,6 +790,7 @@ fn remote_default_window_respected() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -790,6 +813,7 @@ fn remote_window_frames_respected() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -837,6 +861,7 @@ fn write_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -871,6 +896,7 @@ fn write_after_fin_even_with_empty_frame() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -905,6 +931,7 @@ fn window_frame_with_fin_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -939,6 +966,7 @@ fn window_frame_without_fin_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -973,6 +1001,7 @@ fn send_ping() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1013,6 +1042,7 @@ fn remote_pong_wrong_opaque_value() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1053,6 +1083,7 @@ fn remote_pong_out_of_nowhere() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1081,6 +1112,7 @@ fn answer_remote_ping() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1106,11 +1138,79 @@ fn answer_remote_ping() {
 }
 
 #[test]
+fn max_simultaneous_queued_pongs() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    let mut data = Vec::new();
+
+    // Queue many new pings.
+    for _ in 1..16 {
+        data.extend_from_slice(&[0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::MaxSimultaneousPingsExceeded) => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn simultaneous_pongs_flushed() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    let mut data = Vec::new();
+
+    // Queue many new pings.
+    for _ in 1..16 {
+        data.extend_from_slice(&[0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..][..cmp::min(12, data.len() - cursor)]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+
+                // Flush out in order to send the pong.
+                while yamux.extract_next(usize::max_value()).is_some() {}
+            }
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test succeded.
+}
+
+#[test]
 fn dont_send_syn_after_goaway() {
     let mut yamux = Yamux::new(Config {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1142,6 +1242,7 @@ fn substream_reset_on_goaway_if_not_acked() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1172,6 +1273,7 @@ fn can_still_send_after_goaway_if_acked() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1217,6 +1319,7 @@ fn receive_multiple_goaways() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 
@@ -1246,6 +1349,7 @@ fn ignore_incoming_substreams_after_goaway() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
 

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -815,3 +815,141 @@ fn window_frame_without_fin_after_fin() {
 
     assert_eq!(cursor, data.len());
 }
+
+#[test]
+fn send_ping() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    yamux.queue_ping();
+
+    let mut output = Vec::new();
+    while let Some(out) = yamux.extract_next(usize::max_value()) {
+        output.extend_from_slice(out.as_ref());
+    }
+    assert_eq!(&output[0..8], &[0, 2, 0, 1, 0, 0, 0, 0]);
+
+    // Ping response frame.
+    let mut data = vec![0, 2, 0, 2, 0, 0, 0, 0];
+    data.extend_from_slice(&output[8..12]);
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+
+                if matches!(outcome.detail, Some(IncomingDataDetail::PingResponse)) {
+                    return;
+                }
+            }
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn remote_pong_wrong_opaque_value() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    yamux.queue_ping();
+
+    let mut output = Vec::new();
+    while let Some(out) = yamux.extract_next(usize::max_value()) {
+        output.extend_from_slice(out.as_ref());
+    }
+    assert_eq!(&output[0..8], &[0, 2, 0, 1, 0, 0, 0, 0]);
+
+    // Ping response frame.
+    let mut data = vec![0, 2, 0, 2, 0, 0, 0, 0];
+    data.extend_from_slice(&output[8..12]);
+
+    // Intentionally modify the opaque value to not match.
+    data[10] = data[10].overflowing_add(1).0;
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::PingResponseNotMatching) => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn remote_pong_out_of_nowhere() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    // Ping response frame.
+    let data = &[0, 2, 0, 2, 0, 0, 0, 0, 1, 2, 3, 4];
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::PingResponseNotMatching) => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn answer_remote_ping() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    // Ping request frame.
+    let data = &[0, 2, 0, 1, 0, 0, 0, 0, 1, 2, 3, 4];
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(_) => panic!(),
+        }
+    }
+
+    let mut output = Vec::new();
+    while let Some(out) = yamux.extract_next(usize::max_value()) {
+        output.extend_from_slice(out.as_ref());
+    }
+    assert_eq!(output, &[0, 2, 0, 2, 0, 0, 0, 0, 1, 2, 3, 4]);
+}

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -625,9 +625,6 @@ fn remote_default_window_respected() {
 
     let mut output = Vec::new();
     while let Some(out) = yamux.extract_next(usize::max_value()) {
-        if output.len() >= 50 {
-            panic!("{:?}", out.as_ref().len())
-        }
         output.extend_from_slice(out.as_ref());
     }
 

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -29,7 +29,7 @@ fn bad_header_data() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -59,7 +59,7 @@ fn not_immediate_data_send_when_opening_substream() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -74,7 +74,7 @@ fn syn_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -123,7 +123,7 @@ fn extract_bytes_one_by_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -147,7 +147,7 @@ fn inject_bytes_one_by_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -185,7 +185,7 @@ fn ack_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -228,7 +228,7 @@ fn syn_and_ack_together() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -256,7 +256,7 @@ fn syn_and_rst_together() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -284,7 +284,7 @@ fn rst_sent_when_rejecting() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -317,7 +317,7 @@ fn max_simultaneous_rst_substreams() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(16).unwrap(),
     });
@@ -354,7 +354,7 @@ fn invalid_inbound_substream_id() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -382,7 +382,7 @@ fn substream_opened_twice() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -416,7 +416,7 @@ fn substream_opened_back_after_rst() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -457,7 +457,7 @@ fn substream_opened_back_after_graceful_closing() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -529,7 +529,7 @@ fn missing_ack() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -570,7 +570,7 @@ fn multiple_acks() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -614,7 +614,7 @@ fn multiple_writes_combined_into_one() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -643,7 +643,7 @@ fn close_before_syn_sent() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -668,7 +668,7 @@ fn write_after_close_illegal() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -688,7 +688,7 @@ fn credits_exceeded_checked_before_data_is_received() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -727,7 +727,7 @@ fn credits_exceeded_checked_at_the_syn() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -764,7 +764,7 @@ fn data_coming_with_the_syn_taken_into_account() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -804,7 +804,7 @@ fn add_remote_window_works() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -854,7 +854,7 @@ fn add_remote_window_doesnt_immediately_raise_limit() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -897,7 +897,7 @@ fn add_remote_window_saturates() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -914,7 +914,7 @@ fn remote_default_window_respected() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -938,7 +938,7 @@ fn remote_window_frames_respected() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -987,7 +987,7 @@ fn write_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1023,7 +1023,7 @@ fn write_after_fin_even_with_empty_frame() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1059,7 +1059,7 @@ fn window_frame_with_fin_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1095,7 +1095,7 @@ fn window_frame_without_fin_after_fin() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1131,7 +1131,7 @@ fn send_ping() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1173,7 +1173,7 @@ fn remote_pong_wrong_opaque_value() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1215,7 +1215,7 @@ fn pings_answered_in_wrong_order() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1256,7 +1256,7 @@ fn remote_pong_out_of_nowhere() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1286,7 +1286,7 @@ fn answer_remote_ping() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1318,7 +1318,7 @@ fn max_simultaneous_queued_pongs() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1352,7 +1352,7 @@ fn simultaneous_pongs_flushed() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1387,7 +1387,7 @@ fn dont_send_syn_after_goaway() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1420,7 +1420,7 @@ fn substream_reset_on_goaway_if_not_acked() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1452,7 +1452,7 @@ fn can_still_send_after_goaway_if_acked() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1499,7 +1499,7 @@ fn receive_multiple_goaways() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1530,7 +1530,7 @@ fn ignore_incoming_substreams_after_goaway() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });
@@ -1564,7 +1564,7 @@ fn opening_forbidden_after_goaway() {
         capacity: 0,
         is_initiator: true,
         randomness_seed: [0; 32],
-        max_out_data_frame_size: NonZeroU32::new(8192).unwrap(),
+        max_out_data_frame_size: NonZeroU32::new(u32::max_value()).unwrap(),
         max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
         max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
     });

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -1136,5 +1136,5 @@ fn can_still_send_after_goaway_if_acked() {
     while let Some(out) = yamux.extract_next(usize::max_value()) {
         output.extend_from_slice(out.as_ref());
     }
-    assert!(output.ends_with(&[3, 101, 101, 101]));
+    assert!(output.ends_with(&[3, 102, 111, 111]));
 }

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -188,6 +188,60 @@ fn ack_sent() {
 }
 
 #[test]
+fn syn_and_ack_together() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    let data = [0, 0, 0, 1 | 2, 0, 0, 0, 84, 0, 0, 0, 0];
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::UnexpectedAck) => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn syn_and_rst_together() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+        max_simultaneous_queued_pongs: NonZeroUsize::new(4).unwrap(),
+        max_simultaneous_rst_substreams: NonZeroUsize::new(1024).unwrap(),
+    });
+
+    let data = [0, 0, 0, 1 | 8, 0, 0, 0, 84, 0, 0, 0, 0];
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::DataWithRst) => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
 fn rst_sent_when_rejecting() {
     let mut yamux = Yamux::<()>::new(Config {
         capacity: 0,

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -78,6 +78,8 @@ fn ack_sent() {
         }
     }
 
+    yamux.write(opened_substream.unwrap(), b"foo".to_vec());
+
     let mut output = Vec::new();
     while let Some(out) = yamux.extract_next(usize::max_value()) {
         output.extend_from_slice(out.as_ref());

--- a/lib/src/libp2p/connection/yamux/tests.rs
+++ b/lib/src/libp2p/connection/yamux/tests.rs
@@ -1,0 +1,177 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use super::{Config, Error, IncomingDataDetail, Yamux};
+
+#[test]
+fn not_immediate_data_send_when_opening_substream() {
+    let mut yamux = Yamux::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let _ = yamux.open_substream(());
+    assert!(yamux.extract_next(usize::max_value()).is_none())
+}
+
+#[test]
+fn syn_sent() {
+    let mut yamux = Yamux::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let substream_id = yamux.open_substream(());
+    yamux.write(substream_id, b"foo".to_vec());
+
+    let mut output = Vec::new();
+    while let Some(out) = yamux.extract_next(usize::max_value()) {
+        output.extend_from_slice(out.as_ref());
+    }
+
+    assert!(output.starts_with(&[0, 0, 0, 1]));
+    assert!(output.ends_with(&[0, 0, 0, 3, 102, 111, 111]));
+}
+
+#[test]
+fn ack_sent() {
+    let mut yamux = Yamux::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let mut opened_substream = None;
+
+    {
+        let data = [0, 0, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0];
+        let mut cursor = 0;
+        while cursor < data.len() {
+            let outcome = yamux.incoming_data(&data[cursor..]).unwrap();
+            yamux = outcome.yamux;
+            cursor += outcome.bytes_read;
+            match outcome.detail {
+                Some(IncomingDataDetail::IncomingSubstream) => {
+                    assert!(opened_substream.is_none());
+                    opened_substream = Some(yamux.accept_pending_substream(()))
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut output = Vec::new();
+    while let Some(out) = yamux.extract_next(usize::max_value()) {
+        output.extend_from_slice(out.as_ref());
+    }
+
+    assert_eq!(
+        output,
+        &[0, 0, 0, 2, 0, 0, 0, 84, 0, 0, 0, 3, 102, 111, 111]
+    );
+}
+
+#[test]
+fn invalid_inbound_substream_id() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let data = [0, 0, 0, 1, 0, 0, 0, 83, 0, 0, 0, 0];
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+            }
+            Err(Error::InvalidInboundStreamId(v)) if v.get() == 83 => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn substream_opened_twice() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let data = [
+        0, 0, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0,
+    ];
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+
+                if matches!(outcome.detail, Some(IncomingDataDetail::IncomingSubstream)) {
+                    yamux.accept_pending_substream(());
+                }
+            }
+            Err(Error::UnexpectedSyn(v)) if v.get() == 84 => return,
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test failed.
+    panic!()
+}
+
+#[test]
+fn substream_opened_back_after_rst() {
+    let mut yamux = Yamux::<()>::new(Config {
+        capacity: 0,
+        is_initiator: true,
+        randomness_seed: [0; 32],
+    });
+
+    let data = [
+        0, 0, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+        0, 84, 0, 0, 0, 0,
+    ];
+
+    let mut cursor = 0;
+    while cursor < data.len() {
+        match yamux.incoming_data(&data[cursor..]) {
+            Ok(outcome) => {
+                yamux = outcome.yamux;
+                cursor += outcome.bytes_read;
+
+                if matches!(outcome.detail, Some(IncomingDataDetail::IncomingSubstream)) {
+                    yamux.accept_pending_substream(());
+                }
+            }
+            Err(_) => panic!(),
+        }
+    }
+
+    // Test success.
+}

--- a/lib/src/libp2p/connection/yamux/write_queue.rs
+++ b/lib/src/libp2p/connection/yamux/write_queue.rs
@@ -1,0 +1,83 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use alloc::{collections::VecDeque, vec::Vec};
+
+#[derive(Clone)]
+pub struct VecWithOffset(pub Vec<u8>, pub usize);
+
+impl AsRef<[u8]> for VecWithOffset {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[self.1..]
+    }
+}
+
+// TODO: PartialEq/Eq?!
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteQueue {
+    /// Buffer of buffers to be written out.
+    // TODO: is it a good idea to have an unbounded VecDeque?
+    // TODO: call shrink_to_fit from time to time?
+    // TODO: instead of storing `Vec<u8>`s, consider storing a generic `B` and let the user manually write a `B` to the output buffer
+    write_buffers: VecDeque<Vec<u8>>,
+    /// Number of bytes in `self.write_buffers[0]` has have already been written out to the
+    /// socket.
+    first_write_buffer_offset: usize,
+}
+
+impl WriteQueue {
+    pub fn new() -> Self {
+        WriteQueue {
+            write_buffers: VecDeque::with_capacity(16),
+            first_write_buffer_offset: 0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        debug_assert!(!self.write_buffers.is_empty() || self.first_write_buffer_offset == 0);
+        self.write_buffers.is_empty()
+    }
+
+    pub fn push_back(&mut self, data: Vec<u8>) {
+        debug_assert!(!self.write_buffers.is_empty() || self.first_write_buffer_offset == 0);
+        self.write_buffers.push_back(data);
+    }
+
+    pub fn queued_bytes(&self) -> usize {
+        self.write_buffers.iter().fold(0, |n, buf| n + buf.len()) - self.first_write_buffer_offset
+    }
+
+    pub fn extract_some(&mut self, max_size: usize) -> VecWithOffset {
+        let first_buf_avail = self.write_buffers[0].len() - self.first_write_buffer_offset;
+
+        if first_buf_avail <= max_size {
+            let out = VecWithOffset(
+                self.write_buffers.pop_front().unwrap(),
+                self.first_write_buffer_offset,
+            );
+            self.first_write_buffer_offset = 0;
+            out
+        } else {
+            let out = VecWithOffset(
+                self.write_buffers[0][self.first_write_buffer_offset..][..max_size].to_vec(),
+                0,
+            );
+            self.first_write_buffer_offset += max_size;
+            out
+        }
+    }
+}

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Removed support for the `ls` message in the multistream-select protocol, in accordance with the rest of the libp2p ecosystem. This message was in practice never used, and removing support for it simplifies the implementation. ([#379](https://github.com/smol-dot/smoldot/pull/379))
+- Yamux now considers answering pings in the wrong order as invalid.
 
 ### Fixed
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,13 +5,13 @@
 ### Changed
 
 - Removed support for the `ls` message in the multistream-select protocol, in accordance with the rest of the libp2p ecosystem. This message was in practice never used, and removing support for it simplifies the implementation. ([#379](https://github.com/smol-dot/smoldot/pull/379))
-- Yamux now considers answering pings in the wrong order as invalid.
+- Yamux now considers answering pings in the wrong order as invalid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 
 ### Fixed
 
-- Properly check whether Yamux substream IDs allocated by the remote are valid.
-- Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits.
-- Fix Yamux repeatedly sending empty data frames when the allowed window size is 0.
+- Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
+- Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))
+- Fix Yamux repeatedly sending empty data frames when the allowed window size is 0. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 
 ## 1.0.1 - 2023-03-29
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Removed support for the `ls` message in the multistream-select protocol, in accordance with the rest of the libp2p ecosystem. This message was in practice never used, and removing support for it simplifies the implementation. ([#379](https://github.com/smol-dot/smoldot/pull/379))
 
+### Fixed
+
+- Properly check whether Yamux substream IDs allocated by the remote are valid.
+- Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits.
+
 ## 1.0.1 - 2023-03-29
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Properly check whether Yamux substream IDs allocated by the remote are valid.
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits.
+- Fix Yamux repeatedly sending empty data frames when the allowed window size is 0.
 
 ## 1.0.1 - 2023-03-29
 


### PR DESCRIPTION
This PR does a clean-up pass on the Yamux implementation, fixing many issues.

Can be reviewed commit by commit.

A ton of tests have been added, caches have been added (that should lead to better performances if there are a lot of substreams), and a couple of bugs fixed.
