### PR TITLE
Disable post-MVP Wasm features

### DIFF
--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -52,6 +52,16 @@
 //!
 //! The first variant used to be the default model when compiling to WebAssembly, but the second
 //! variant (importing memory objects) is preferred nowadays.
+//!
+//! # Wasm features
+//!
+//! The WebAssembly specification is a moving one. The specification as it was when it launched
+//! in 2017 is commonly referred to as "the MVP" (minimum viable product). Since then, various
+//! extensions have been added to the WebAssembly format.
+//!
+//! The code in this module, however, doesn't allow any of the feature that were added post-MVP.
+//! Trying to use WebAssembly code that uses one of these features will result in an error.
+//!
 
 mod interpreter;
 #[cfg(all(target_arch = "x86_64", feature = "std"))]

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -54,7 +54,22 @@ impl InterpreterPrototype {
         module_bytes: &[u8],
         symbols: &mut dyn FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
-        let engine = wasmi::Engine::default(); // TODO: investigate config
+        let engine = {
+            let mut config = wasmi::Config::default();
+
+            // Disable all the post-MVP wasm features.
+            config.wasm_sign_extension(false);
+            config.wasm_reference_types(false);
+            config.wasm_bulk_memory(false);
+            config.wasm_multi_value(false);
+            config.wasm_extended_const(false);
+            config.wasm_mutable_global(false);
+            config.wasm_saturating_float_to_int(false);
+            config.wasm_tail_call(false);
+
+            wasmi::Engine::new(&config)
+        };
+
         let module = wasmi::Module::new(&engine, module_bytes)
             .map_err(|err| NewErr::InvalidWasm(err.to_string()))?;
 

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -78,6 +78,18 @@ impl JitPrototype {
         // environment variables whatsoever. Whether to use `Enable` or `Disable` below isn't
         // very important, so long as it is not `Environment`.
         config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
+
+        // Disable all post-MVP wasm features.
+        // Some of these configuration options are `true` by default while some others are `false`
+        // by default, but we just disable them all to be sure.
+        config.wasm_threads(false);
+        config.wasm_reference_types(false);
+        config.wasm_simd(false);
+        config.wasm_bulk_memory(false);
+        config.wasm_multi_value(false);
+        config.wasm_multi_memory(false);
+        config.wasm_memory64(false);
+
         let engine =
             wasmtime::Engine::new(&config).map_err(|err| NewErr::InvalidWasm(err.to_string()))?;
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Removed support for the `ls` message in the multistream-select protocol, in accordance with the rest of the libp2p ecosystem. This message was in practice never used, and removing support for it simplifies the implementation. ([#379](https://github.com/smol-dot/smoldot/pull/379))
 
+### Fixed
+
+- Post-MVP WebAssembly features are now properly disabled when compiling runtimes. This rejects runtimes that Substrate would consider as invalid as well.
+
 ## 1.0.1 - 2023-03-29
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Post-MVP WebAssembly features are now properly disabled when compiling runtimes. This rejects runtimes that Substrate would consider as invalid as well.
+- Post-MVP WebAssembly features are now properly disabled when compiling runtimes. This rejects runtimes that Substrate would consider as invalid as well. ([#386](https://github.com/smol-dot/smoldot/pull/386))
 
 ## 1.0.1 - 2023-03-29
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/217

It's unclear to me whether `sign-ext` and [Non-trapping float-to-int conversions](https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md) should be disabled as well. See https://github.com/paritytech/substrate/issues/10707#issuecomment-1494081313.