### PR TITLE
Merge the `ClientConfig` into `PlatformRef`

### DIFF
--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -29,16 +29,10 @@ fn main() {
     // Any advance usage, such as embedding a client in WebAssembly, will likely require a custom
     // implementation of these bindings.
     let mut client = smoldot_light::Client::new(
-        smoldot_light::platform::async_std::AsyncStdTcpWebSocket,
-        smoldot_light::ClientConfig {
-            // The smoldot client will need to spawn tasks that run in the background. In order to do
-            // so, we need to provide a "tasks spawner".
-            tasks_spawner: Box::new(move |_name, task| {
-                async_std::task::spawn(task);
-            }),
-            client_name: env!("CARGO_PKG_NAME").into(),
-            client_version: env!("CARGO_PKG_VERSION").into(),
-        },
+        smoldot_light::platform::async_std::AsyncStdTcpWebSocket::new(
+            env!("CARGO_PKG_NAME").into(),
+            env!("CARGO_PKG_VERSION").into(),
+        ),
     );
 
     // Ask the client to connect to a chain.

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -274,9 +274,6 @@ pub struct StartConfig<'a, TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
     pub platform: TPlat,
 
-    /// Closure that spawns background tasks.
-    pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
-
     /// Access to the network, and index of the chain to sync from the point of view of the
     /// network service.
     pub network_service: (Arc<network_service::NetworkService<TPlat>>, usize),

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -69,9 +69,6 @@ pub struct Config<TPlat> {
     /// Access to the platform's capabilities.
     pub platform: TPlat,
 
-    /// Closure that spawns background tasks.
-    pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
-
     /// Value sent back for the agent version when receiving an identification request.
     pub identify_agent_version: String,
 
@@ -169,9 +166,6 @@ struct SharedGuarded<TPlat: PlatformRef> {
 
     messages_from_connections_rx:
         mpsc::Receiver<(service::ConnectionId, service::ConnectionToCoordinator)>,
-
-    /// Value received in [`Config::tasks_executor`].
-    tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
 
     active_connections: HashMap<
         service::ConnectionId,
@@ -271,7 +265,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                 active_connections: HashMap::with_capacity_and_hasher(32, Default::default()),
                 messages_from_connections_tx,
                 messages_from_connections_rx,
-                tasks_executor: config.tasks_executor,
                 blocks_requests: HashMap::with_capacity_and_hasher(8, Default::default()),
                 grandpa_warp_sync_requests: HashMap::with_capacity_and_hasher(
                     8,
@@ -291,7 +284,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
         });
 
         // Spawn main task that processes the network service.
-        (shared.guarded.try_lock().unwrap().tasks_executor)(
+        shared.platform.spawn_task(
             "network-service".into(),
             Box::pin({
                 let shared = shared.clone();
@@ -305,7 +298,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
 
         // Spawn task starts a discovery request at a periodic interval.
         // This is done through a separate task due to ease of implementation.
-        (shared.guarded.try_lock().unwrap().tasks_executor)(
+        shared.platform.spawn_task(
             "network-discovery".into(),
             Box::pin({
                 let shared = shared.clone();
@@ -1384,7 +1377,7 @@ async fn update_round<TPlat: PlatformRef>(
         // Sending the new task might fail in case a shutdown is happening, in which case
         // we don't really care about the state of anything anymore.
         // The sending here is normally very quick.
-        (guarded.tasks_executor)(task_name, Box::pin(task));
+        shared.platform.spawn_task(task_name.into(), Box::pin(task));
     }
 
     // Pull messages that the coordinator has generated in destination to the various

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{ops, str, time::Duration};
 use futures::prelude::*;
 
@@ -81,6 +81,21 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
 
     /// Creates a future that becomes ready after the given instant has been reached.
     fn sleep_until(&self, when: Self::Instant) -> Self::Delay;
+
+    /// Spawns a task that runs indefinitely in the background.
+    ///
+    /// The first parameter is the name of the task, which can be useful for debugging purposes.
+    ///
+    /// The `Future` must be run until it yields a value.
+    fn spawn_task(&self, task_name: Cow<str>, task: future::BoxFuture<'static, ()>);
+
+    /// Value returned when a JSON-RPC client requests the name of the client, or when a peer
+    /// performs an identification request. Reasonable value is `env!("CARGO_PKG_NAME")`.
+    fn client_name(&self) -> Cow<str>;
+
+    /// Value returned when a JSON-RPC client requests the version of the client, or when a peer
+    /// performs an identification request. Reasonable value is `env!("CARGO_PKG_VERSION")`.
+    fn client_version(&self) -> Cow<str>;
 
     /// Should be called after a CPU-intensive operation in order to yield back control.
     ///

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -96,9 +96,6 @@ pub struct Config<TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
     pub platform: TPlat,
 
-    /// Closure that spawns background tasks.
-    pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
-
     /// Service responsible for synchronizing the chain.
     pub sync_service: Arc<sync_service::SyncService<TPlat>>,
 
@@ -170,7 +167,7 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
 
         // Spawns a task that runs in the background and updates the content of the mutex.
         let background_task_abort;
-        (config.tasks_executor)(log_target.clone(), {
+        config.platform.spawn_task(log_target.clone().into(), {
             let sync_service = config.sync_service.clone();
             let guarded = guarded.clone();
             let platform = config.platform.clone();

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -104,9 +104,6 @@ pub struct Config<TPlat: PlatformRef> {
     /// Access to the platform's capabilities.
     pub platform: TPlat,
 
-    /// Closure that spawns background tasks.
-    pub tasks_executor: Box<dyn FnMut(String, future::BoxFuture<'static, ()>) + Send>,
-
     /// Service responsible for synchronizing the chain.
     pub sync_service: Arc<sync_service::SyncService<TPlat>>,
 
@@ -146,11 +143,11 @@ impl<TPlat: PlatformRef> TransactionsService<TPlat> {
         let log_target = format!("tx-service-{}", config.log_name);
         let (to_background, from_foreground) = mpsc::channel(8);
 
-        (config.tasks_executor)(
-            log_target.clone(),
+        config.platform.spawn_task(
+            log_target.clone().into(),
             Box::pin(background_task::<TPlat>(
                 log_target,
-                config.platform,
+                config.platform.clone(),
                 config.sync_service,
                 config.runtime_service,
                 config.network_service.0,

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -199,19 +199,8 @@ pub(crate) fn init<TChain>(
         ))
         .unwrap();
 
-    let client = smoldot_light::Client::new(
-        platform::Platform,
-        smoldot_light::ClientConfig {
-            tasks_spawner: Box::new(move |name, task| {
-                new_task_tx.unbounded_send((name, task)).unwrap()
-            }),
-            client_name: env!("CARGO_PKG_NAME").into(),
-            client_version: env!("CARGO_PKG_VERSION").into(),
-        },
-    );
-
     Client {
-        smoldot: client,
+        smoldot: smoldot_light::Client::new(platform::Platform::new(new_task_tx)),
         chains: slab::Slab::with_capacity(8),
         periodically_yield,
         main_task,


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/348

This PR removes the `ClientConfig` struct, and merges it into `PlatformRef`.

This overall makes more sense.
