### PR TITLE
Make the list of `wasmtime` targets more precise

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -88,7 +88,9 @@ soketto = { version = "0.7.1", optional = true }
 # TODO:
 parity-scale-codec = { version = "3.4.0", features = ["derive"], default-features = false } # TODO: a lot of unnecessary overhead in terms of memory allocations
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+# This list of targets matches the tier 1 and tier 2 of platforms supported by wasmtime: <https://docs.wasmtime.dev/stability-tiers.html>
+# The arch and OS of a specific target can be found with the command `rustc +nightly -Z unstable-options --print target-spec-json --target ...`
+[target.'cfg(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")))'.dependencies]
 # `std` feature
 wasmtime = { version = "7.0.0", default-features = false, features = ["async", "cranelift"], optional = true }
 

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -64,7 +64,8 @@
 //!
 
 mod interpreter;
-#[cfg(all(target_arch = "x86_64", feature = "std"))]
+// This list of targets matches the one in the `Cargo.toml` file.
+#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
 mod jit;
 
 mod tests;
@@ -98,7 +99,7 @@ pub struct VirtualMachinePrototype {
 
 #[derive(Clone)]
 enum VirtualMachinePrototypeInner {
-    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
     Jit(jit::JitPrototype),
     Interpreter(interpreter::InterpreterPrototype),
 }
@@ -112,11 +113,11 @@ impl VirtualMachinePrototype {
     pub fn new(config: Config) -> Result<Self, NewErr> {
         Ok(VirtualMachinePrototype {
             inner: match config.exec_hint {
-                #[cfg(all(target_arch = "x86_64", feature = "std"))]
+                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
-                #[cfg(not(all(target_arch = "x86_64", feature = "std")))]
+                #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Interpreter(
                     interpreter::InterpreterPrototype::new(config.module_bytes, config.symbols)?,
                 ),
@@ -129,7 +130,7 @@ impl VirtualMachinePrototype {
                     )
                 }
 
-                #[cfg(all(target_arch = "x86_64", feature = "std"))]
+                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
                 ExecHint::ForceWasmtime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
@@ -142,7 +143,7 @@ impl VirtualMachinePrototype {
     /// The global variable must be a `u32`, otherwise an error is returned.
     pub fn global_value(&mut self, name: &str) -> Result<u32, GlobalValueErr> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.global_value(name),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.global_value(name),
         }
@@ -153,7 +154,7 @@ impl VirtualMachinePrototype {
     /// `None` if there is no limit.
     pub fn memory_max_pages(&self) -> Option<HeapPages> {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.memory_max_pages(),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.memory_max_pages(),
         }
@@ -165,7 +166,7 @@ impl VirtualMachinePrototype {
     /// the actual execution..
     pub fn prepare(self) -> Prepare {
         match self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachinePrototypeInner::Jit(inner) => Prepare {
                 inner: PrepareInner::Jit(inner.prepare()),
             },
@@ -179,7 +180,7 @@ impl VirtualMachinePrototype {
 impl fmt::Debug for VirtualMachinePrototype {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachinePrototypeInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachinePrototypeInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -191,7 +192,7 @@ pub struct Prepare {
 }
 
 enum PrepareInner {
-    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
     Jit(jit::Prepare),
     Interpreter(interpreter::Prepare),
 }
@@ -201,7 +202,7 @@ impl Prepare {
     pub fn into_prototype(self) -> VirtualMachinePrototype {
         VirtualMachinePrototype {
             inner: match self.inner {
-                #[cfg(all(target_arch = "x86_64", feature = "std"))]
+                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
                 PrepareInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
                 }
@@ -215,7 +216,7 @@ impl Prepare {
     /// Returns the size of the memory, in bytes.
     pub fn memory_size(&self) -> HeapPages {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Jit(inner) => inner.memory_size(),
             PrepareInner::Interpreter(inner) => inner.memory_size(),
         }
@@ -230,11 +231,11 @@ impl Prepare {
         size: u32,
     ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
         Ok(match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Interpreter(inner) => either::Right(inner.read_memory(offset, size)?),
-            #[cfg(not(all(target_arch = "x86_64", feature = "std")))]
+            #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
             PrepareInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
     }
@@ -244,7 +245,7 @@ impl Prepare {
     /// Returns an error if the range is invalid or out of range.
     pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Jit(inner) => inner.write_memory(offset, value),
             PrepareInner::Interpreter(inner) => inner.write_memory(offset, value),
         }
@@ -256,7 +257,7 @@ impl Prepare {
     /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
     pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Jit(inner) => inner.grow_memory(additional),
             PrepareInner::Interpreter(inner) => inner.grow_memory(additional),
         }
@@ -271,7 +272,7 @@ impl Prepare {
     ) -> Result<VirtualMachine, (StartErr, VirtualMachinePrototype)> {
         Ok(VirtualMachine {
             inner: match self.inner {
-                #[cfg(all(target_arch = "x86_64", feature = "std"))]
+                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
                 PrepareInner::Jit(inner) => match inner.start(function_name, params) {
                     Ok(vm) => VirtualMachineInner::Jit(vm),
                     Err((err, proto)) => {
@@ -302,7 +303,7 @@ impl Prepare {
 impl fmt::Debug for Prepare {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             PrepareInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             PrepareInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -314,7 +315,7 @@ pub struct VirtualMachine {
 }
 
 enum VirtualMachineInner {
-    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
     Jit(jit::Jit),
     Interpreter(interpreter::Interpreter),
 }
@@ -329,7 +330,7 @@ impl VirtualMachine {
     /// that call.
     pub fn run(&mut self, value: Option<WasmValue>) -> Result<ExecOutcome, RunErr> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.run(value),
             VirtualMachineInner::Interpreter(inner) => inner.run(value),
         }
@@ -340,7 +341,7 @@ impl VirtualMachine {
     /// > **Note**: This can change over time if the Wasm code uses the `grow` opcode.
     pub fn memory_size(&self) -> HeapPages {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.memory_size(),
             VirtualMachineInner::Interpreter(inner) => inner.memory_size(),
         }
@@ -355,13 +356,13 @@ impl VirtualMachine {
         size: u32,
     ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
         Ok(match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Interpreter(inner) => {
                 either::Right(inner.read_memory(offset, size)?)
             }
-            #[cfg(not(all(target_arch = "x86_64", feature = "std")))]
+            #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
             VirtualMachineInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
     }
@@ -371,7 +372,7 @@ impl VirtualMachine {
     /// Returns an error if the range is invalid or out of range.
     pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.write_memory(offset, value),
             VirtualMachineInner::Interpreter(inner) => inner.write_memory(offset, value),
         }
@@ -383,7 +384,7 @@ impl VirtualMachine {
     /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
     pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => inner.grow_memory(additional),
             VirtualMachineInner::Interpreter(inner) => inner.grow_memory(additional),
         }
@@ -393,7 +394,7 @@ impl VirtualMachine {
     pub fn into_prototype(self) -> VirtualMachinePrototype {
         VirtualMachinePrototype {
             inner: match self.inner {
-                #[cfg(all(target_arch = "x86_64", feature = "std"))]
+                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
                 VirtualMachineInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
                 }
@@ -408,7 +409,7 @@ impl VirtualMachine {
 impl fmt::Debug for VirtualMachine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(target_arch = "x86_64", feature = "std"))]
+            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
             VirtualMachineInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachineInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -435,8 +436,8 @@ pub enum ExecHint {
     /// Forces using the `wasmtime` backend.
     ///
     /// This variant is useful for testing purposes.
-    #[cfg(all(target_arch = "x86_64", feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(target_arch = "x86_64", feature = "std"))))]
+    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+    #[cfg_attr(docsrs, doc(cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))))]
     ForceWasmtime,
 }
 
@@ -450,11 +451,11 @@ impl ExecHint {
 
     /// Returns `ForceWasmtime` if it is available on the current platform, and `None` otherwise.
     pub fn force_wasmtime_if_available() -> Option<ExecHint> {
-        #[cfg(all(target_arch = "x86_64", feature = "std"))]
+        #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
         fn value() -> Option<ExecHint> {
             Some(ExecHint::ForceWasmtime)
         }
-        #[cfg(not(all(target_arch = "x86_64", feature = "std")))]
+        #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
         fn value() -> Option<ExecHint> {
             None
         }
@@ -582,7 +583,7 @@ impl<'a> TryFrom<&'a wasmi::FuncType> for Signature {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "std"))]
+#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
 impl<'a> TryFrom<&'a wasmtime::FuncType> for Signature {
     type Error = UnsupportedTypeError;
 
@@ -690,7 +691,7 @@ impl From<WasmValue> for wasmi::Value {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "std"))]
+#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
 impl From<WasmValue> for wasmtime::Val {
     fn from(val: WasmValue) -> Self {
         match val {
@@ -700,7 +701,7 @@ impl From<WasmValue> for wasmtime::Val {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "std"))]
+#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
 impl<'a> TryFrom<&'a wasmtime::Val> for WasmValue {
     type Error = UnsupportedTypeError;
 
@@ -734,7 +735,7 @@ impl TryFrom<wasmi::core::ValueType> for ValueType {
     }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "std"))]
+#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
 impl TryFrom<wasmtime::ValType> for ValueType {
     type Error = UnsupportedTypeError;
 

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -64,8 +64,19 @@
 //!
 
 mod interpreter;
+
 // This list of targets matches the one in the `Cargo.toml` file.
-#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+#[cfg(all(
+    any(
+        all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux", target_os = "macos")
+        ),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "s390x", target_os = "linux")
+    ),
+    feature = "std"
+))]
 mod jit;
 
 mod tests;
@@ -99,7 +110,17 @@ pub struct VirtualMachinePrototype {
 
 #[derive(Clone)]
 enum VirtualMachinePrototypeInner {
-    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+    #[cfg(all(
+        any(
+            all(
+                target_arch = "x86_64",
+                any(target_os = "windows", target_os = "linux", target_os = "macos")
+            ),
+            all(target_arch = "aarch64", target_os = "linux"),
+            all(target_arch = "s390x", target_os = "linux")
+        ),
+        feature = "std"
+    ))]
     Jit(jit::JitPrototype),
     Interpreter(interpreter::InterpreterPrototype),
 }
@@ -113,11 +134,31 @@ impl VirtualMachinePrototype {
     pub fn new(config: Config) -> Result<Self, NewErr> {
         Ok(VirtualMachinePrototype {
             inner: match config.exec_hint {
-                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+                #[cfg(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                ))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
-                #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
+                #[cfg(not(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                )))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Interpreter(
                     interpreter::InterpreterPrototype::new(config.module_bytes, config.symbols)?,
                 ),
@@ -130,7 +171,17 @@ impl VirtualMachinePrototype {
                     )
                 }
 
-                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+                #[cfg(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                ))]
                 ExecHint::ForceWasmtime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
@@ -143,7 +194,17 @@ impl VirtualMachinePrototype {
     /// The global variable must be a `u32`, otherwise an error is returned.
     pub fn global_value(&mut self, name: &str) -> Result<u32, GlobalValueErr> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.global_value(name),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.global_value(name),
         }
@@ -154,7 +215,17 @@ impl VirtualMachinePrototype {
     /// `None` if there is no limit.
     pub fn memory_max_pages(&self) -> Option<HeapPages> {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.memory_max_pages(),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.memory_max_pages(),
         }
@@ -166,7 +237,17 @@ impl VirtualMachinePrototype {
     /// the actual execution..
     pub fn prepare(self) -> Prepare {
         match self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachinePrototypeInner::Jit(inner) => Prepare {
                 inner: PrepareInner::Jit(inner.prepare()),
             },
@@ -180,7 +261,17 @@ impl VirtualMachinePrototype {
 impl fmt::Debug for VirtualMachinePrototype {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachinePrototypeInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachinePrototypeInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -192,7 +283,17 @@ pub struct Prepare {
 }
 
 enum PrepareInner {
-    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+    #[cfg(all(
+        any(
+            all(
+                target_arch = "x86_64",
+                any(target_os = "windows", target_os = "linux", target_os = "macos")
+            ),
+            all(target_arch = "aarch64", target_os = "linux"),
+            all(target_arch = "s390x", target_os = "linux")
+        ),
+        feature = "std"
+    ))]
     Jit(jit::Prepare),
     Interpreter(interpreter::Prepare),
 }
@@ -202,7 +303,17 @@ impl Prepare {
     pub fn into_prototype(self) -> VirtualMachinePrototype {
         VirtualMachinePrototype {
             inner: match self.inner {
-                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+                #[cfg(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                ))]
                 PrepareInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
                 }
@@ -216,7 +327,17 @@ impl Prepare {
     /// Returns the size of the memory, in bytes.
     pub fn memory_size(&self) -> HeapPages {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Jit(inner) => inner.memory_size(),
             PrepareInner::Interpreter(inner) => inner.memory_size(),
         }
@@ -231,11 +352,41 @@ impl Prepare {
         size: u32,
     ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
         Ok(match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Interpreter(inner) => either::Right(inner.read_memory(offset, size)?),
-            #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
+            #[cfg(not(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            )))]
             PrepareInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
     }
@@ -245,7 +396,17 @@ impl Prepare {
     /// Returns an error if the range is invalid or out of range.
     pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Jit(inner) => inner.write_memory(offset, value),
             PrepareInner::Interpreter(inner) => inner.write_memory(offset, value),
         }
@@ -257,7 +418,17 @@ impl Prepare {
     /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
     pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Jit(inner) => inner.grow_memory(additional),
             PrepareInner::Interpreter(inner) => inner.grow_memory(additional),
         }
@@ -272,7 +443,17 @@ impl Prepare {
     ) -> Result<VirtualMachine, (StartErr, VirtualMachinePrototype)> {
         Ok(VirtualMachine {
             inner: match self.inner {
-                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+                #[cfg(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                ))]
                 PrepareInner::Jit(inner) => match inner.start(function_name, params) {
                     Ok(vm) => VirtualMachineInner::Jit(vm),
                     Err((err, proto)) => {
@@ -303,7 +484,17 @@ impl Prepare {
 impl fmt::Debug for Prepare {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             PrepareInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             PrepareInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -315,7 +506,17 @@ pub struct VirtualMachine {
 }
 
 enum VirtualMachineInner {
-    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+    #[cfg(all(
+        any(
+            all(
+                target_arch = "x86_64",
+                any(target_os = "windows", target_os = "linux", target_os = "macos")
+            ),
+            all(target_arch = "aarch64", target_os = "linux"),
+            all(target_arch = "s390x", target_os = "linux")
+        ),
+        feature = "std"
+    ))]
     Jit(jit::Jit),
     Interpreter(interpreter::Interpreter),
 }
@@ -330,7 +531,17 @@ impl VirtualMachine {
     /// that call.
     pub fn run(&mut self, value: Option<WasmValue>) -> Result<ExecOutcome, RunErr> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => inner.run(value),
             VirtualMachineInner::Interpreter(inner) => inner.run(value),
         }
@@ -341,7 +552,17 @@ impl VirtualMachine {
     /// > **Note**: This can change over time if the Wasm code uses the `grow` opcode.
     pub fn memory_size(&self) -> HeapPages {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => inner.memory_size(),
             VirtualMachineInner::Interpreter(inner) => inner.memory_size(),
         }
@@ -356,13 +577,43 @@ impl VirtualMachine {
         size: u32,
     ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
         Ok(match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Interpreter(inner) => {
                 either::Right(inner.read_memory(offset, size)?)
             }
-            #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
+            #[cfg(not(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            )))]
             VirtualMachineInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
     }
@@ -372,7 +623,17 @@ impl VirtualMachine {
     /// Returns an error if the range is invalid or out of range.
     pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => inner.write_memory(offset, value),
             VirtualMachineInner::Interpreter(inner) => inner.write_memory(offset, value),
         }
@@ -384,7 +645,17 @@ impl VirtualMachine {
     /// of time by using [`VirtualMachinePrototype::memory_max_pages`].
     pub fn grow_memory(&mut self, additional: HeapPages) -> Result<(), OutOfBoundsError> {
         match &mut self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => inner.grow_memory(additional),
             VirtualMachineInner::Interpreter(inner) => inner.grow_memory(additional),
         }
@@ -394,7 +665,17 @@ impl VirtualMachine {
     pub fn into_prototype(self) -> VirtualMachinePrototype {
         VirtualMachinePrototype {
             inner: match self.inner {
-                #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+                #[cfg(all(
+                    any(
+                        all(
+                            target_arch = "x86_64",
+                            any(target_os = "windows", target_os = "linux", target_os = "macos")
+                        ),
+                        all(target_arch = "aarch64", target_os = "linux"),
+                        all(target_arch = "s390x", target_os = "linux")
+                    ),
+                    feature = "std"
+                ))]
                 VirtualMachineInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
                 }
@@ -409,7 +690,17 @@ impl VirtualMachine {
 impl fmt::Debug for VirtualMachine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inner {
-            #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+            #[cfg(all(
+                any(
+                    all(
+                        target_arch = "x86_64",
+                        any(target_os = "windows", target_os = "linux", target_os = "macos")
+                    ),
+                    all(target_arch = "aarch64", target_os = "linux"),
+                    all(target_arch = "s390x", target_os = "linux")
+                ),
+                feature = "std"
+            ))]
             VirtualMachineInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachineInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
         }
@@ -436,8 +727,31 @@ pub enum ExecHint {
     /// Forces using the `wasmtime` backend.
     ///
     /// This variant is useful for testing purposes.
-    #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
-    #[cfg_attr(docsrs, doc(cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))))]
+    #[cfg(all(
+        any(
+            all(
+                target_arch = "x86_64",
+                any(target_os = "windows", target_os = "linux", target_os = "macos")
+            ),
+            all(target_arch = "aarch64", target_os = "linux"),
+            all(target_arch = "s390x", target_os = "linux")
+        ),
+        feature = "std"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            any(
+                all(
+                    target_arch = "x86_64",
+                    any(target_os = "windows", target_os = "linux", target_os = "macos")
+                ),
+                all(target_arch = "aarch64", target_os = "linux"),
+                all(target_arch = "s390x", target_os = "linux")
+            ),
+            feature = "std"
+        )))
+    )]
     ForceWasmtime,
 }
 
@@ -451,11 +765,31 @@ impl ExecHint {
 
     /// Returns `ForceWasmtime` if it is available on the current platform, and `None` otherwise.
     pub fn force_wasmtime_if_available() -> Option<ExecHint> {
-        #[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+        #[cfg(all(
+            any(
+                all(
+                    target_arch = "x86_64",
+                    any(target_os = "windows", target_os = "linux", target_os = "macos")
+                ),
+                all(target_arch = "aarch64", target_os = "linux"),
+                all(target_arch = "s390x", target_os = "linux")
+            ),
+            feature = "std"
+        ))]
         fn value() -> Option<ExecHint> {
             Some(ExecHint::ForceWasmtime)
         }
-        #[cfg(not(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std")))]
+        #[cfg(not(all(
+            any(
+                all(
+                    target_arch = "x86_64",
+                    any(target_os = "windows", target_os = "linux", target_os = "macos")
+                ),
+                all(target_arch = "aarch64", target_os = "linux"),
+                all(target_arch = "s390x", target_os = "linux")
+            ),
+            feature = "std"
+        )))]
         fn value() -> Option<ExecHint> {
             None
         }
@@ -583,7 +917,17 @@ impl<'a> TryFrom<&'a wasmi::FuncType> for Signature {
     }
 }
 
-#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+#[cfg(all(
+    any(
+        all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux", target_os = "macos")
+        ),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "s390x", target_os = "linux")
+    ),
+    feature = "std"
+))]
 impl<'a> TryFrom<&'a wasmtime::FuncType> for Signature {
     type Error = UnsupportedTypeError;
 
@@ -691,7 +1035,17 @@ impl From<WasmValue> for wasmi::Value {
     }
 }
 
-#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+#[cfg(all(
+    any(
+        all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux", target_os = "macos")
+        ),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "s390x", target_os = "linux")
+    ),
+    feature = "std"
+))]
 impl From<WasmValue> for wasmtime::Val {
     fn from(val: WasmValue) -> Self {
         match val {
@@ -701,7 +1055,17 @@ impl From<WasmValue> for wasmtime::Val {
     }
 }
 
-#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+#[cfg(all(
+    any(
+        all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux", target_os = "macos")
+        ),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "s390x", target_os = "linux")
+    ),
+    feature = "std"
+))]
 impl<'a> TryFrom<&'a wasmtime::Val> for WasmValue {
     type Error = UnsupportedTypeError;
 
@@ -735,7 +1099,17 @@ impl TryFrom<wasmi::core::ValueType> for ValueType {
     }
 }
 
-#[cfg(all(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")), feature = "std"))]
+#[cfg(all(
+    any(
+        all(
+            target_arch = "x86_64",
+            any(target_os = "windows", target_os = "linux", target_os = "macos")
+        ),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "s390x", target_os = "linux")
+    ),
+    feature = "std"
+))]
 impl TryFrom<wasmtime::ValType> for ValueType {
     type Error = UnsupportedTypeError;
 


### PR DESCRIPTION
Fix #426 

The list of platforms on which `wasmtime` is enabled now matches the supported platforms found here: https://docs.wasmtime.dev/stability-tiers.html

I understand that this big conditional compilation directive is hard to read, but there's no better way to do it as far as I know.
