### PR TITLE
Use the wasi functions for time retrieval, and yield less often to the JS engine

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - As NodeJS v14 reaches its end of life on April 30th 2023, the minimum NodeJS version required to run smoldot is now v16. The smoldot Wasm binary now has SIMD enabled, meaning that the minimum Deno version required to run smoldot is now v1.9.
 - When receiving an identify request through the libp2p protocol, smoldot now sends back `smoldot-light-wasm vX.X.X` (with proper version numbers) as its agent name and version, instead of previously just `smoldot`. ([#417](https://github.com/smol-dot/smoldot/pull/417))
+- Yielding to the browser using `setTimeout` and `setImmediate` is now done less frequently in order to reduce the overhead of doing so. ([#481](https://github.com/smol-dot/smoldot/pull/481))
 
 ### Fixed
 

--- a/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -34,11 +34,6 @@ export interface Config {
     bufferIndices: Array<Uint8Array>,
 
     /**
-     * Returns the number of milliseconds since an arbitrary epoch.
-     */
-    performanceNow: () => number,
-
-    /**
      * Tries to open a new connection using the given configuration.
      *
      * @see Connection
@@ -306,12 +301,6 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                 config.logCallback(level, target, message);
             }
         },
-
-        // Must return the UNIX time in milliseconds.
-        unix_time_ms: () => Date.now(),
-
-        // Must return the value of a monotonic clock in milliseconds.
-        monotonic_clock_ms: () => config.performanceNow(),
 
         // Must call `timer_finished` after the given number of milliseconds has elapsed.
         start_timer: (id: number, ms: number) => {

--- a/wasm-node/javascript/src/instance/bindings-wasi.ts
+++ b/wasm-node/javascript/src/instance/bindings-wasi.ts
@@ -93,7 +93,7 @@ export default (config: Config): WebAssembly.ModuleImports => {
             switch (clockId) {
                 case 0: {
                     // Realtime clock.
-                    const now = BigInt(Date.now()) * BigInt(1_000_000);
+                    const now = BigInt(Math.floor(Date.now())) * BigInt(1_000_000);
                     buffer.writeUInt64LE(mem, outPtr, now)
 
                     // Success.

--- a/wasm-node/javascript/src/instance/bindings-wasi.ts
+++ b/wasm-node/javascript/src/instance/bindings-wasi.ts
@@ -102,8 +102,9 @@ export default (config: Config): WebAssembly.ModuleImports => {
                 case 1: {
                     // Monotonic clock.
                     const nowMs = config.performanceNow();
-                    const now = BigInt(Math.floor(nowMs)) * BigInt(1_000_000) +
-                        BigInt(Math.floor(((nowMs - Math.floor(nowMs)) * 1_000_000)));
+                    const nowMsInt = Math.floor(nowMs);
+                    const now = BigInt(nowMsInt) * BigInt(1_000_000) +
+                        BigInt(Math.floor(((nowMs - nowMsInt) * 1_000_000)));
                     buffer.writeUInt64LE(mem, outPtr, now)
 
                     // Success.

--- a/wasm-node/javascript/src/instance/buffer.ts
+++ b/wasm-node/javascript/src/instance/buffer.ts
@@ -47,6 +47,18 @@ export function writeUInt32LE(buffer: Uint8Array, offset: number, value: number)
     buffer[offset] = value & 0xff
 }
 
+export function writeUInt64LE(buffer: Uint8Array, offset: number, value: bigint) {
+    checkRange(buffer, offset, 8);
+    buffer[offset + 7] = Number((value >> BigInt(56)) & BigInt(0xff))
+    buffer[offset + 6] = Number((value >> BigInt(48)) & BigInt(0xff))
+    buffer[offset + 5] = Number((value >> BigInt(40)) & BigInt(0xff))
+    buffer[offset + 4] = Number((value >> BigInt(32)) & BigInt(0xff))
+    buffer[offset + 3] = Number((value >> BigInt(24)) & BigInt(0xff))
+    buffer[offset + 2] = Number((value >> BigInt(16)) & BigInt(0xff))
+    buffer[offset + 1] = Number((value >> BigInt(8)) & BigInt(0xff))
+    buffer[offset] = Number(value & BigInt(0xff))
+}
+
 function checkRange(buffer: Uint8Array, offset: number, length: number) {
     if (!Number.isInteger(offset) || offset < 0)
         throw new RangeError()

--- a/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/wasm-node/javascript/src/instance/raw-instance.ts
@@ -105,7 +105,6 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     // Used to bind with the smoldot-light bindings. See the `bindings-smoldot-light.js` file.
     const smoldotJsConfig: SmoldotBindingsConfig = {
         bufferIndices,
-        performanceNow: platformBindings.performanceNow,
         connect: platformBindings.connect,
         onPanic: (message) => {
             killAll();
@@ -119,6 +118,7 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     const wasiConfig: WasiConfig = {
         envVars: [],
         getRandomValues: platformBindings.getRandomValues,
+        performanceNow: platformBindings.performanceNow,
         onProcExit: (retCode) => {
             killAll();
             config.onWasmPanic(`proc_exit called: ${retCode}`)

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -130,38 +130,6 @@ extern "C" {
     /// virtual machine at offset `ptr` and with length `len`.
     pub fn log(level: u32, target_ptr: u32, target_len: u32, message_ptr: u32, message_len: u32);
 
-    /// Must return the number of milliseconds that have passed since the UNIX epoch, ignoring
-    /// leap seconds.
-    ///
-    /// Must never return `NaN` or infinite.
-    ///
-    /// This is typically implemented by calling `Date.now()`.
-    ///
-    /// See <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now>
-    ///
-    /// > **Note**: Ideally this function isn't needed. The wasi target supports clocks through
-    /// >           the `clock_time_get` syscall. However, since `clock_time_get` uses `u64s`, and
-    /// >           browsers don't support `u64s`, using it causes an unbypassable exception. See
-    /// >           also <https://github.com/dcodeIO/webassembly/issues/26#issuecomment-410157370>.
-    pub fn unix_time_ms() -> f64;
-
-    /// Must return the number of milliseconds that have passed since an arbitrary point in time.
-    ///
-    /// Must never return `NaN` or infinite.
-    ///
-    /// Contrary to [`unix_time_ms`], the returned value must never be inferior to a value
-    /// previously returned. Consequently, this must not be implemented using `Date.now()`, whose
-    /// value can decrease if the user adjusts their machine's clock, but rather with
-    /// `Performance.now()` or similar.
-    ///
-    /// See <https://developer.mozilla.org/fr/docs/Web/API/Performance/now>
-    ///
-    /// > **Note**: Ideally this function isn't needed. The wasi target supports clocks through
-    /// >           the `clock_time_get` syscall. However, since `clock_time_get` uses `u64s`, and
-    /// >           browsers don't support `u64s`, using it causes an unbypassable exception. See
-    /// >           also <https://github.com/dcodeIO/webassembly/issues/26#issuecomment-410157370>.
-    pub fn monotonic_clock_ms() -> f64;
-
     /// After at least `milliseconds` milliseconds have passed, must call [`timer_finished`] with
     /// the `id` passed as parameter.
     ///

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -137,8 +137,8 @@ extern "C" {
     /// have passed, and this will likely cause smoldot to restart a new timer for the remainder
     /// of the duration.
     ///
-    /// When [`timer_finished`] is called, the value of [`monotonic_clock_ms`] must have increased
-    /// by at least the given number of `milliseconds`.
+    /// When [`timer_finished`] is called, the value of the monotonic clock (in the WASI bindings)
+    /// must have increased by at least the given number of `milliseconds`.
     ///
     /// If `milliseconds` is 0, [`timer_finished`] should be called as soon as possible.
     ///

--- a/wasm-node/rust/src/cpu_rate_limiter.rs
+++ b/wasm-node/rust/src/cpu_rate_limiter.rs
@@ -100,7 +100,7 @@ impl<T: Future> Future for CpuRateLimiter<T> {
                 debug_assert!(after_poll_sleep >= 0.0 && !after_poll_sleep.is_nan());
                 *this.sleep_deprevation_sec += after_poll_sleep;
 
-                if *this.sleep_deprevation_sec > 5.0 {
+                if *this.sleep_deprevation_sec > 0.005 {
                     this.prevent_poll_until.set(crate::timers::Delay::new_at(
                         after_polling
                             + Duration::try_from_secs_f64(*this.sleep_deprevation_sec)

--- a/wasm-node/rust/src/cpu_rate_limiter.rs
+++ b/wasm-node/rust/src/cpu_rate_limiter.rs
@@ -22,6 +22,8 @@ use core::{
     time::Duration,
 };
 
+use std::time::Instant;
+
 /// Wraps around a `Future` and enforces an upper bound to the CPU consumed by the polling of
 /// this `Future`.
 ///
@@ -75,12 +77,12 @@ impl<T: Future> Future for CpuRateLimiter<T> {
             return Poll::Pending;
         }
 
-        let before_polling = crate::Instant::now();
+        let before_polling = Instant::now();
 
         match this.inner.poll(cx) {
             Poll::Ready(value) => Poll::Ready(value),
             Poll::Pending => {
-                let after_polling = crate::Instant::now();
+                let after_polling = Instant::now();
 
                 // Time it took to execute `poll`.
                 let poll_duration = after_polling - before_polling;

--- a/wasm-node/rust/src/cpu_rate_limiter.rs
+++ b/wasm-node/rust/src/cpu_rate_limiter.rs
@@ -90,9 +90,6 @@ impl<T: Future> Future for CpuRateLimiter<T> {
                 // In order to enforce the rate limiting, we prevent `poll` from executing
                 // for a certain amount of time.
                 // The base equation here is: `(after_poll_sleep + poll_duration) * rate_limit == poll_duration * u32::max_value()`.
-                // Because `Duration::mul_f64` and `Duration::from_secs_f64` panic in case of
-                // overflow, we need to do the operation of multiplying and checking the bounds
-                // manually.
                 let after_poll_sleep =
                     poll_duration.as_secs_f64() * *this.max_divided_by_rate_limit_minus_one;
                 debug_assert!(after_poll_sleep >= 0.0 && !after_poll_sleep.is_nan());

--- a/wasm-node/rust/src/timers.rs
+++ b/wasm-node/rust/src/timers.rs
@@ -30,7 +30,7 @@ use core::{
     time::Duration,
 };
 use futures_util::future;
-use std::{collections::BinaryHeap, sync::Mutex};
+use std::{collections::BinaryHeap, sync::Mutex, time::Instant};
 
 pub(crate) fn timer_finished(timer_id: u32) {
     let callback = {
@@ -40,8 +40,6 @@ pub(crate) fn timer_finished(timer_id: u32) {
 
     callback();
 }
-
-use super::Instant;
 
 /// `Future` that automatically wakes up after a certain amount of time has elapsed.
 pub struct Delay {


### PR DESCRIPTION
Fix #418 