### PR TITLE
Decode the wasm module from index-*.ts

### DIFF
--- a/wasm-node/javascript/src/client.ts
+++ b/wasm-node/javascript/src/client.ts
@@ -370,7 +370,7 @@ export interface AddChainOptions {
 // This function is similar to the `start` function found in `index.ts`, except with an extra
 // parameter containing the platform-specific bindings.
 // Contrary to the one within `index.js`, this function is not supposed to be directly used.
-export function start(options: ClientOptions, platformBindings: PlatformBindings): Client {
+export function start(options: ClientOptions, wasmModule: Promise<WebAssembly.Module>, platformBindings: PlatformBindings): Client {
     const logCallback = options.logCallback || ((level, target, message) => {
         // The first parameter of the methods of `console` has some printf-like substitution
         // capabilities. We don't really need to use this, but not using it means that the logs might
@@ -398,6 +398,7 @@ export function start(options: ClientOptions, platformBindings: PlatformBindings
     const alreadyDestroyedError: { value: null | AlreadyDestroyedError } = { value: null };
 
     const instance = startInstance({
+        wasmModule,
         // Maximum level of log entries sent by the client.
         // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
         maxLogLevel: options.maxLogLevel || 3,

--- a/wasm-node/javascript/src/index-browser.ts
+++ b/wasm-node/javascript/src/index-browser.ts
@@ -21,6 +21,7 @@ import { Client, ClientOptions, start as innerStart } from './client.js'
 import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
 import { classicDecode, multibaseBase64Decode } from './base64.js'
 import { inflate } from 'pako';
+import { default as wasmBase64 } from './instance/autogen/wasm.js';
 
 export {
     AddChainError,
@@ -46,10 +47,13 @@ export {
 export function start(options?: ClientOptions): Client {
     options = options || {}
 
-    return innerStart(options, {
-        trustedBase64DecodeAndZlibInflate: (input) => {
-            return Promise.resolve(inflate(classicDecode(input)))
-        },
+    // The actual Wasm bytecode is base64-decoded then deflate-decoded from a constant found in a
+    // different file.
+    // This is suboptimal compared to using `instantiateStreaming`, but it is the most
+    // cross-platform cross-bundler approach.
+    const wasmModule = WebAssembly.compile(inflate(classicDecode(wasmBase64)));
+
+    return innerStart(options, wasmModule, {
         registerShouldPeriodicallyYield: (callback) => {
             if (typeof document === 'undefined')   // We might be in a web worker.
                 return [false, () => { }];

--- a/wasm-node/javascript/src/index-nodejs.ts
+++ b/wasm-node/javascript/src/index-nodejs.ts
@@ -21,6 +21,7 @@
 
 import { Client, ClientOptions, start as innerStart } from './client.js'
 import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
+import { default as wasmBase64 } from './instance/autogen/wasm.js';
 
 import { WebSocket } from 'ws';
 import { inflate } from 'pako';
@@ -53,10 +54,13 @@ export {
 export function start(options?: ClientOptions): Client {
     options = options || {};
 
-    return innerStart(options || {}, {
-        trustedBase64DecodeAndZlibInflate: (input) => {
-            return Promise.resolve(inflate(Buffer.from(input, 'base64')))
-        },
+    // The actual Wasm bytecode is base64-decoded then deflate-decoded from a constant found in a
+    // different file.
+    // This is suboptimal compared to using `instantiateStreaming`, but it is the most
+    // cross-platform cross-bundler approach.
+    const wasmModule = WebAssembly.compile(inflate(Buffer.from(wasmBase64, 'base64')));
+
+    return innerStart(options || {}, wasmModule, {
         registerShouldPeriodicallyYield: (_callback) => {
             return [true, () => { }]
         },


### PR DESCRIPTION
In the future I would like to give the option for the user to load and compile the module in the background, then send it to the main thread. To achieve that, they would need to import a separate entry point called for example `smoldot/no-auto-module`.
In this context, the automatic loading the module should be done in `index-*.ts`.