### PR TITLE
Send back name and version to identify requests

### DIFF
--- a/full-node/src/run.rs
+++ b/full-node/src/run.rs
@@ -433,6 +433,7 @@ pub async fn run(cli_options: cli::CliOptionsRun) {
                 .into_iter(),
             )
             .collect(),
+            identify_agent_version: concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION")).to_owned(),
             noise_key,
             tasks_executor: &mut |task| threads_pool.spawn_ok(task),
             jaeger_service: jaeger_service.clone(),

--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -36,8 +36,8 @@ fn main() {
         tasks_spawner: Box::new(move |_name, task| {
             async_std::task::spawn(task);
         }),
-        system_name: env!("CARGO_PKG_NAME").into(),
-        system_version: env!("CARGO_PKG_VERSION").into(),
+        client_name: env!("CARGO_PKG_NAME").into(),
+        client_version: env!("CARGO_PKG_VERSION").into(),
     });
 
     // Ask the client to connect to a chain.

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- When receiving an identify request through the libp2p protocol, smoldot now sends back `smoldot-light-wasm vX.X.X` (with proper version numbers) as its agent name and version, instead of previously just `smoldot`.
+
 ## 1.0.2 - 2023-04-12
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- When receiving an identify request through the libp2p protocol, smoldot now sends back `smoldot-light-wasm vX.X.X` (with proper version numbers) as its agent name and version, instead of previously just `smoldot`.
+- When receiving an identify request through the libp2p protocol, smoldot now sends back `smoldot-light-wasm vX.X.X` (with proper version numbers) as its agent name and version, instead of previously just `smoldot`. ([#417](https://github.com/smol-dot/smoldot/pull/417))
 
 ## 1.0.2 - 2023-04-12
 

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -203,8 +203,8 @@ pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
         tasks_spawner: Box::new(move |name, task| {
             new_task_tx.unbounded_send((name, task)).unwrap()
         }),
-        system_name: env!("CARGO_PKG_NAME").into(),
-        system_version: env!("CARGO_PKG_VERSION").into(),
+        client_name: env!("CARGO_PKG_NAME").into(),
+        client_version: env!("CARGO_PKG_VERSION").into(),
     });
 
     Client {


### PR DESCRIPTION
When receiving an identify request through the libp2p protocol, we now properly send back the version number rather than just `"smoldot"`.