### PR TITLE
Implement the `clear_prefix` host functions by iterating keys

### DIFF
--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -358,6 +358,18 @@ impl NextKey {
         self.0.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.0.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.0.prefix()
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -645,6 +645,18 @@ impl NextKey {
         self.0.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.0.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.0.prefix()
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -1054,6 +1054,18 @@ impl<T> StorageNextKey<T> {
         self.inner.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.inner.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner.prefix()
+    }
+
     /// Access to the Nth ancestor's information and hierarchy. Returns `None` if `n` is too
     /// large. A value of `0` for `n` corresponds to the parent block. A value of `1` corresponds
     /// to the parent's parent. And so on.

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -277,6 +277,18 @@ impl NextKey {
         self.0.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.0.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.0.prefix()
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2478,6 +2478,16 @@ pub enum StorageKey<T> {
     ChildTrieDefault { child_trie: T, key: T },
 }
 
+impl<T> StorageKey<T> {
+    /// Returns the key alone.
+    pub fn into_key(self) -> T {
+        match self {
+            StorageKey::MainTrie { key } => key,
+            StorageKey::ChildTrieDefault { key, .. } => key,
+        }
+    }
+}
+
 impl<T> fmt::Debug for StorageKey<T>
 where
     T: AsRef<[u8]>,

--- a/lib/src/executor/read_only_runtime_host.rs
+++ b/lib/src/executor/read_only_runtime_host.rs
@@ -213,6 +213,18 @@ impl NextKey {
         }
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        false
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        &[][..]
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2694,6 +2694,18 @@ impl<TRq, TSrc, TBl> StorageNextKey<TRq, TSrc, TBl> {
         self.inner.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.inner.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner.prefix()
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -619,6 +619,24 @@ impl NextKey {
         }
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        match &self.0 {
+            NextKeyInner::Stage1(inner, _) => inner.or_equal(),
+            NextKeyInner::Stage2(inner, _) => inner.or_equal(),
+        }
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        match &self.0 {
+            NextKeyInner::Stage1(inner, _) => either::Left(inner.prefix()),
+            NextKeyInner::Stage2(inner, _) => either::Right(inner.prefix()),
+        }
+    }
+
     /// Injects the key.
     ///
     /// # Panic

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -638,6 +638,18 @@ impl StorageNextKey {
         self.inner.key()
     }
 
+    /// If `true`, then the provided value must the one superior or equal to the requested key.
+    /// If `false`, then the provided value must be strictly superior to the requested key.
+    pub fn or_equal(&self) -> bool {
+        self.inner.or_equal()
+    }
+
+    /// Returns the prefix the next key must start with. If the next key doesn't start with the
+    /// given prefix, then `None` should be provided.
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+        self.inner.prefix()
+    }
+
     /// Injects the key.
     ///
     /// # Panic


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/272

When `clear_prefix` is called by the runtime, instead of asking for the list of all keys of that prefix, we know ask for keys one by one through an iteration.

While it is likely slower, it is also considerably cleaner when it comes to handling the tricky behavior of `clear_prefix` w.r.t. overlay items.
If we need to gain back the speed in the future, we can do so by changing `NextKey` again to have some kind of iteration system, where multiple yields of `NextKey` requires a sequence of keys, or something like that.

This PR goes in the direction of removing the `PrefixKeys` variant from function calls.
