### PR TITLE
Use pointers rather than `usize` in jit.rs

### DIFF
--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -193,8 +193,10 @@ impl JitPrototype {
                                                     .unwrap(),
                                                 expected_return_ty,
                                                 in_interrupted_waker: None, // Filled below
-                                                memory_pointer: memory.data_ptr(&caller) as usize,
-                                                memory_size: memory.data_size(&mut caller),
+                                                memory: SliceRawParts(
+                                                    memory.data_ptr(&caller),
+                                                    memory.data_size(&caller),
+                                                ),
                                             };
                                         }
                                         Shared::ExecutingStart => {
@@ -234,8 +236,10 @@ impl JitPrototype {
                                             memory.grow(&mut caller, additional).unwrap();
                                             *shared_lock = Shared::WithinFunctionCall {
                                                 in_interrupted_waker: Some(cx.waker().clone()),
-                                                memory_pointer: memory.data_ptr(&caller) as usize,
-                                                memory_size: memory.data_size(&caller),
+                                                memory: SliceRawParts(
+                                                    memory.data_ptr(&caller),
+                                                    memory.data_size(&caller),
+                                                ),
                                                 expected_return_ty,
                                             };
                                             Poll::Pending
@@ -534,23 +538,18 @@ enum Shared {
         /// Parameters of the function currently being called.
         parameters: Vec<WasmValue>,
 
-        /// See [`Shared::WithinFunctionCall::memory_pointer`].
-        memory_pointer: usize,
-        /// See [`Shared::WithinFunctionCall::memory_size`].
-        memory_size: usize,
+        /// See [`Shared::WithinFunctionCall::memory`].
+        memory: SliceRawParts,
         /// See [`Shared::WithinFunctionCall::expected_return_ty`].
         expected_return_ty: Option<ValueType>,
         /// See [`Shared::WithinFunctionCall::in_interrupted_waker`].
         in_interrupted_waker: Option<Waker>,
     },
     WithinFunctionCall {
-        /// Pointer to the location where the virtual machine memory is located in the host
-        /// memory. This pointer is invalidated if the memory is grown, which can happen between
-        /// function calls.
-        memory_pointer: usize,
-        /// Size of the virtual machine memory in bytes. This size is invalidated if the memory
-        /// is grown, which can happen between function calls.
-        memory_size: usize,
+        /// Pointer and size of the location where the virtual machine memory is located in the
+        /// host memory. This pointer is invalidated if the memory is grown, which can happen
+        /// between function calls.
+        memory: SliceRawParts,
 
         /// Type of the return value of the function.
         expected_return_ty: Option<ValueType>,
@@ -574,6 +573,13 @@ enum Shared {
         memory: wasmtime::Memory,
     },
 }
+
+/// This idiotic struct and unsafe code are necessary because Rust doesn't implement `Send` and
+/// `Sync` for raw pointers.
+#[derive(Copy, Clone)]
+struct SliceRawParts(*mut u8, usize);
+unsafe impl Send for SliceRawParts {}
+unsafe impl Sync for SliceRawParts {}
 
 /// See [`super::VirtualMachine`].
 pub struct Jit {
@@ -632,16 +638,14 @@ impl Jit {
                     Shared::WithinFunctionCall {
                         in_interrupted_waker,
                         expected_return_ty,
-                        memory_pointer,
-                        memory_size,
+                        memory,
                     } => {
                         let provided_value_ty = value.as_ref().map(|v| v.ty());
                         if expected_return_ty != provided_value_ty {
                             *shared_lock = Shared::WithinFunctionCall {
                                 in_interrupted_waker,
                                 expected_return_ty,
-                                memory_pointer,
-                                memory_size,
+                                memory,
                             };
                             return Err(RunErr::BadValueTy {
                                 expected: expected_return_ty,
@@ -755,14 +759,12 @@ impl Jit {
                     Shared::EnteredFunctionCall {
                         function_index,
                         parameters,
-                        memory_pointer,
-                        memory_size,
+                        memory,
                         expected_return_ty,
                         in_interrupted_waker,
                     } => {
                         *shared_lock = Shared::WithinFunctionCall {
-                            memory_pointer,
-                            memory_size,
+                            memory,
                             expected_return_ty,
                             in_interrupted_waker,
                         };
@@ -787,7 +789,7 @@ impl Jit {
             }
             JitInner::Executing(_) => {
                 let size_bytes = match *self.shared.try_lock().unwrap() {
-                    Shared::WithinFunctionCall { memory_size, .. } => memory_size,
+                    Shared::WithinFunctionCall { memory, .. } => memory.1,
                     _ => unreachable!(),
                 };
 
@@ -810,16 +812,12 @@ impl Jit {
         let memory_slice = match &self.inner {
             JitInner::NotStarted { store, .. } | JitInner::Done(store) => self.memory.data(store),
             JitInner::Executing(_) => {
-                let (memory_pointer, memory_size) = match *self.shared.try_lock().unwrap() {
-                    Shared::WithinFunctionCall {
-                        memory_pointer,
-                        memory_size,
-                        ..
-                    } => (memory_pointer, memory_size),
+                let memory = match *self.shared.try_lock().unwrap() {
+                    Shared::WithinFunctionCall { memory, .. } => memory,
                     _ => unreachable!(),
                 };
 
-                unsafe { slice::from_raw_parts(memory_pointer as *mut u8, memory_size) }
+                unsafe { slice::from_raw_parts(memory.0, memory.1) }
             }
             JitInner::Poisoned => unreachable!(),
         };
@@ -843,16 +841,12 @@ impl Jit {
                 self.memory.data_mut(store)
             }
             JitInner::Executing(_) => {
-                let (memory_pointer, memory_size) = match *self.shared.try_lock().unwrap() {
-                    Shared::WithinFunctionCall {
-                        memory_pointer,
-                        memory_size,
-                        ..
-                    } => (memory_pointer, memory_size),
+                let memory = match *self.shared.try_lock().unwrap() {
+                    Shared::WithinFunctionCall { memory, .. } => memory,
                     _ => unreachable!(),
                 };
 
-                unsafe { slice::from_raw_parts_mut(memory_pointer as *mut u8, memory_size) }
+                unsafe { slice::from_raw_parts_mut(memory.0, memory.1) }
             }
             JitInner::Poisoned => unreachable!(),
         };
@@ -891,17 +885,16 @@ impl Jit {
                 let mut shared_lock = self.shared.try_lock().unwrap();
                 match mem::replace(&mut *shared_lock, Shared::Poisoned) {
                     Shared::WithinFunctionCall {
-                        memory_pointer,
-                        memory_size,
+                        memory,
                         expected_return_ty,
                         in_interrupted_waker,
                     } => {
                         // We check now what the memory bounds are, as it is more difficult to
                         // recover from `grow` returning an error than checking manually.
-                        let current_pages = if memory_size == 0 {
+                        let current_pages = if memory.1 == 0 {
                             0
                         } else {
-                            1 + u64::try_from((memory_size - 1) / (64 * 1024)).unwrap()
+                            1 + u64::try_from((memory.1 - 1) / (64 * 1024)).unwrap()
                         };
                         if self
                             .memory_type
@@ -910,8 +903,7 @@ impl Jit {
                         {
                             // Put everything back as it was.
                             *shared_lock = Shared::WithinFunctionCall {
-                                memory_pointer,
-                                memory_size,
+                                memory,
                                 expected_return_ty,
                                 in_interrupted_waker,
                             };


### PR DESCRIPTION
As explained [here](https://doc.rust-lang.org/std/ptr/index.html#strict-provenance), casting pointers to `usize` and back isn't a good idea.

It is currently done in `jit.rs` in order to avoid having to add two `unsafe` keywords that this PR unfortunately adds, but using the `unsafe` is more correct than the casting.
