### PR TITLE
No longer hardcode the maximum notification size in `established`

### DIFF
--- a/fuzz/fuzz_targets/network-connection-encrypted.rs
+++ b/fuzz/fuzz_targets/network-connection-encrypted.rs
@@ -230,7 +230,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
                 continue;
             }
             Some(Event::NotificationsInOpen { id, .. }) => {
-                local.accept_in_notifications_substream(id, b"dummy handshake".to_vec());
+                local.accept_in_notifications_substream(id, b"dummy handshake".to_vec(), 16);
                 continue;
             }
 

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -925,6 +925,7 @@ where
             CoordinatorToConnectionInner::AcceptInNotifications {
                 substream_id: *inner_substream_id,
                 handshake,
+                max_notification_size: 16 * 1024 * 1024, // TODO: obtain from protocol configuration
             },
         ));
 
@@ -1859,6 +1860,7 @@ enum CoordinatorToConnectionInner<TNow> {
     AcceptInNotifications {
         substream_id: established::SubstreamId,
         handshake: Vec<u8>,
+        max_notification_size: usize,
     },
     RejectInNotifications {
         substream_id: established::SubstreamId,

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -496,6 +496,7 @@ where
                 CoordinatorToConnectionInner::AcceptInNotifications {
                     substream_id,
                     handshake,
+                    max_notification_size,
                 },
                 MultiStreamConnectionTaskInner::Established {
                     established,
@@ -509,7 +510,11 @@ where
                 {
                     notifications_in_open_cancel_acknowledgments.remove(idx);
                 } else {
-                    established.accept_in_notifications_substream(substream_id, handshake);
+                    established.accept_in_notifications_substream(
+                        substream_id,
+                        handshake,
+                        max_notification_size,
+                    );
                 }
             }
             (

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -365,7 +365,11 @@ where
                 {
                     notifications_in_open_cancel_acknowledgments.remove(idx);
                 } else {
-                    established.accept_in_notifications_substream(substream_id, handshake, max_notification_size);
+                    established.accept_in_notifications_substream(
+                        substream_id,
+                        handshake,
+                        max_notification_size,
+                    );
                 }
             }
             (

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -351,6 +351,7 @@ where
                 CoordinatorToConnectionInner::AcceptInNotifications {
                     substream_id,
                     handshake,
+                    max_notification_size,
                 },
                 SingleStreamConnectionTaskInner::Established {
                     established,
@@ -364,7 +365,7 @@ where
                 {
                     notifications_in_open_cancel_acknowledgments.remove(idx);
                 } else {
-                    established.accept_in_notifications_substream(substream_id, handshake);
+                    established.accept_in_notifications_substream(substream_id, handshake, max_notification_size);
                 }
             }
             (

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -794,6 +794,7 @@ where
         &mut self,
         substream_id: SubstreamId,
         handshake: Vec<u8>,
+        max_notification_size: usize,
     ) {
         let substream_id = match substream_id.0 {
             SubstreamIdInner::MultiStream(id) => id,
@@ -802,8 +803,6 @@ where
 
         let inner_substream_id = self.out_in_substreams_map.get(&substream_id).unwrap();
 
-        let max_notification_size = 16 * 1024 * 1024; // TODO: hack
-                                                      // TODO: self.notifications_protocols[protocol_index].max_notification_size;
         self.in_substreams
             .get_mut(inner_substream_id)
             .unwrap()

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -885,14 +885,13 @@ where
         &mut self,
         substream_id: SubstreamId,
         handshake: Vec<u8>,
+        max_notification_size: usize,
     ) {
         let substream_id = match substream_id.0 {
             SubstreamIdInner::SingleStream(id) => id,
             _ => panic!(),
         };
 
-        let max_notification_size = 16 * 1024 * 1024; // TODO: hack
-                                                      // TODO: self.inner.notifications_protocols[protocol_index].max_notification_size;
         self.inner
             .yamux
             .user_data_mut(substream_id)

--- a/lib/src/libp2p/connection/established/tests.rs
+++ b/lib/src/libp2p/connection/established/tests.rs
@@ -552,7 +552,7 @@ fn outbound_substream_works() {
             assert_eq!(handshake, b"hello");
             connections
                 .bob
-                .accept_in_notifications_substream(id, b"hello back".to_vec());
+                .accept_in_notifications_substream(id, b"hello back".to_vec(), 4 * 1024);
         }
         _ev => unreachable!("{:?}", _ev),
     }
@@ -765,7 +765,7 @@ fn outbound_substream_close_demanded() {
             assert_eq!(handshake, b"hello");
             connections
                 .bob
-                .accept_in_notifications_substream(id, b"hello back".to_vec());
+                .accept_in_notifications_substream(id, b"hello back".to_vec(), 4 * 1024);
         }
         _ev => unreachable!("{:?}", _ev),
     }


### PR DESCRIPTION
Instead it is now hardcoded in `collection.rs`.
While you might think "isn't this the same?", well my objective is to clean up the `established` module as much as possible, while the `collection` module is still a bit wonky.