### PR TITLE
Add `TrieStructure::range`

### DIFF
--- a/lib/src/trie/nibble.rs
+++ b/lib/src/trie/nibble.rs
@@ -27,10 +27,13 @@ impl Nibble {
         Nibble(0)
     }
 
+    /// Returns the equivalent of `Nibble::try_from(15).unwrap()`. It is the maximum possible value
+    /// for a nibble.
     pub fn max() -> Self {
         Nibble(15)
     }
 
+    /// Add the given number to the nibble. Returns `None` on overflow.
     pub fn checked_add(self, val: u8) -> Option<Self> {
         let new_nibble = self.0.checked_add(val)?;
         if new_nibble >= 16 {

--- a/lib/src/trie/nibble.rs
+++ b/lib/src/trie/nibble.rs
@@ -21,6 +21,25 @@ use core::fmt;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Nibble(u8);
 
+impl Nibble {
+    /// Returns the equivalent of `Nibble::try_from(0).unwrap()`.
+    pub fn zero() -> Self {
+        Nibble(0)
+    }
+
+    pub fn max() -> Self {
+        Nibble(15)
+    }
+
+    pub fn checked_add(self, val: u8) -> Option<Self> {
+        let new_nibble = self.0.checked_add(val)?;
+        if new_nibble >= 16 {
+            return None;
+        }
+        Some(Nibble(new_nibble))
+    }
+}
+
 impl TryFrom<u8> for Nibble {
     type Error = NibbleFromU8Error;
 

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -874,14 +874,12 @@ impl<TUd> TrieStructure<TUd> {
                     let node = self.nodes.get(iter.0).unwrap();
 
                     // End the iterator if we were about to jump out of the end bound.
-                    if iter_key_nibbles_extra
-                        < if iter.1.is_some() { 2 } else { 1 } + node.partial_key.len()
-                    {
+                    if iter_key_nibbles_extra < 2 + node.partial_key.len() {
                         return None;
                     }
 
                     let Some((parent_node_index, parent_nibble_direction)) = node.parent else { return None; };
-                    iter_key_nibbles_extra -= if iter.1.is_some() { 2 } else { 1 };
+                    iter_key_nibbles_extra -= 2;
                     iter_key_nibbles_extra -= node.partial_key.len();
                     iter = (parent_node_index, None);
                     let next_sibling_nibble = parent_nibble_direction.checked_add(1);
@@ -892,7 +890,7 @@ impl<TUd> TrieStructure<TUd> {
                     } else {
                         iter_key_nibbles_extra += 1;
                     }
-                    iter.1 = Some(next_sibling_nibble);
+                    iter = (parent_node_index, Some(next_sibling_nibble));
                 }
             }
         }))

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -596,6 +596,16 @@ impl<TUd> TrieStructure<TUd> {
     }
 
     /// Returns all nodes whose full key is within the given range, in lexicographic order.
+    // TODO: change API to accept the range trait
+    pub fn range<'a>(
+        &'a self,
+        start_bound: ops::Bound<impl Iterator<Item = Nibble>>,
+        end_bound: ops::Bound<impl Iterator<Item = Nibble> + 'a>,
+    ) -> impl Iterator<Item = NodeIndex> + 'a {
+        self.range_inner(start_bound, end_bound).map(NodeIndex)
+    }
+
+    /// Returns all nodes whose full key is within the given range, in lexicographic order.
     fn range_inner<'a>(
         &'a self,
         start_bound: ops::Bound<impl Iterator<Item = Nibble>>,

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -732,6 +732,10 @@ impl<TUd> TrieStructure<TUd> {
                     let Some((parent, parent_nibble)) = iter_node.parent
                         else { return either::Right(iter::empty()); };
                     let next_nibble = parent_nibble.checked_add(1);
+                    if iter_key_nibbles_extra == 0 {
+                        return either::Right(iter::empty());
+                    }
+                    iter_key_nibbles_extra -= 1;
                     if iter_key_nibbles_extra == 0 && next_nibble == Some(*end_key.peek().unwrap())
                     {
                         let _ = end_key.next();

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -824,14 +824,14 @@ impl<TUd> TrieStructure<TUd> {
                         let node = self.nodes.get(iter.0).unwrap();
 
                         // End the iterator if we were about to jump out of the end bound.
-                        if iter_key_nibbles_extra < 1 + node.partial_key.len() {
+                        if iter_key_nibbles_extra < 2 + node.partial_key.len() {
                             return None;
                         }
 
                         let Some((parent_node_index, parent_nibble_direction)) = node.parent else { return None; };
-                        iter_key_nibbles_extra -= 1;
+                        iter_key_nibbles_extra -= 2;
                         iter_key_nibbles_extra -= node.partial_key.len();
-                        iter.0 = parent_node_index;
+                        iter = (parent_node_index, None);
                         let next_sibling_nibble = match parent_nibble_direction.checked_add(1) {
                             Some(idx) => idx,
                             None => continue,

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -598,7 +598,7 @@ impl<TUd> TrieStructure<TUd> {
     /// Returns all nodes whose full key is within the given range, in lexicographic order.
     fn range_inner<'a>(
         &'a self,
-        start_bound: ops::Bound<impl Iterator<Item = Nibble> + 'a>,
+        start_bound: ops::Bound<impl Iterator<Item = Nibble>>,
         end_bound: ops::Bound<impl Iterator<Item = Nibble> + 'a>,
     ) -> impl Iterator<Item = usize> + 'a {
         // Start by processing the end bound to obtain an "end key".
@@ -647,8 +647,10 @@ impl<TUd> TrieStructure<TUd> {
         // Iterate down the tree, updating the variables above. At each iteration, one of the
         // three following is true:
         //
-        // - `iter` is inferior or inferior or equal to `start_key`.
-        // - `iter` is the first node that is superior or strictly superior to `start_key`.
+        // - `iter` is inferior or inferior or equal (depending on `start_key_is_inclusive`) to
+        //   `start_key`.
+        // - `iter` is the first node that is superior or strictly superior (depending on
+        //   `start_key_is_inclusive`) to `start_key`.
         // - `iter` points to a non-existing node that is inferior/inferior-or-equal to
         //   `start_key`, but is right before the first node that is superior/strictly superior to
         //   `start_key`.

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -823,6 +823,9 @@ impl<TUd> TrieStructure<TUd> {
                             cmp::Ordering::Equal => {
                                 debug_assert_eq!(iter_key_nibbles_extra, 0);
                                 let _ = end_key.next();
+                                if end_key.peek().is_none() {
+                                    return None;
+                                }
                             }
                         }
                     }

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -731,7 +731,18 @@ impl<TUd> TrieStructure<TUd> {
                     // Stop the search immediately after the current node in the parent.
                     let Some((parent, parent_nibble)) = iter_node.parent
                         else { return either::Right(iter::empty()); };
-                    iter = (parent, Some(parent_nibble.checked_add(1)));
+                    let next_nibble = parent_nibble.checked_add(1);
+                    if iter_key_nibbles_extra == 0 && next_nibble == Some(*end_key.peek().unwrap())
+                    {
+                        let _ = end_key.next();
+                        // `iter` is already past the end bound. Return an empty range.
+                        if end_key.peek().is_none() {
+                            return either::Right(iter::empty());
+                        }
+                    } else {
+                        iter_key_nibbles_extra += 1;
+                    }
+                    iter = (parent, Some(next_nibble));
                     break 'start_search;
                 }
             }

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -714,6 +714,10 @@ impl<TUd> TrieStructure<TUd> {
                             if end_key.peek().is_none() {
                                 return either::Right(iter::empty());
                             }
+                        } else if iter_key_nibbles_extra == 0
+                            && iter_node_pk_nibble > *end_key.peek().unwrap()
+                        {
+                            return either::Right(iter::empty());
                         } else {
                             iter_key_nibbles_extra += 1;
                         }
@@ -885,7 +889,6 @@ impl<TUd> TrieStructure<TUd> {
                     let Some((parent_node_index, parent_nibble_direction)) = node.parent else { return None; };
                     iter_key_nibbles_extra -= 2;
                     iter_key_nibbles_extra -= node.partial_key.len();
-                    iter = (parent_node_index, None);
                     let next_sibling_nibble = parent_nibble_direction.checked_add(1);
                     if iter_key_nibbles_extra == 0
                         && next_sibling_nibble == Some(*end_key.peek().unwrap())

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -763,6 +763,8 @@ impl<TUd> TrieStructure<TUd> {
                     if end_key.peek().is_none() {
                         return either::Right(iter::empty());
                     }
+                } else if iter_key_nibbles_extra == 0 && next_nibble > *end_key.peek().unwrap() {
+                    return either::Right(iter::empty());
                 } else {
                     iter_key_nibbles_extra += 1;
                 }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -904,7 +904,7 @@ fn range() {
             }
 
             let btree_result = btree_map
-                .range((start_range_btree, end_range_btree))
+                .range((start_range_btree.clone(), end_range_btree.clone()))
                 .map(|(_, idx)| *idx)
                 .collect::<Vec<_>>();
             let trie_result = trie
@@ -912,8 +912,8 @@ fn range() {
                 .collect::<Vec<_>>();
             assert_eq!(
                 btree_result, trie_result,
-                "all_keys: {:?}\nbtree_result: {:?}\ntrie_result: {:?}",
-                final_storage, btree_result, trie_result
+                "all_keys: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
+                final_storage, btree_result, trie_result, start_range_btree, end_range_btree
             );
         }
     }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -19,6 +19,8 @@
 
 use super::{Nibble, TrieStructure};
 
+use alloc::collections::BTreeMap;
+use core::ops;
 use rand::{
     distributions::{Distribution as _, Uniform},
     seq::SliceRandom as _,
@@ -781,4 +783,116 @@ fn iter_properly_traverses() {
     }
 
     assert_eq!(trie.all_nodes_ordered().count(), trie.nodes.len());
+}
+
+#[test]
+fn range() {
+    // This test makes sure that the `range` function works as expected.
+    // It first builds a random tree structure, then puts all the nodes of the structure into
+    // a `BTreeMap` (from the standard library), then compares whether `TreeStructure::range`
+    // returns the same results as `BTreeMap::range`.
+
+    fn uniform_sample(min: u8, max: u8) -> u8 {
+        Uniform::new_inclusive(min, max).sample(&mut rand::thread_rng())
+    }
+
+    // We run the test multiple times because of randomness.
+    for _ in 0..256 {
+        // Generate a set of random keys that will find themselves in the trie in the end.
+        let final_storage: HashSet<Vec<Nibble>> = {
+            let mut list = vec![Vec::new()];
+            for _ in 0..25 {
+                for elem in list.clone().into_iter() {
+                    for _ in 0..uniform_sample(0, 4) {
+                        let mut elem = elem.clone();
+                        for _ in 0..uniform_sample(0, 3) {
+                            elem.push(Nibble::try_from(uniform_sample(0, 15)).unwrap());
+                        }
+                        list.push(elem);
+                    }
+                }
+            }
+            list.into_iter().skip(1).collect()
+        };
+
+        // Create a trie and puts `final_storage` in it.
+        let mut trie = TrieStructure::new();
+        for key in &final_storage {
+            match trie.node(key.iter().copied()) {
+                super::Entry::Vacant(e) => {
+                    e.insert_storage_value().insert((), ());
+                }
+                super::Entry::Occupied(super::NodeAccess::Branch(e)) => {
+                    e.insert_storage_value();
+                }
+                super::Entry::Occupied(super::NodeAccess::Storage(_)) => {
+                    unreachable!()
+                }
+            }
+        }
+
+        // Create a `BTreeMap` containins all the nodes of the trie.
+        let btree_map = trie
+            .iter_unordered()
+            .map(|node_index| {
+                let full_key = trie
+                    .node_full_key_by_index(node_index)
+                    .unwrap()
+                    .collect::<Vec<_>>();
+                (full_key, node_index)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        // Randomly query ranges of the btree map and the trie.
+        for _ in 0..64 {
+            let mut start_key = Vec::new();
+            for _ in 0..uniform_sample(0, 5) {
+                start_key.push(Nibble::try_from(uniform_sample(0, 15)).unwrap());
+            }
+
+            let mut end_key = Vec::new();
+            for _ in 0..uniform_sample(0, 5) {
+                end_key.push(Nibble::try_from(uniform_sample(0, 15)).unwrap());
+            }
+
+            let (start_range_btree, start_range_trie) = match uniform_sample(0, 2) {
+                0 => (
+                    ops::Bound::Included(start_key.clone()),
+                    ops::Bound::Included(start_key.iter().copied()),
+                ),
+                1 => (
+                    ops::Bound::Excluded(start_key.clone()),
+                    ops::Bound::Excluded(start_key.iter().copied()),
+                ),
+                2 => (ops::Bound::Unbounded, ops::Bound::Unbounded),
+                _ => unreachable!(),
+            };
+
+            let (end_range_btree, end_range_trie) = match uniform_sample(0, 2) {
+                0 => (
+                    ops::Bound::Included(end_key.clone()),
+                    ops::Bound::Included(end_key.iter().copied()),
+                ),
+                1 => (
+                    ops::Bound::Excluded(end_key.clone()),
+                    ops::Bound::Excluded(end_key.iter().copied()),
+                ),
+                2 => (ops::Bound::Unbounded, ops::Bound::Unbounded),
+                _ => unreachable!(),
+            };
+
+            let btree_result = btree_map
+                .range((start_range_btree, end_range_btree))
+                .map(|(_, idx)| *idx)
+                .collect::<Vec<_>>();
+            let trie_result = trie
+                .range(start_range_trie, end_range_trie)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                btree_result, trie_result,
+                "all_keys: {:?}\nbtree_result: {:?}\ntrie_result: {:?}",
+                final_storage, btree_result, trie_result
+            );
+        }
+    }
 }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -881,6 +881,28 @@ fn range() {
                 _ => unreachable!(),
             };
 
+            match (&start_range_btree, &end_range_btree) {
+                (
+                    ops::Bound::Included(start) | ops::Bound::Excluded(start),
+                    ops::Bound::Included(end) | ops::Bound::Excluded(end),
+                ) if start > end => {
+                    let trie_result = trie
+                        .range(start_range_trie, end_range_trie)
+                        .collect::<Vec<_>>();
+                    assert_eq!(
+                        trie_result,
+                        Vec::new(),
+                        "{:?} {:?} {:?} {:?}",
+                        final_storage,
+                        trie_result,
+                        start_range_btree,
+                        end_range_btree
+                    );
+                    continue;
+                }
+                _ => {}
+            }
+
             let btree_result = btree_map
                 .range((start_range_btree, end_range_btree))
                 .map(|(_, idx)| *idx)

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -891,7 +891,7 @@ fn range() {
                         .collect::<Vec<_>>();
                     assert!(
                         trie_result.is_empty(),
-                        "{:?} {:?} {:?} {:?}",
+                        "\nbtree: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
                         btree_map,
                         trie_result,
                         start_range_btree,
@@ -899,16 +899,13 @@ fn range() {
                     );
                     continue;
                 }
-                (
-                    ops::Bound::Excluded(start),
-                    ops::Bound::Excluded(end),
-                ) if start == end => {
+                (ops::Bound::Excluded(start), ops::Bound::Excluded(end)) if start == end => {
                     let trie_result = trie
                         .range(start_range_trie, end_range_trie)
                         .collect::<Vec<_>>();
                     assert!(
                         trie_result.is_empty(),
-                        "{:?} {:?} {:?} {:?}",
+                        "\nbtree: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
                         btree_map,
                         trie_result,
                         start_range_btree,

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -801,7 +801,7 @@ fn range() {
         // Generate a set of random keys that will find themselves in the trie in the end.
         let final_storage: HashSet<Vec<Nibble>> = {
             let mut list = vec![Vec::new()];
-            for _ in 0..25 {
+            for _ in 0..4 {
                 for elem in list.clone().into_iter() {
                     for _ in 0..uniform_sample(0, 4) {
                         let mut elem = elem.clone();

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -893,7 +893,7 @@ fn range() {
                         trie_result,
                         Vec::new(),
                         "{:?} {:?} {:?} {:?}",
-                        final_storage,
+                        btree_map,
                         trie_result,
                         start_range_btree,
                         end_range_btree
@@ -912,8 +912,8 @@ fn range() {
                 .collect::<Vec<_>>();
             assert_eq!(
                 btree_result, trie_result,
-                "all_keys: {:?}\nbtree: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
-                final_storage, btree_map, btree_result, trie_result, start_range_btree, end_range_btree
+                "btree: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
+                btree_map, btree_result, trie_result, start_range_btree, end_range_btree
             );
         }
     }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -912,7 +912,7 @@ fn range() {
                 .collect::<Vec<_>>();
             assert_eq!(
                 btree_result, trie_result,
-                "btree: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
+                "\nbtree: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
                 btree_map, btree_result, trie_result, start_range_btree, end_range_btree
             );
         }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -797,7 +797,7 @@ fn range() {
     }
 
     // We run the test multiple times because of randomness.
-    for _ in 0..256 {
+    for _ in 0..4096 {
         // Generate a set of random keys that will find themselves in the trie in the end.
         let final_storage: BTreeSet<Vec<Nibble>> = {
             let mut list = vec![Vec::new()];

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -889,9 +889,8 @@ fn range() {
                     let trie_result = trie
                         .range(start_range_trie, end_range_trie)
                         .collect::<Vec<_>>();
-                    assert_eq!(
-                        trie_result,
-                        Vec::new(),
+                    assert!(
+                        trie_result.is_empty(),
                         "{:?} {:?} {:?} {:?}",
                         btree_map,
                         trie_result,

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -912,8 +912,8 @@ fn range() {
                 .collect::<Vec<_>>();
             assert_eq!(
                 btree_result, trie_result,
-                "all_keys: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
-                final_storage, btree_result, trie_result, start_range_btree, end_range_btree
+                "all_keys: {:?}\nbtree: {:?}\nbtree_result: {:?}\ntrie_result: {:?}\nstart: {:?}\nend: {:?}",
+                final_storage, btree_map, btree_result, trie_result, start_range_btree, end_range_btree
             );
         }
     }

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -19,7 +19,7 @@
 
 use super::{Nibble, TrieStructure};
 
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::ops;
 use rand::{
     distributions::{Distribution as _, Uniform},
@@ -799,7 +799,7 @@ fn range() {
     // We run the test multiple times because of randomness.
     for _ in 0..256 {
         // Generate a set of random keys that will find themselves in the trie in the end.
-        let final_storage: HashSet<Vec<Nibble>> = {
+        let final_storage: BTreeSet<Vec<Nibble>> = {
             let mut list = vec![Vec::new()];
             for _ in 0..4 {
                 for elem in list.clone().into_iter() {

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -899,6 +899,23 @@ fn range() {
                     );
                     continue;
                 }
+                (
+                    ops::Bound::Excluded(start),
+                    ops::Bound::Excluded(end),
+                ) if start == end => {
+                    let trie_result = trie
+                        .range(start_range_trie, end_range_trie)
+                        .collect::<Vec<_>>();
+                    assert!(
+                        trie_result.is_empty(),
+                        "{:?} {:?} {:?} {:?}",
+                        btree_map,
+                        trie_result,
+                        start_range_btree,
+                        end_range_btree
+                    );
+                    continue;
+                }
                 _ => {}
             }
 


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/272

While working on https://github.com/smol-dot/smoldot/pull/424, I realized that I needed a `range` function for `TrieStructure`.

However, it turns out that this is insanely complicated to implement properly.

I've started this PR but I'm going to abandon it and implement `PrefixKeys` inefficiently, which is ok since `PrefixKeys` is going to be removed in the future.

I'm opening this PR in order to not lose the code in case this function ends up being needed, but I'm not planning to finish it at the moment.