### PR TITLE
Request justifications of blocks on epoch change

### DIFF
--- a/full-node/src/run/network_service.rs
+++ b/full-node/src/run/network_service.rs
@@ -962,6 +962,7 @@ async fn update_round(inner: &Arc<Inner>, event_senders: &mut [mpsc::Sender<Even
                         state.set_id,
                         state.commit_finalized_height,
                     );
+                    // TODO: report to the sync state machine
                 }
                 service::Event::GrandpaCommitMessage {
                     chain_index,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -871,6 +871,11 @@ pub enum Event {
         chain_index: usize,
         announce: service::EncodedBlockAnnounce,
     },
+    GrandpaNeighborPacket {
+        peer_id: PeerId,
+        chain_index: usize,
+        finalized_block_height: u64,
+    },
     /// Received a GrandPa commit message from the network.
     GrandpaCommitMessage {
         peer_id: PeerId,
@@ -1252,6 +1257,11 @@ async fn update_round<TPlat: PlatformRef>(
                         state.set_id,
                         state.commit_finalized_height,
                     );
+                    break Event::GrandpaNeighborPacket {
+                        chain_index,
+                        peer_id,
+                        finalized_block_height: state.commit_finalized_height,
+                    };
                 }
                 service::Event::GrandpaCommitMessage {
                     chain_index,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1173,6 +1173,16 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 }
             }
 
+            network_service::Event::GrandpaNeighborPacket {
+                peer_id,
+                chain_index,
+                finalized_block_height,
+            } if chain_index == self.network_chain_index => {
+                let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
+                self.sync
+                    .update_source_finality_state(sync_source_id, finalized_block_height);
+            }
+
             network_service::Event::GrandpaCommitMessage {
                 chain_index,
                 peer_id,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fix finality stalling on epoch change.
 - Fix `AlreadyDestroyedError` not being properly thrown if a function is called after `terminate()`. ([#438](https://github.com/smol-dot/smoldot/pull/438))
 
 ## 1.0.2 - 2023-04-12


### PR DESCRIPTION
Should fix https://github.com/smol-dot/smoldot/issues/239

This PR does the following:

- We now track the finalized block of all of our peers based on the GrandPa neighbor message that they send.
- Send out justification requests when a peer has a finalized block superior or equal to a local "finality checkpoint". A "finality checkpoint" is a block that needs to be finalized before any other block on top can be finalized as well, which represents epoch changes.
