### PR TITLE
Add a extra requirement to writable bytes to avoid overflows

### DIFF
--- a/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -102,7 +102,7 @@ export interface Config {
      *
      * The connection and stream must currently be in the `Open` state.
      *
-     * The number of bytes most never exceed the number of "writable bytes" of the stream.
+     * The number of bytes must never exceed the number of "writable bytes" of the stream.
      * `onWritableBytes` can be used in order to notify that more writable bytes are available.
      *
      * The `streamId` must be provided if and only if the connection is of type "multi-stream".
@@ -197,7 +197,8 @@ export interface ConnectionConfig {
     onStreamReset: (streamId: number) => void;
 
     /**
-     * Callback called when more data can be written on the stream.
+     * Callback called when some data sent using {@link Connection.send} has effectively been
+     * written on the stream, meaning that some buffer space is now free.
      *
      * Can only happen while the connection is in the `Open` state.
      *
@@ -205,6 +206,9 @@ export interface ConnectionConfig {
      *
      * The `streamId` parameter must be provided if and only if the connection is of type
      * "multi-stream".
+     *
+     * Only a number of bytes equal to the size of the data provided to {@link Connection.send}
+     * should be reported. In other words, the `initialWritableBytes` must never be exceeded.
      */
     onWritableBytes: (numExtra: number, streamId?: number) => void;
 

--- a/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -208,7 +208,7 @@ export interface ConnectionConfig {
      * "multi-stream".
      *
      * Only a number of bytes equal to the size of the data provided to {@link Connection.send}
-     * should be reported. In other words, the `initialWritableBytes` must never be exceeded.
+     * must be reported. In other words, the `initialWritableBytes` must never be exceeded.
      */
     onWritableBytes: (numExtra: number, streamId?: number) => void;
 

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -619,6 +619,14 @@ pub extern "C" fn stream_message(connection_id: u32, stream_id: u32, buffer_inde
 /// stream (and, in the case of a multi-stream connection, the stream itself) must be in the
 /// `Open` state.
 ///
+/// `total_sent - total_reported_writable_bytes` must always be `>= 0`, where `total_sent` is the
+/// total number of bytes sent on the stream using [`stream_send`] and
+/// `total_reported_writable_bytes` is the total number of bytes reported using
+/// [`stream_writable_bytes`].
+/// In other words, this function is meant to notify that data sent using [`stream_send`̀] has
+/// effectively been sent out. It is not possible to exceed the `initial_writable_bytes` provided
+/// when the stream was created.
+///
 /// If `connection_id` is a single-stream connection, then the value of `stream_id` is ignored.
 /// If `connection_id` is a multi-stream connection, then `stream_id` corresponds to the stream
 /// on which the data was received, as was provided to [`connection_stream_opened`].


### PR DESCRIPTION
Close #358 