### PR TITLE
Pass a concrete `Platform` around the light client

### DIFF
--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -28,17 +28,18 @@ fn main() {
     // example, we provide `AsyncStdTcpWebSocket`, which are the "plug and play" default platform.
     // Any advance usage, such as embedding a client in WebAssembly, will likely require a custom
     // implementation of these bindings.
-    let mut client = smoldot_light::Client::<
+    let mut client = smoldot_light::Client::new(
         smoldot_light::platform::async_std::AsyncStdTcpWebSocket,
-    >::new(smoldot_light::ClientConfig {
-        // The smoldot client will need to spawn tasks that run in the background. In order to do
-        // so, we need to provide a "tasks spawner".
-        tasks_spawner: Box::new(move |_name, task| {
-            async_std::task::spawn(task);
-        }),
-        client_name: env!("CARGO_PKG_NAME").into(),
-        client_version: env!("CARGO_PKG_VERSION").into(),
-    });
+        smoldot_light::ClientConfig {
+            // The smoldot client will need to spawn tasks that run in the background. In order to do
+            // so, we need to provide a "tasks spawner".
+            tasks_spawner: Box::new(move |_name, task| {
+                async_std::task::spawn(task);
+            }),
+            client_name: env!("CARGO_PKG_NAME").into(),
+            client_version: env!("CARGO_PKG_VERSION").into(),
+        },
+    );
 
     // Ask the client to connect to a chain.
     let smoldot_light::AddChainSuccess {

--- a/light-base/src/database.rs
+++ b/light-base/src/database.rs
@@ -57,7 +57,7 @@ pub struct DatabaseContent {
 ///
 /// The returned string is guaranteed to not exceed `max_size` bytes. A truncated or invalid
 /// database is intentionally returned if `max_size` is too low to fit all the information.
-pub async fn encode_database<TPlat: platform::Platform>(
+pub async fn encode_database<TPlat: platform::PlatformRef>(
     network_service: &network_service::NetworkService<TPlat>,
     sync_service: &sync_service::SyncService<TPlat>,
     genesis_block_hash: &[u8; 32],

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -271,6 +271,9 @@ pub struct ServicePrototype {
 
 /// Configuration for a JSON-RPC service.
 pub struct StartConfig<'a, TPlat: Platform> {
+    /// Access to the platform's capabilities.
+    pub platform: TPlat,
+
     /// Closure that spawns background tasks.
     pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
 

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -40,7 +40,7 @@
 mod background;
 
 use crate::{
-    network_service, platform::Platform, runtime_service, sync_service, transactions_service,
+    network_service, platform::PlatformRef, runtime_service, sync_service, transactions_service,
 };
 
 use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
@@ -270,7 +270,7 @@ pub struct ServicePrototype {
 }
 
 /// Configuration for a JSON-RPC service.
-pub struct StartConfig<'a, TPlat: Platform> {
+pub struct StartConfig<'a, TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
     pub platform: TPlat,
 
@@ -325,7 +325,7 @@ pub struct StartConfig<'a, TPlat: Platform> {
 
 impl ServicePrototype {
     /// Consumes this prototype and starts the service through [`StartConfig::tasks_executor`].
-    pub fn start<TPlat: Platform>(self, config: StartConfig<'_, TPlat>) {
+    pub fn start<TPlat: PlatformRef>(self, config: StartConfig<'_, TPlat>) {
         background::start(
             self.log_target.clone(),
             self.requests_subscriptions.clone(),

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    network_service, platform::Platform, runtime_service, sync_service, transactions_service,
+    network_service, platform::PlatformRef, runtime_service, sync_service, transactions_service,
 };
 
 use super::StartConfig;
@@ -50,7 +50,7 @@ mod state_chain;
 mod transactions;
 
 /// Fields used to process JSON-RPC requests in the background.
-struct Background<TPlat: Platform> {
+struct Background<TPlat: PlatformRef> {
     /// Target to use for all the logs.
     log_target: String,
 
@@ -215,7 +215,7 @@ struct Cache {
         lru::LruCache<([u8; 32], Option<methods::HexString>), Vec<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 
-pub(super) fn start<TPlat: Platform>(
+pub(super) fn start<TPlat: PlatformRef>(
     log_target: String,
     requests_subscriptions: Arc<requests_subscriptions::RequestsSubscriptions<SubscriptionMessage>>,
     mut config: StartConfig<'_, TPlat>,
@@ -398,7 +398,7 @@ pub(super) fn start<TPlat: Platform>(
     debug_assert!(background_abort_registrations.next().is_none());
 }
 
-impl<TPlat: Platform> Background<TPlat> {
+impl<TPlat: PlatformRef> Background<TPlat> {
     /// Pulls one request from the inner state machine, and processes it.
     async fn handle_request(self: &Arc<Self>) {
         let (json_rpc_request, state_machine_request_id) =

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -19,7 +19,7 @@
 
 use super::{Background, SubscriptionMessage};
 
-use crate::{platform::Platform, runtime_service, sync_service};
+use crate::{platform::PlatformRef, runtime_service, sync_service};
 
 use alloc::{
     borrow::ToOwned as _,
@@ -44,7 +44,7 @@ use smoldot::{
     network::protocol,
 };
 
-impl<TPlat: Platform> Background<TPlat> {
+impl<TPlat: PlatformRef> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_call`].
     pub(super) async fn chain_head_call(
         self: &Arc<Self>,
@@ -692,7 +692,7 @@ fn convert_runtime_spec(
     }
 }
 
-struct ChainHeadFollowTask<TPlat: Platform> {
+struct ChainHeadFollowTask<TPlat: PlatformRef> {
     /// Tree of hashes of all the current non-finalized blocks. This includes unpinned blocks.
     non_finalized_blocks: fork_tree::ForkTree<[u8; 32]>,
 
@@ -706,7 +706,7 @@ struct ChainHeadFollowTask<TPlat: Platform> {
     sync_service: Arc<sync_service::SyncService<TPlat>>,
 }
 
-enum Subscription<TPlat: Platform> {
+enum Subscription<TPlat: PlatformRef> {
     RuntimeUpdates {
         notifications: runtime_service::Subscription<TPlat>,
         subscription_id: runtime_service::SubscriptionId,
@@ -715,7 +715,7 @@ enum Subscription<TPlat: Platform> {
     NoRuntimeUpdates(mpsc::Receiver<sync_service::Notification>),
 }
 
-impl<TPlat: Platform> ChainHeadFollowTask<TPlat> {
+impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
     async fn run(
         mut self,
         requests_subscriptions: Arc<

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -17,7 +17,7 @@
 
 //! All JSON-RPC method handlers that do nothing but return a value already found in the node.
 
-use super::{Background, Platform};
+use super::{Background, PlatformRef};
 
 use alloc::{borrow::Cow, format, string::ToString as _, sync::Arc, vec::Vec};
 use core::num::NonZeroUsize;
@@ -27,7 +27,7 @@ use smoldot::{
     network::protocol,
 };
 
-impl<TPlat: Platform> Background<TPlat> {
+impl<TPlat: PlatformRef> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::chain_getFinalizedHead`].
     pub(super) async fn chain_get_finalized_head(
         self: &Arc<Self>,

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -17,7 +17,7 @@
 
 //! All legacy JSON-RPC method handlers that relate to the chain or the storage.
 
-use super::{Background, Platform, SubscriptionMessage};
+use super::{Background, PlatformRef, SubscriptionMessage};
 
 use crate::runtime_service;
 
@@ -44,7 +44,7 @@ use smoldot::{
 
 mod sub_utils;
 
-impl<TPlat: Platform> Background<TPlat> {
+impl<TPlat: PlatformRef> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::system_accountNextIndex`].
     pub(super) async fn account_next_index(
         self: &Arc<Self>,

--- a/light-base/src/json_rpc_service/background/state_chain/sub_utils.rs
+++ b/light-base/src/json_rpc_service/background/state_chain/sub_utils.rs
@@ -19,7 +19,7 @@
 //! by the JSON-RPC service.
 
 use crate::{
-    platform::Platform,
+    platform::PlatformRef,
     runtime_service::{Notification, RuntimeError, RuntimeService},
 };
 
@@ -37,7 +37,7 @@ use smoldot::{executor, header};
 /// The stream can generate an `Err` if the runtime in the best block is invalid.
 ///
 /// The stream is infinite. In other words it is guaranteed to never return `None`.
-pub async fn subscribe_runtime_version<TPlat: Platform>(
+pub async fn subscribe_runtime_version<TPlat: PlatformRef>(
     runtime_service: &Arc<RuntimeService<TPlat>>,
 ) -> (
     Result<executor::CoreVersion, RuntimeError>,
@@ -223,7 +223,7 @@ pub async fn subscribe_runtime_version<TPlat: Platform>(
 ///
 /// This function only returns once the runtime of the current finalized block is known. This
 /// might take a long time.
-pub async fn subscribe_finalized<TPlat: Platform>(
+pub async fn subscribe_finalized<TPlat: PlatformRef>(
     runtime_service: &Arc<RuntimeService<TPlat>>,
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {
@@ -306,7 +306,7 @@ pub async fn subscribe_finalized<TPlat: Platform>(
 ///
 /// This function only returns once the runtime of the current best block is known. This might
 /// take a long time.
-pub async fn subscribe_best<TPlat: Platform>(
+pub async fn subscribe_best<TPlat: PlatformRef>(
     runtime_service: &Arc<RuntimeService<TPlat>>,
 ) -> (Vec<u8>, stream::BoxStream<'static, Vec<u8>>) {
     let mut master_stream = stream::unfold(runtime_service.clone(), |runtime_service| async move {

--- a/light-base/src/json_rpc_service/background/transactions.rs
+++ b/light-base/src/json_rpc_service/background/transactions.rs
@@ -17,7 +17,7 @@
 
 //! All JSON-RPC method handlers that relate to transactions.
 
-use super::{Background, Platform, SubscriptionMessage};
+use super::{Background, PlatformRef, SubscriptionMessage};
 
 use crate::transactions_service;
 
@@ -25,7 +25,7 @@ use alloc::{borrow::ToOwned as _, str, string::ToString as _, sync::Arc, vec::Ve
 use futures::prelude::*;
 use smoldot::json_rpc::{self, methods, requests_subscriptions};
 
-impl<TPlat: Platform> Background<TPlat> {
+impl<TPlat: PlatformRef> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::author_pendingExtrinsics`].
     pub(super) async fn author_pending_extrinsics(
         self: &Arc<Self>,

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -159,6 +159,9 @@ pub struct ChainId(usize);
 
 /// Holds a list of chains, connections, and JSON-RPC services.
 pub struct Client<TPlat: platform::Platform, TChain = ()> {
+    /// Access to the platform capabilities.
+    platform: TPlat,
+
     /// Tasks can be spawned by calling this function. The first parameter is the name of the task
     /// used for debugging purposes.
     spawn_new_task: Arc<dyn Fn(String, future::BoxFuture<'static, ()>) + Send + Sync>,
@@ -314,9 +317,10 @@ impl JsonRpcResponses {
 
 impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
     /// Initializes the smoldot client.
-    pub fn new(config: ClientConfig) -> Self {
+    pub fn new(platform: TPlat, config: ClientConfig) -> Self {
         let expected_chains = 8;
         Client {
+            platform,
             spawn_new_task: config.tasks_spawner.into(),
             public_api_chains: slab::Slab::with_capacity(expected_chains),
             chains_by_key: HashMap::with_capacity_and_hasher(expected_chains, Default::default()),
@@ -639,6 +643,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                 // Spawn a background task that initializes the services of the new chain and
                 // yields a `ChainServices`.
                 let running_chain_init_future: future::RemoteHandle<ChainServices<TPlat>> = {
+                    let platform = self.platform.clone();
                     let spawn_new_task = self.spawn_new_task.clone();
                     let chain_spec = chain_spec.clone(); // TODO: quite expensive
                     let log_name = log_name.clone();
@@ -671,6 +676,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
 
                         let running_chain = start_services(
                             log_name.clone(),
+                            &platform,
                             spawn_new_task,
                             chain_information,
                             genesis_block_header
@@ -793,17 +799,19 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                 future::MaybeDone::Gone => unreachable!(),
             };
 
+            let platform = self.platform.clone();
+
             async move {
                 // Wait for the chain to finish initializing to proceed.
                 (&mut running_chain_init).await;
                 let running_chain = Pin::new(&mut running_chain_init).take_output().unwrap();
                 running_chain
                     .network_service
-                    .discover(&TPlat::now(), 0, checkpoint_nodes, false)
+                    .discover(&platform.now(), 0, checkpoint_nodes, false)
                     .await;
                 running_chain
                     .network_service
-                    .discover(&TPlat::now(), 0, bootstrap_nodes, true)
+                    .discover(&platform.now(), 0, bootstrap_nodes, true)
                     .await;
             }
             .boxed()
@@ -830,6 +838,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
             let spawn_new_task = self.spawn_new_task.clone();
             let system_name = self.client_name.clone();
             let system_version = self.client_version.clone();
+            let platform = self.platform.clone();
 
             let init_future = async move {
                 // Wait for the chain to finish initializing before starting the JSON-RPC service.
@@ -837,6 +846,7 @@ impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
                 let running_chain = Pin::new(&mut running_chain_init).take_output().unwrap();
 
                 service_starter.start(json_rpc_service::StartConfig {
+                    platform,
                     tasks_executor: Box::new(move |name, task| spawn_new_task(name, task)),
                     sync_service: running_chain.sync_service,
                     network_service: (running_chain.network_service, 0), // TODO: 0?
@@ -997,6 +1007,7 @@ pub enum AddChainError {
 /// other services will later shut down as well.
 async fn start_services<TPlat: platform::Platform>(
     log_name: String,
+    platform: &TPlat,
     spawn_new_task: Arc<
         dyn Fn(String, Pin<Box<dyn Future<Output = ()> + Send + 'static>>) + Send + Sync,
     >,
@@ -1015,6 +1026,7 @@ async fn start_services<TPlat: platform::Platform>(
     // The network service is responsible for connecting to the peer-to-peer network.
     let (network_service, mut network_event_receivers) =
         network_service::NetworkService::new(network_service::Config {
+            platform: platform.clone(),
             tasks_executor: Box::new({
                 let spawn_new_task = spawn_new_task.clone();
                 move |name, fut| spawn_new_task(name, fut)
@@ -1053,6 +1065,7 @@ async fn start_services<TPlat: platform::Platform>(
         // chain.
         let sync_service = Arc::new(
             sync_service::SyncService::new(sync_service::Config {
+                platform: platform.clone(),
                 log_name: log_name.clone(),
                 chain_information: chain_information.clone(),
                 block_number_bytes: usize::from(chain_spec.block_number_bytes()),
@@ -1076,6 +1089,7 @@ async fn start_services<TPlat: platform::Platform>(
         let runtime_service = Arc::new(
             runtime_service::RuntimeService::new(runtime_service::Config {
                 log_name: log_name.clone(),
+                platform: platform.clone(),
                 tasks_executor: Box::new({
                     let spawn_new_task = spawn_new_task.clone();
                     move |name, fut| spawn_new_task(name, fut)
@@ -1098,6 +1112,7 @@ async fn start_services<TPlat: platform::Platform>(
                 log_name: log_name.clone(),
                 chain_information: chain_information.clone(),
                 block_number_bytes: usize::from(chain_spec.block_number_bytes()),
+                platform: platform.clone(),
                 tasks_executor: Box::new({
                     let spawn_new_task = spawn_new_task.clone();
                     move |name, fut| spawn_new_task(name, fut)
@@ -1114,6 +1129,7 @@ async fn start_services<TPlat: platform::Platform>(
         let runtime_service = Arc::new(
             runtime_service::RuntimeService::new(runtime_service::Config {
                 log_name: log_name.clone(),
+                platform: platform.clone(),
                 tasks_executor: Box::new({
                     let spawn_new_task = spawn_new_task.clone();
                     move |name, fut| spawn_new_task(name, fut)
@@ -1134,6 +1150,7 @@ async fn start_services<TPlat: platform::Platform>(
     let transactions_service = Arc::new(
         transactions_service::TransactionsService::new(transactions_service::Config {
             log_name,
+            platform: platform.clone(),
             tasks_executor: Box::new(move |name, fut| spawn_new_task(name, fut)),
             sync_service: sync_service.clone(),
             runtime_service: runtime_service.clone(),

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! The [`Client`] contains two generic parameters:
 //!
-//! - An implementation of the [`platform::Platform`] trait. This is how the client will
+//! - An implementation of the [`platform::PlatformRef`] trait. This is how the client will
 //! communicate with the outside, such as getting the current time.
 //! - An opaque user data. If you do not use this, you can simply use `()`.
 //!
@@ -158,7 +158,7 @@ pub struct AddChainConfig<'a, TChain, TRelays> {
 pub struct ChainId(usize);
 
 /// Holds a list of chains, connections, and JSON-RPC services.
-pub struct Client<TPlat: platform::Platform, TChain = ()> {
+pub struct Client<TPlat: platform::PlatformRef, TChain = ()> {
     /// Access to the platform capabilities.
     platform: TPlat,
 
@@ -230,7 +230,7 @@ struct ChainKey {
     fork_id: Option<String>,
 }
 
-struct RunningChain<TPlat: platform::Platform> {
+struct RunningChain<TPlat: platform::PlatformRef> {
     /// Services that are dedicated to this chain. Wrapped within a `MaybeDone` because the
     /// initialization is performed asynchronously.
     services: future::MaybeDone<future::Shared<future::RemoteHandle<ChainServices<TPlat>>>>,
@@ -244,7 +244,7 @@ struct RunningChain<TPlat: platform::Platform> {
     num_references: NonZeroU32,
 }
 
-struct ChainServices<TPlat: platform::Platform> {
+struct ChainServices<TPlat: platform::PlatformRef> {
     network_service: Arc<network_service::NetworkService<TPlat>>,
     network_identity: peer_id::PeerId,
     sync_service: Arc<sync_service::SyncService<TPlat>>,
@@ -254,7 +254,7 @@ struct ChainServices<TPlat: platform::Platform> {
     block_number_bytes: usize,
 }
 
-impl<TPlat: platform::Platform> Clone for ChainServices<TPlat> {
+impl<TPlat: platform::PlatformRef> Clone for ChainServices<TPlat> {
     fn clone(&self) -> Self {
         ChainServices {
             network_service: self.network_service.clone(),
@@ -315,7 +315,7 @@ impl JsonRpcResponses {
     }
 }
 
-impl<TPlat: platform::Platform, TChain> Client<TPlat, TChain> {
+impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
     /// Initializes the smoldot client.
     pub fn new(platform: TPlat, config: ClientConfig) -> Self {
         let expected_chains = 8;
@@ -1005,7 +1005,7 @@ pub enum AddChainError {
 ///
 /// Returns some of the services that have been started. If these service get shut down, all the
 /// other services will later shut down as well.
-async fn start_services<TPlat: platform::Platform>(
+async fn start_services<TPlat: platform::PlatformRef>(
     log_name: String,
     platform: &TPlat,
     spawn_new_task: Arc<

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Shared;
-use crate::platform::{Platform, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
+use crate::platform::{PlatformRef, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
 
 use alloc::{string::ToString as _, sync::Arc, vec, vec::Vec};
 use core::{cmp, iter, pin::Pin};
@@ -28,7 +28,7 @@ use smoldot::{
 
 /// Asynchronous task managing a specific connection, including the connection process and the
 /// processing of the connection after it's been open.
-pub(super) async fn connection_task<TPlat: Platform>(
+pub(super) async fn connection_task<TPlat: PlatformRef>(
     start_connect: service::StartConnect<TPlat::Instant>,
     shared: Arc<Shared<TPlat>>,
     connection_to_coordinator_tx: mpsc::Sender<(
@@ -198,7 +198,7 @@ pub(super) async fn connection_task<TPlat: Platform>(
 
 /// Asynchronous task managing a specific single-stream connection after it's been open.
 // TODO: a lot of logging disappeared
-async fn single_stream_connection_task<TPlat: Platform>(
+async fn single_stream_connection_task<TPlat: PlatformRef>(
     mut connection: TPlat::Stream,
     shared: Arc<Shared<TPlat>>,
     connection_id: service::ConnectionId,
@@ -404,7 +404,7 @@ async fn single_stream_connection_task<TPlat: Platform>(
 /// >           buffer to not go over the frame size limit of WebRTC. It can easily be made more
 /// >           general-purpose.
 // TODO: a lot of logging disappeared
-async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
+async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     mut connection: TPlat::Connection,
     shared: Arc<Shared<TPlat>>,
     connection_id: service::ConnectionId,
@@ -418,7 +418,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();
 
-    // Number of substreams that are currently being opened by the `Platform` implementation
+    // Number of substreams that are currently being opened by the `PlatformRef` implementation
     // and that the `connection_task` state machine isn't aware of yet.
     let mut pending_opening_out_substreams = 0;
     // Newly-open substream that has just been yielded by the connection.

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::Shared;
-use crate::platform::{PlatformRef, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
+use crate::platform::{PlatformConnection, PlatformRef, PlatformSubstreamDirection, ReadBuffer};
 
 use alloc::{string::ToString as _, sync::Arc, vec, vec::Vec};
 use core::{cmp, iter, pin::Pin};

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -46,13 +46,15 @@ pub(super) async fn connection_task<TPlat: Platform>(
             start_connect.id, start_connect.expected_peer_id,
             start_connect.multiaddr
         );
-        TPlat::connect(&start_connect.multiaddr.to_string())
+        shared
+            .platform
+            .connect(&start_connect.multiaddr.to_string())
     };
 
     let socket = {
         let socket = socket.fuse();
         futures::pin_mut!(socket);
-        let mut timeout = TPlat::sleep_until(start_connect.timeout).fuse();
+        let mut timeout = shared.platform.sleep_until(start_connect.timeout).fuse();
 
         let result = futures::select! {
             _ = timeout => Err(None),
@@ -107,8 +109,11 @@ pub(super) async fn connection_task<TPlat: Platform>(
                 );
 
                 for chain_index in 0..guarded.network.num_chains() {
-                    guarded
-                        .unassign_slot_and_ban(chain_index, start_connect.expected_peer_id.clone());
+                    guarded.unassign_slot_and_ban(
+                        &shared.platform,
+                        chain_index,
+                        start_connect.expected_peer_id.clone(),
+                    );
                 }
 
                 // We wake up the background task so that the slot can potentially be
@@ -228,16 +233,16 @@ async fn single_stream_connection_task<TPlat: Platform>(
             connection_task.inject_coordinator_message(message);
         }
 
-        let now = TPlat::now();
+        let now = shared.platform.now();
 
         let (read_bytes, written_bytes, wake_up_after) = if !connection_task.is_reset_called() {
             let write_side_was_open = write_buffer.is_some();
             let writable_bytes = cmp::min(
-                TPlat::writable_bytes(&mut connection),
+                shared.platform.writable_bytes(&mut connection),
                 write_buffer.as_ref().map_or(0, |b| b.len()),
             );
 
-            let incoming_buffer = match TPlat::read_buffer(&mut connection) {
+            let incoming_buffer = match shared.platform.read_buffer(&mut connection) {
                 ReadBuffer::Reset => {
                     connection_task.reset();
                     continue;
@@ -275,17 +280,19 @@ async fn single_stream_connection_task<TPlat: Platform>(
             if written_bytes != 0 {
                 // `written_bytes`non-zero when the writing side has been closed before
                 // doesn't make sense and would indicate a bug in the networking code
-                TPlat::send(
+                shared.platform.send(
                     &mut connection,
                     &write_buffer.as_mut().unwrap()[..written_bytes],
                 );
             }
             if write_size_closed {
-                TPlat::close_send(&mut connection);
+                shared.platform.close_send(&mut connection);
                 debug_assert!(write_buffer.is_some());
                 write_buffer = None;
             }
-            TPlat::advance_read_cursor(&mut connection, read_bytes);
+            shared
+                .platform
+                .advance_read_cursor(&mut connection, read_bytes);
 
             (read_bytes, written_bytes, wake_up_after)
         } else {
@@ -350,7 +357,7 @@ async fn single_stream_connection_task<TPlat: Platform>(
             // As documented in `update_stream`, we call this function one last time in order to
             // give the possibility to the implementation to process closing the writing side
             // before the connection is dropped.
-            TPlat::update_stream(&mut connection).await;
+            shared.platform.update_stream(&mut connection).await;
             return;
         }
 
@@ -366,7 +373,7 @@ async fn single_stream_connection_task<TPlat: Platform>(
         let poll_after = if let Some(wake_up) = wake_up_after {
             if wake_up > now {
                 let dur = wake_up - now;
-                future::Either::Left(TPlat::sleep(dur))
+                future::Either::Left(shared.platform.sleep(dur))
             } else {
                 // "Wake up" immediately.
                 continue;
@@ -376,7 +383,7 @@ async fn single_stream_connection_task<TPlat: Platform>(
         }
         .fuse();
         // Future that is woken up when new data is ready on the socket or more data is writable.
-        let stream_update = TPlat::update_stream(&mut connection);
+        let stream_update = shared.platform.update_stream(&mut connection);
         // Future that is woken up when a new message is coming from the coordinator.
         let message_from_coordinator = Pin::new(&mut coordinator_to_connection).peek();
 
@@ -437,7 +444,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
             .desired_outbound_substreams()
             .saturating_sub(pending_opening_out_substreams)
         {
-            TPlat::open_out_substream(&mut connection);
+            shared.platform.open_out_substream(&mut connection);
             pending_opening_out_substreams += 1;
         }
 
@@ -464,7 +471,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
             connection_task.inject_coordinator_message(message);
         }
 
-        let now = TPlat::now();
+        let now = shared.platform.now();
 
         // When reading/writing substreams, the substream can ask to be woken up after a certain
         // time. This variable stores the earliest time when we should be waking up.
@@ -476,9 +483,12 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
             loop {
                 let (substream, write_side_was_open) = &mut open_substreams[substream_id];
 
-                let writable_bytes = cmp::min(TPlat::writable_bytes(substream), write_buffer.len());
+                let writable_bytes = cmp::min(
+                    shared.platform.writable_bytes(substream),
+                    write_buffer.len(),
+                );
 
-                let incoming_buffer = match TPlat::read_buffer(substream) {
+                let incoming_buffer = match shared.platform.read_buffer(substream) {
                     ReadBuffer::Open(buf) => buf,
                     ReadBuffer::Closed => panic!(), // Forbidden for WebRTC.
                     ReadBuffer::Reset => {
@@ -519,13 +529,15 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
 
                 // Now update the connection.
                 if written_bytes != 0 {
-                    TPlat::send(substream, &write_buffer[..written_bytes]);
+                    shared
+                        .platform
+                        .send(substream, &write_buffer[..written_bytes]);
                 }
                 if must_close_writing_side {
-                    TPlat::close_send(substream);
+                    shared.platform.close_send(substream);
                     *write_side_was_open = false;
                 }
-                TPlat::advance_read_cursor(substream, read_bytes);
+                shared.platform.advance_read_cursor(substream, read_bytes);
 
                 // If the `connection_task` requires this substream to be killed, we drop the
                 // `Stream` object.
@@ -609,7 +621,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
         let mut poll_after = if let Some(wake_up) = wake_up_after.clone() {
             if wake_up > now {
                 let dur = wake_up - now;
-                future::Either::Left(TPlat::sleep(dur))
+                future::Either::Left(shared.platform.sleep(dur))
             } else {
                 // "Wake up" immediately.
                 continue;
@@ -621,11 +633,9 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
 
         // Future that is woken up when new data is ready on any of the streams.
         let streams_updated = iter::once(future::Either::Right(future::pending()))
-            .chain(
-                open_substreams
-                    .iter_mut()
-                    .map(|(_, (stream, _))| future::Either::Left(TPlat::update_stream(stream))),
-            )
+            .chain(open_substreams.iter_mut().map(|(_, (stream, _))| {
+                future::Either::Left(shared.platform.update_stream(stream))
+            }))
             .collect::<future::SelectAll<_>>();
 
         // Future that is woken up when a new message is coming from the coordinator.
@@ -635,7 +645,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: Platform>(
         debug_assert!(newly_open_substream.is_none());
         futures::select! {
             _ = message_from_coordinator => {}
-            substream = if remote_has_reset { either::Right(future::pending()) } else { either::Left(TPlat::next_substream(&mut connection)) }.fuse() => {
+            substream = if remote_has_reset { either::Right(future::pending()) } else { either::Left(shared.platform.next_substream(&mut connection)) }.fuse() => {
                 match substream {
                     Some(s) => newly_open_substream = Some(s),
                     None => {

--- a/light-base/src/platform/async_std.rs
+++ b/light-base/src/platform/async_std.rs
@@ -18,7 +18,9 @@
 #![cfg(feature = "std")]
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
-use super::{ConnectError, PlatformRef, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
+use super::{
+    ConnectError, PlatformConnection, PlatformRef, PlatformSubstreamDirection, ReadBuffer,
+};
 
 use alloc::collections::VecDeque;
 use core::{ops, pin::Pin, str, task::Poll, time::Duration};

--- a/light-base/src/platform/async_std.rs
+++ b/light-base/src/platform/async_std.rs
@@ -34,6 +34,7 @@ use std::{
 
 /// Implementation of the [`Platform`] trait that uses the `async-std` library and provides TCP
 /// and WebSocket connections.
+#[derive(Clone)]
 pub struct AsyncStdTcpWebSocket;
 
 impl Platform for AsyncStdTcpWebSocket {
@@ -50,30 +51,30 @@ impl Platform for AsyncStdTcpWebSocket {
     type NextSubstreamFuture<'a> =
         future::Pending<Option<(Self::Stream, PlatformSubstreamDirection)>>;
 
-    fn now_from_unix_epoch() -> Duration {
+    fn now_from_unix_epoch(&self) -> Duration {
         // Intentionally panic if the time is configured earlier than the UNIX EPOCH.
         std::time::UNIX_EPOCH.elapsed().unwrap()
     }
 
-    fn now() -> Self::Instant {
+    fn now(&self) -> Self::Instant {
         std::time::Instant::now()
     }
 
-    fn sleep(duration: Duration) -> Self::Delay {
+    fn sleep(&self, duration: Duration) -> Self::Delay {
         async_std::task::sleep(duration).boxed()
     }
 
-    fn sleep_until(when: Self::Instant) -> Self::Delay {
+    fn sleep_until(&self, when: Self::Instant) -> Self::Delay {
         let duration = when.saturating_duration_since(std::time::Instant::now());
-        Self::sleep(duration)
+        self.sleep(duration)
     }
 
-    fn yield_after_cpu_intensive() -> Self::Yield {
+    fn yield_after_cpu_intensive(&self) -> Self::Yield {
         // No-op.
         future::ready(())
     }
 
-    fn connect(multiaddr: &str) -> Self::ConnectFuture {
+    fn connect(&self, multiaddr: &str) -> Self::ConnectFuture {
         // We simply copy the address to own it. We could be more zero-cost here, but doing so
         // would considerably complicate the implementation.
         let multiaddr = multiaddr.to_owned();
@@ -198,19 +199,19 @@ impl Platform for AsyncStdTcpWebSocket {
         })
     }
 
-    fn open_out_substream(c: &mut Self::Connection) {
+    fn open_out_substream(&self, c: &mut Self::Connection) {
         // This function can only be called with so-called "multi-stream" connections. We never
         // open such connection.
         match *c {}
     }
 
-    fn next_substream(c: &'_ mut Self::Connection) -> Self::NextSubstreamFuture<'_> {
+    fn next_substream(&self, c: &'_ mut Self::Connection) -> Self::NextSubstreamFuture<'_> {
         // This function can only be called with so-called "multi-stream" connections. We never
         // open such connection.
         match *c {}
     }
 
-    fn update_stream(stream: &'_ mut Self::Stream) -> Self::StreamUpdateFuture<'_> {
+    fn update_stream<'a>(&self, stream: &'a mut Self::Stream) -> Self::StreamUpdateFuture<'a> {
         Box::pin(future::poll_fn(|cx| {
             let Some((read_buffer, write_buffer)) = stream.buffers.as_mut() else { return Poll::Pending };
 
@@ -326,7 +327,7 @@ impl Platform for AsyncStdTcpWebSocket {
         }))
     }
 
-    fn read_buffer(stream: &mut Self::Stream) -> ReadBuffer {
+    fn read_buffer<'a>(&self, stream: &'a mut Self::Stream) -> ReadBuffer<'a> {
         match stream.buffers.as_ref().map(|(r, _)| r) {
             None => ReadBuffer::Reset,
             Some(StreamReadBuffer::Closed) => ReadBuffer::Closed,
@@ -336,7 +337,7 @@ impl Platform for AsyncStdTcpWebSocket {
         }
     }
 
-    fn advance_read_cursor(stream: &mut Self::Stream, extra_bytes: usize) {
+    fn advance_read_cursor(&self, stream: &mut Self::Stream, extra_bytes: usize) {
         let Some(StreamReadBuffer::Open { ref mut cursor, .. }) =
             stream.buffers.as_mut().map(|(r, _)| r)
         else {
@@ -348,13 +349,13 @@ impl Platform for AsyncStdTcpWebSocket {
         cursor.start += extra_bytes;
     }
 
-    fn writable_bytes(stream: &mut Self::Stream) -> usize {
+    fn writable_bytes(&self, stream: &mut Self::Stream) -> usize {
         let Some(StreamWriteBuffer::Open { ref mut buffer, must_close: false, ..}) =
             stream.buffers.as_mut().map(|(_, w)| w) else { return 0 };
         buffer.capacity() - buffer.len()
     }
 
-    fn send(stream: &mut Self::Stream, data: &[u8]) {
+    fn send(&self, stream: &mut Self::Stream, data: &[u8]) {
         debug_assert!(!data.is_empty());
 
         // Because `writable_bytes` returns 0 if the writing side is closed, and because `data`
@@ -366,7 +367,7 @@ impl Platform for AsyncStdTcpWebSocket {
         buffer.extend(data.iter().copied());
     }
 
-    fn close_send(stream: &mut Self::Stream) {
+    fn close_send(&self, stream: &mut Self::Stream) {
         // It is not illegal to call this on an already-reset stream.
         let Some((_, write_buffer)) = stream.buffers.as_mut() else { return };
 

--- a/light-base/src/platform/async_std.rs
+++ b/light-base/src/platform/async_std.rs
@@ -18,7 +18,7 @@
 #![cfg(feature = "std")]
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
-use super::{ConnectError, Platform, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
+use super::{ConnectError, PlatformRef, PlatformConnection, PlatformSubstreamDirection, ReadBuffer};
 
 use alloc::collections::VecDeque;
 use core::{ops, pin::Pin, str, task::Poll, time::Duration};
@@ -32,12 +32,12 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-/// Implementation of the [`Platform`] trait that uses the `async-std` library and provides TCP
+/// Implementation of the [`PlatformRef`] trait that uses the `async-std` library and provides TCP
 /// and WebSocket connections.
 #[derive(Clone)]
 pub struct AsyncStdTcpWebSocket;
 
-impl Platform for AsyncStdTcpWebSocket {
+impl PlatformRef for AsyncStdTcpWebSocket {
     type Delay = future::BoxFuture<'static, ()>;
     type Yield = future::Ready<()>;
     type Instant = std::time::Instant;

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -26,7 +26,7 @@
 //!
 //! Use [`SyncService::subscribe_all`] to get notified about updates to the state of the chain.
 
-use crate::{network_service, platform::Platform, runtime_service};
+use crate::{network_service, platform::PlatformRef, runtime_service};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{fmt, num::NonZeroU32, time::Duration};
@@ -47,7 +47,7 @@ mod parachain;
 mod standalone;
 
 /// Configuration for a [`SyncService`].
-pub struct Config<TPlat: Platform> {
+pub struct Config<TPlat: PlatformRef> {
     /// Name of the chain, for logging purposes.
     ///
     /// > **Note**: This name will be directly printed out. Any special character should already
@@ -80,7 +80,7 @@ pub struct Config<TPlat: Platform> {
 }
 
 /// See [`Config::parachain`].
-pub struct ConfigParachain<TPlat: Platform> {
+pub struct ConfigParachain<TPlat: PlatformRef> {
     /// Runtime service that synchronizes the relay chain of this parachain.
     pub relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
 
@@ -101,7 +101,7 @@ pub struct ConfigParachain<TPlat: Platform> {
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct BlocksRequestId(usize);
 
-pub struct SyncService<TPlat: Platform> {
+pub struct SyncService<TPlat: PlatformRef> {
     /// Sender of messages towards the background task.
     to_background: Mutex<mpsc::Sender<ToBackground>>,
 
@@ -113,7 +113,7 @@ pub struct SyncService<TPlat: Platform> {
     block_number_bytes: usize,
 }
 
-impl<TPlat: Platform> SyncService<TPlat> {
+impl<TPlat: PlatformRef> SyncService<TPlat> {
     pub async fn new(mut config: Config<TPlat>) -> Self {
         let (to_background, from_foreground) = mpsc::channel(16);
 

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -60,6 +60,9 @@ pub struct Config<TPlat: Platform> {
     /// Number of bytes of the block number in the networking protocol.
     pub block_number_bytes: usize,
 
+    /// Access to the platform's capabilities.
+    pub platform: TPlat,
+
     /// Closure that spawns background tasks.
     pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
 
@@ -121,6 +124,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                 log_target.clone(),
                 Box::pin(parachain::start_parachain(
                     log_target,
+                    config.platform,
                     config.chain_information,
                     config.block_number_bytes,
                     config_parachain.relay_chain_sync.clone(),
@@ -136,6 +140,7 @@ impl<TPlat: Platform> SyncService<TPlat> {
                 log_target.clone(),
                 Box::pin(standalone::start_standalone_chain(
                     log_target,
+                    config.platform,
                     config.chain_information,
                     config.block_number_bytes,
                     from_foreground,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::ToBackground;
-use crate::{network_service, platform::Platform, runtime_service};
+use crate::{network_service, platform::PlatformRef, runtime_service};
 
 use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
 use core::{
@@ -38,7 +38,7 @@ use smoldot::{
 };
 
 /// Starts a sync service background task to synchronize a parachain.
-pub(super) async fn start_parachain<TPlat: Platform>(
+pub(super) async fn start_parachain<TPlat: PlatformRef>(
     log_target: String,
     platform: TPlat,
     chain_information: chain::chain_information::ValidChainInformation,
@@ -98,7 +98,7 @@ pub(super) async fn start_parachain<TPlat: Platform>(
 }
 
 /// Task that is running in the background.
-struct ParachainBackgroundTask<TPlat: Platform> {
+struct ParachainBackgroundTask<TPlat: PlatformRef> {
     /// Target to use for all logs.
     log_target: String,
 
@@ -146,7 +146,7 @@ struct ParachainBackgroundTask<TPlat: Platform> {
     subscription_state: ParachainBackgroundState<TPlat>,
 }
 
-enum ParachainBackgroundState<TPlat: Platform> {
+enum ParachainBackgroundState<TPlat: PlatformRef> {
     /// Currently subscribing to the relay chain runtime service.
     NotSubscribed {
         /// List of senders that will get notified when the tree of blocks is modified.
@@ -164,7 +164,7 @@ enum ParachainBackgroundState<TPlat: Platform> {
     Subscribed(ParachainBackgroundTaskAfterSubscription<TPlat>),
 }
 
-struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
+struct ParachainBackgroundTaskAfterSubscription<TPlat: PlatformRef> {
     /// List of senders that get notified when the tree of blocks is modified.
     all_subscriptions: Vec<mpsc::Sender<super::Notification>>,
 
@@ -214,7 +214,7 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: Platform> {
     next_start_parahead_fetch: future::Either<future::Fuse<TPlat::Delay>, future::Pending<()>>,
 }
 
-impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
+impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
     async fn run(mut self) {
         loop {
             // Start fetching paraheads of new blocks whose parahead needs to be fetched.
@@ -1090,7 +1090,7 @@ impl<TPlat: Platform> ParachainBackgroundTask<TPlat> {
     }
 }
 
-async fn parahead<TPlat: Platform>(
+async fn parahead<TPlat: PlatformRef>(
     relay_chain_sync: &Arc<runtime_service::RuntimeService<TPlat>>,
     relay_chain_block_number_bytes: usize,
     subscription_id: runtime_service::SubscriptionId,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{BlockNotification, FinalizedBlockRuntime, Notification, SubscribeAll, ToBackground};
-use crate::{network_service, platform::Platform};
+use crate::{network_service, platform::PlatformRef};
 
 use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
 use core::{
@@ -35,7 +35,7 @@ use smoldot::{
 };
 
 /// Starts a sync service background task to synchronize a standalone chain (relay chain or not).
-pub(super) async fn start_standalone_chain<TPlat: Platform>(
+pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
     log_target: String,
     platform: TPlat,
     chain_information: chain::chain_information::ValidChainInformation,
@@ -361,7 +361,7 @@ pub(super) async fn start_standalone_chain<TPlat: Platform>(
     }
 }
 
-struct Task<TPlat: Platform> {
+struct Task<TPlat: PlatformRef> {
     /// Log target to use for all logs that are emitted.
     log_target: String,
 
@@ -452,7 +452,7 @@ struct Task<TPlat: Platform> {
     >,
 }
 
-impl<TPlat: Platform> Task<TPlat> {
+impl<TPlat: PlatformRef> Task<TPlat> {
     /// Starts one network request if any is necessary.
     ///
     /// Returns `true` if a request has been started.

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -58,12 +58,12 @@ pub(crate) enum Chain {
     },
 }
 
-pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
+pub(crate) fn init<TChain>(
     max_log_level: u32,
     enable_current_task: bool,
     cpu_rate_limit: u32,
     periodically_yield: bool,
-) -> Client<TPlat, TChain> {
+) -> Client<platform::Platform, TChain> {
     // Try initialize the logging and the panic hook.
     let _ = log::set_boxed_logger(Box::new(Logger)).map(|()| {
         log::set_max_level(match max_log_level {
@@ -199,13 +199,16 @@ pub(crate) fn init<TPlat: smoldot_light::platform::Platform, TChain>(
         ))
         .unwrap();
 
-    let client = smoldot_light::Client::new(smoldot_light::ClientConfig {
-        tasks_spawner: Box::new(move |name, task| {
-            new_task_tx.unbounded_send((name, task)).unwrap()
-        }),
-        client_name: env!("CARGO_PKG_NAME").into(),
-        client_version: env!("CARGO_PKG_VERSION").into(),
-    });
+    let client = smoldot_light::Client::new(
+        platform::Platform,
+        smoldot_light::ClientConfig {
+            tasks_spawner: Box::new(move |name, task| {
+                new_task_tx.unbounded_send((name, task)).unwrap()
+            }),
+            client_name: env!("CARGO_PKG_NAME").into(),
+            client_version: env!("CARGO_PKG_VERSION").into(),
+        },
+    );
 
     Client {
         smoldot: client,

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -22,7 +22,7 @@ use futures::{channel::mpsc, prelude::*};
 use smoldot::informant::BytesDisplay;
 use std::{panic, sync::atomic::Ordering, task};
 
-pub(crate) struct Client<TPlat: smoldot_light::platform::Platform, TChain> {
+pub(crate) struct Client<TPlat: smoldot_light::platform::PlatformRef, TChain> {
     pub(crate) smoldot: smoldot_light::Client<TPlat, TChain>,
 
     /// List of all chains that have been added by the user.

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -30,10 +30,10 @@ use std::{
     },
 };
 
-/// Total number of bytes that all the connections created through [`Platform`] combined have
+/// Total number of bytes that all the connections created through [`PlatformRef`] combined have
 /// received.
 pub static TOTAL_BYTES_RECEIVED: AtomicU64 = AtomicU64::new(0);
-/// Total number of bytes that all the connections created through [`Platform`] combined have
+/// Total number of bytes that all the connections created through [`PlatformRef`] combined have
 /// sent.
 pub static TOTAL_BYTES_SENT: AtomicU64 = AtomicU64::new(0);
 
@@ -41,7 +41,7 @@ pub static TOTAL_BYTES_SENT: AtomicU64 = AtomicU64::new(0);
 pub(crate) struct Platform;
 
 // TODO: this trait implementation was written before GATs were stable in Rust; now that the associated types have lifetimes, it should be possible to considerably simplify this code
-impl smoldot_light::platform::Platform for Platform {
+impl smoldot_light::platform::PlatformRef for Platform {
     type Delay = Delay;
     type Yield = Yield;
     type Instant = crate::Instant;
@@ -616,9 +616,9 @@ enum ConnectionInner {
     MultiStreamWebRtc {
         /// List of substreams that the host (i.e. JavaScript side) has reported have been opened,
         /// but that haven't been reported through
-        /// [`smoldot_light::platform::Platform::next_substream`] yet.
+        /// [`smoldot_light::platform::PlatformRef::next_substream`] yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection, u32)>,
-        /// Number of objects (connections and streams) in the [`Platform`] API that reference
+        /// Number of objects (connections and streams) in the [`PlatformRef`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.
         connection_handles_alive: u32,
         /// Multihash encoding of the TLS certificate used by the local node at the DTLS layer.
@@ -630,7 +630,7 @@ enum ConnectionInner {
     Reset {
         /// Message given by the bindings to justify the closure.
         message: String,
-        /// Number of objects (connections and streams) in the [`Platform`] API that reference
+        /// Number of objects (connections and streams) in the [`PlatformRef`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.
         connection_handles_alive: u32,
     },

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -37,6 +37,7 @@ pub static TOTAL_BYTES_RECEIVED: AtomicU64 = AtomicU64::new(0);
 /// sent.
 pub static TOTAL_BYTES_SENT: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Clone)]
 pub(crate) struct Platform;
 
 // TODO: this trait implementation was written before GATs were stable in Rust; now that the associated types have lifetimes, it should be possible to considerably simplify this code
@@ -62,7 +63,7 @@ impl smoldot_light::platform::Platform for Platform {
         )>,
     >;
 
-    fn now_from_unix_epoch() -> Duration {
+    fn now_from_unix_epoch(&self) -> Duration {
         let value = unsafe { bindings::unix_time_ms() };
         debug_assert!(value.is_finite());
         // The documentation of `now_from_unix_epoch()` mentions that it's ok to panic if we're
@@ -74,19 +75,19 @@ impl smoldot_light::platform::Platform for Platform {
         Duration::from_secs_f64(value / 1000.0)
     }
 
-    fn now() -> Self::Instant {
+    fn now(&self) -> Self::Instant {
         crate::Instant::now()
     }
 
-    fn sleep(duration: Duration) -> Self::Delay {
+    fn sleep(&self, duration: Duration) -> Self::Delay {
         Delay::new(duration)
     }
 
-    fn sleep_until(when: Self::Instant) -> Self::Delay {
+    fn sleep_until(&self, when: Self::Instant) -> Self::Delay {
         Delay::new_at(when)
     }
 
-    fn yield_after_cpu_intensive() -> Self::Yield {
+    fn yield_after_cpu_intensive(&self) -> Self::Yield {
         // We do not yield once, but twice.
         // The reason is that, at the time of writing, `FuturesUnordered` yields to the outside
         // after one of its futures has yielded twice.
@@ -100,7 +101,7 @@ impl smoldot_light::platform::Platform for Platform {
         }
     }
 
-    fn connect(url: &str) -> Self::ConnectFuture {
+    fn connect(&self, url: &str) -> Self::ConnectFuture {
         let mut lock = STATE.try_lock().unwrap();
 
         let connection_id = lock.next_connection_id;
@@ -206,9 +207,10 @@ impl smoldot_light::platform::Platform for Platform {
         .boxed()
     }
 
-    fn next_substream(
-        ConnectionWrapper(connection_id): &'_ mut Self::Connection,
-    ) -> Self::NextSubstreamFuture<'_> {
+    fn next_substream<'a>(
+        &self,
+        ConnectionWrapper(connection_id): &'a mut Self::Connection,
+    ) -> Self::NextSubstreamFuture<'a> {
         let connection_id = *connection_id;
 
         async move {
@@ -262,7 +264,7 @@ impl smoldot_light::platform::Platform for Platform {
         .boxed()
     }
 
-    fn open_out_substream(ConnectionWrapper(connection_id): &mut Self::Connection) {
+    fn open_out_substream(&self, ConnectionWrapper(connection_id): &mut Self::Connection) {
         match STATE
             .try_lock()
             .unwrap()
@@ -281,7 +283,8 @@ impl smoldot_light::platform::Platform for Platform {
         }
     }
 
-    fn update_stream(
+    fn update_stream<'a>(
+        &self,
         StreamWrapper {
             connection_id,
             stream_id,
@@ -289,8 +292,8 @@ impl smoldot_light::platform::Platform for Platform {
             is_reset,
             writable_bytes,
             ..
-        }: &'_ mut Self::Stream,
-    ) -> Self::StreamUpdateFuture<'_> {
+        }: &'a mut Self::Stream,
+    ) -> Self::StreamUpdateFuture<'a> {
         Box::pin(async move {
             loop {
                 if *is_reset {
@@ -336,13 +339,14 @@ impl smoldot_light::platform::Platform for Platform {
         })
     }
 
-    fn read_buffer(
+    fn read_buffer<'a>(
+        &self,
         StreamWrapper {
             read_buffer,
             is_reset,
             ..
-        }: &mut Self::Stream,
-    ) -> smoldot_light::platform::ReadBuffer {
+        }: &'a mut Self::Stream,
+    ) -> smoldot_light::platform::ReadBuffer<'a> {
         if *is_reset {
             return smoldot_light::platform::ReadBuffer::Reset;
         }
@@ -355,6 +359,7 @@ impl smoldot_light::platform::Platform for Platform {
     }
 
     fn advance_read_cursor(
+        &self,
         StreamWrapper {
             read_buffer,
             is_reset,
@@ -369,6 +374,7 @@ impl smoldot_light::platform::Platform for Platform {
     }
 
     fn writable_bytes(
+        &self,
         StreamWrapper {
             is_reset,
             writable_bytes,
@@ -384,6 +390,7 @@ impl smoldot_light::platform::Platform for Platform {
     }
 
     fn send(
+        &self,
         StreamWrapper {
             connection_id,
             stream_id,
@@ -419,6 +426,7 @@ impl smoldot_light::platform::Platform for Platform {
     }
 
     fn close_send(
+        &self,
         StreamWrapper {
             connection_id,
             stream_id,

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -30,10 +30,10 @@ use std::{
     },
 };
 
-/// Total number of bytes that all the connections created through [`PlatformRef`] combined have
+/// Total number of bytes that all the connections created through [`Platform`] combined have
 /// received.
 pub static TOTAL_BYTES_RECEIVED: AtomicU64 = AtomicU64::new(0);
-/// Total number of bytes that all the connections created through [`PlatformRef`] combined have
+/// Total number of bytes that all the connections created through [`Platform`] combined have
 /// sent.
 pub static TOTAL_BYTES_SENT: AtomicU64 = AtomicU64::new(0);
 
@@ -618,7 +618,7 @@ enum ConnectionInner {
         /// but that haven't been reported through
         /// [`smoldot_light::platform::PlatformRef::next_substream`] yet.
         opened_substreams_to_pick_up: VecDeque<(u32, PlatformSubstreamDirection, u32)>,
-        /// Number of objects (connections and streams) in the [`PlatformRef`] API that reference
+        /// Number of objects (connections and streams) in the [`Platform`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.
         connection_handles_alive: u32,
         /// Multihash encoding of the TLS certificate used by the local node at the DTLS layer.
@@ -630,7 +630,7 @@ enum ConnectionInner {
     Reset {
         /// Message given by the bindings to justify the closure.
         message: String,
-        /// Number of objects (connections and streams) in the [`PlatformRef`] API that reference
+        /// Number of objects (connections and streams) in the [`Platform`] API that reference
         /// this connection. If it switches from 1 to 0, the connection must be removed.
         connection_handles_alive: u32,
     },


### PR DESCRIPTION
Preliminary change for https://github.com/smol-dot/smoldot/issues/348 and https://github.com/smol-dot/smoldot/issues/412

This PR adds `platform: TPlat` fields around the light client.
Instead of being freestanding functions, the platform functions are now methods that accept a `&self` as parameter.

The `Platform` trait has been renamed to `PlatformRef` and now requires `Clone + Sync` as well.

Because this trait implementation is on a dummy zero-sized object, this shouldn't actually change anything at all.

However, this makes it possible to add fields to the implementations of `Platform`, instead of relying on static variables.
