### PR TITLE
Simplify the `chain_head.rs` module

### DIFF
--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -36,9 +36,7 @@ use core::{
     time::Duration,
 };
 use futures::{lock::Mutex, prelude::*};
-use hashbrown::HashMap;
 use smoldot::{
-    chain::fork_tree,
     executor::{host, runtime_host},
     header,
     json_rpc::{self, methods, requests_subscriptions},
@@ -99,16 +97,6 @@ struct Background<TPlat: Platform> {
     /// If `true`, we have already printed a warning about usage of the legacy JSON-RPC API. This
     /// flag prevents printing this message multiple times.
     printed_legacy_json_rpc_warning: atomic::AtomicBool,
-}
-
-struct FollowSubscription {
-    /// Tree of hashes of all the current non-finalized blocks. This includes unpinned blocks.
-    non_finalized_blocks: fork_tree::ForkTree<[u8; 32]>,
-
-    /// For each pinned block hash, the SCALE-encoded header of the block.
-    pinned_blocks_headers: HashMap<[u8; 32], Vec<u8>, fnv::FnvBuildHasher>,
-
-    runtime_subscribe_all: Option<runtime_service::SubscriptionId>,
 }
 
 pub(super) enum SubscriptionMessage {

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1308,6 +1308,7 @@ impl<TPlat: Platform> ChainHeadFollowTask<TPlat> {
                                         .to_json_call_object_parameters(None),
                                     )
                                     .await;
+                                break;
                             }
                             either::Left(Err(())) => {
                                 requests_subscriptions
@@ -1322,6 +1323,7 @@ impl<TPlat: Platform> ChainHeadFollowTask<TPlat> {
                                         .to_json_call_object_parameters(None),
                                     )
                                     .await;
+                                break;
                             }
                             either::Right((
                                 SubscriptionMessage::StopIfChainHeadStorage { stop_request_id },
@@ -1494,6 +1496,7 @@ impl<TPlat: Platform> ChainHeadFollowTask<TPlat> {
                                         }
                                         .to_json_call_object_parameters(None)
                                     ).await;
+                                    break;
                                 }
                                 either::Left(Err(_)) => {
                                     requests_subscriptions.set_queued_notification(
@@ -1506,6 +1509,7 @@ impl<TPlat: Platform> ChainHeadFollowTask<TPlat> {
                                         }
                                         .to_json_call_object_parameters(None)
                                     ).await;
+                                    break;
                                 }
                                 either::Right((
                                     SubscriptionMessage::StopIfChainHeadBody { stop_request_id },

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -950,7 +950,9 @@ impl ChainHeadFollowTask {
                         .on_foreground_message(&me, message, confirmation_sender)
                         .await
                     {
-                        ops::ControlFlow::Break(()) => break,
+                        // Intentionally `return` rather than `break` in order to not generate
+                        // a `stop` event.
+                        ops::ControlFlow::Break(()) => return,
                         ops::ControlFlow::Continue(()) => {}
                     }
                 }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 - Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription. ([#409](https://github.com/smol-dot/smoldot/pull/409))
 - No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`. ([#409](https://github.com/smol-dot/smoldot/pull/409))
-- Fix the JSON-RPC service not being deallocated when a chain was removed with some subscriptions still active. ([#409](https://github.com/smol-dot/smoldot/pull/409), [#408](https://github.com/smol-dot/smoldot/pull/408))
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))
 - Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Fixed
 
-- Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription.
-- No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`.
+- Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription. ([#409](https://github.com/smol-dot/smoldot/pull/409))
+- No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`. ([#409](https://github.com/smol-dot/smoldot/pull/409))
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))
 - Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fix the JSON-RPC service not being deallocated when a chain is removed with some subscriptions still active. ([#408](https://github.com/smol-dot/smoldot/pull/408), [#410](https://github.com/smol-dot/smoldot/pull/410), [#409](https://github.com/smol-dot/smoldot/pull/409))
 - Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription. ([#409](https://github.com/smol-dot/smoldot/pull/409))
 - No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`. ([#409](https://github.com/smol-dot/smoldot/pull/409))
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription. ([#409](https://github.com/smol-dot/smoldot/pull/409))
 - No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`. ([#409](https://github.com/smol-dot/smoldot/pull/409))
+- Fix the JSON-RPC service not being deallocated when a chain was removed with some subscriptions still active. ([#409](https://github.com/smol-dot/smoldot/pull/409), [#408](https://github.com/smol-dot/smoldot/pull/408))
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))
 - Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription.
+- No longer generate a `chainHead_unstable_followEvent` notification with a `stop` event in response to a call to `chainHead_unstable_unfollow`.
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))
 - Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Calling the `chainHead_unstable_call`, `chainHead_unstable_storage`, or `chainHead_unstable_body` JSON-RPC functions with the hash of an unpinned block no longer silently kills the `chainHead_follow` subscription.
 - Fix a potential undefined behavior in the way the Rust and JavaScript communicate. ([#396](https://github.com/smol-dot/smoldot/pull/396))
 - Properly check whether Yamux substream IDs allocated by the remote are valid. ([#383](https://github.com/smol-dot/smoldot/pull/383))
 - Fix the size of the data of Yamux frames with the `SYN` flag not being verified against the allowed credits. ([#383](https://github.com/smol-dot/smoldot/pull/383))


### PR DESCRIPTION
This PR makes the code of the `chain_head.rs` module more simple by splitting its code between various functions that belong to the same struct.

Also fixes the `chain_head`-specific cyclic references mentioned in https://github.com/smol-dot/smoldot/issues/406