### PR TITLE
Make wasm execution explicit and move CPU rate limit and periodic yield to the JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,7 @@ name = "smoldot-light-wasm"
 version = "1.0.3"
 dependencies = [
  "async-executor",
+ "async-task",
  "event-listener",
  "fnv",
  "futures-util",

--- a/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -50,6 +50,7 @@ export interface Config {
 
     logCallback: (level: number, target: string, message: string) => void,
     jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
+    advanceExecutionReadyCallback: () => void,
     currentTaskCallback?: (taskName: string | null) => void,
 }
 
@@ -273,6 +274,10 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
 
             const buf = config.bufferIndices[bufferIndex]!;
             new Uint8Array(instance.exports.memory.buffer).set(buf, targetPtr);
+        },
+
+        advance_execution_ready: () => {
+            config.advanceExecutionReadyCallback();
         },
 
         // Used by the Rust side to notify that a JSON-RPC response or subscription notification

--- a/wasm-node/javascript/src/instance/bindings.ts
+++ b/wasm-node/javascript/src/instance/bindings.ts
@@ -23,8 +23,8 @@
  */
 export interface SmoldotWasmExports extends WebAssembly.Exports {
     memory: WebAssembly.Memory,
-    init: (maxLogLevel: number, enableCurrentTask: number, cpuRateLimit: number, periodicallyYield: number) => void,
-    set_periodically_yield: (periodicallyYield: number) => void,
+    init: (maxLogLevel: number, enableCurrentTask: number) => void,
+    advance_execution: () => number,
     start_shutdown: () => void,
     add_chain: (chainSpecBufferIndex: number, databaseContentBufferIndex: number, jsonRpcRunning: number, potentialRelayChainsBufferIndex: number) => number;
     remove_chain: (chainId: number) => void,

--- a/wasm-node/javascript/src/instance/instance.ts
+++ b/wasm-node/javascript/src/instance/instance.ts
@@ -129,6 +129,8 @@ export function start(configMessage: Config, platformBindings: instance.Platform
                 currentTask.name = taskName
             },
             cpuRateLimit: configMessage.cpuRateLimit,
+            enableCurrentTask: configMessage.enableCurrentTask,
+            maxLogLevel: configMessage.maxLogLevel,
         };
 
         return await instance.startInstance(config, platformBindings)
@@ -136,9 +138,6 @@ export function start(configMessage: Config, platformBindings: instance.Platform
 
     state = {
         initialized: false, promise: initPromise.then(([instance, bufferIndices]) => {
-            // Smoldot requires an initial call to the `init` function in order to do its internal
-            // configuration.
-            instance.exports.init(configMessage.maxLogLevel, configMessage.enableCurrentTask ? 1 : 0);
             state = { initialized: true, instance, bufferIndices };
             return [instance, bufferIndices];
         })

--- a/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/wasm-node/javascript/src/instance/raw-instance.ts
@@ -39,6 +39,8 @@ export interface Config {
     wasmModule: WebAssembly.Module,
     jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
+    maxLogLevel: number;
+    enableCurrentTask: boolean;
     cpuRateLimit: number,
 }
 
@@ -133,7 +135,10 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     smoldotJsConfig.instance = instance;
     wasiConfig.instance = instance;
 
-    // TODO: this execution might start before `init` is called; it's actually okay to do so in practice, but the documentation says it's forbidden
+    // Smoldot requires an initial call to the `init` function in order to do its internal
+    // configuration.
+    instance.exports.init(config.maxLogLevel, config.enableCurrentTask ? 1 : 0);
+
     (async () => {
         // In order to avoid calling `setTimeout` too often, we accumulate sleep up until
         // a certain threshold.

--- a/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/wasm-node/javascript/src/instance/raw-instance.ts
@@ -82,6 +82,8 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     let killAll: () => void;
 
     const bufferIndices = new Array;
+    // Callback called when `advance_execution_ready` is called by the Rust code, if any.
+    const advanceExecutionPromise: { value: null | (() => void) } = { value: null };
 
     // Used to bind with the smoldot-light bindings. See the `bindings-smoldot-light.js` file.
     const smoldotJsConfig: SmoldotBindingsConfig = {
@@ -91,6 +93,11 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
             killAll();
             config.onWasmPanic(message);
             throw new Error();
+        },
+        advanceExecutionReadyCallback: () => {
+            if (advanceExecutionPromise.value)
+                advanceExecutionPromise.value();
+            advanceExecutionPromise.value = null;
         },
         ...config
     };
@@ -125,5 +132,67 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
     const instance = result as SmoldotWasmInstance;
     smoldotJsConfig.instance = instance;
     wasiConfig.instance = instance;
+
+    // TODO: this execution might start before `init` is called; it's actually okay to do so in practice, but the documentation says it's forbidden
+    (async () => {
+        // In order to avoid calling `setTimeout` too often, we accumulate sleep up until
+        // a certain threshold.
+        let missingSleep = 0;
+
+        // Extract (to make sure the value doesn't change) and sanitize `cpuRateLimit`.
+        let cpuRateLimit = config.cpuRateLimit;
+        if (isNaN(cpuRateLimit)) cpuRateLimit = 1.0;
+        if (cpuRateLimit > 1.0) cpuRateLimit = 1.0;
+        if (cpuRateLimit < 0.0) cpuRateLimit = 0.0;
+
+        const periodicallyYield = { value: false };
+        const [periodicallyYieldInit, unregisterCallback] = platformBindings.registerShouldPeriodicallyYield((newValue) => {
+            periodicallyYield.value = newValue;
+        });
+        periodicallyYield.value = periodicallyYieldInit;
+
+        let now = platformBindings.performanceNow();
+
+        while (true) {
+            const whenReadyAgain = new Promise((resolve) => advanceExecutionPromise.value = resolve as () => void);
+
+            const outcome = instance.exports.advance_execution();
+            if (outcome === 0) {
+                unregisterCallback();
+                break;
+            }
+
+            const afterExec = platformBindings.performanceNow();
+            const elapsed = afterExec - now;
+            now = afterExec;
+
+            // In order to enforce the rate limiting, we stop executing for a certain
+            // amount of time.
+            // The base equation here is: `(sleep + elapsed) * rateLimit == elapsed`,
+            // from which the calculation below is derived.
+            const sleep = elapsed * (1.0 / cpuRateLimit - 1.0);
+            missingSleep += sleep;
+
+            if (missingSleep > (periodicallyYield ? 5 : 1000)) {
+                // `setTimeout` has a maximum value, after which it will overflow. 🤦
+                // See <https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value>
+                // While adding a cap technically skews the CPU rate limiting algorithm, we don't
+                // really care for such extreme values.
+                if (missingSleep > 2147483646)  // Doc says `> 2147483647`, but I don't really trust their pedanticism so let's be safe
+                    missingSleep = 2147483646;
+                await new Promise((resolve) => setTimeout(resolve, missingSleep));
+                missingSleep = 0;
+            }
+
+            await whenReadyAgain;
+
+            const afterWait = platformBindings.performanceNow();
+            missingSleep -= (afterWait - now);
+            if (missingSleep < 0)
+                missingSleep = 0;
+            now = afterWait;
+        }
+    })();
+
     return [instance, bufferIndices];
 }

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-executor = { version = "1.5.1", default-features = false }
+async-task = { version = "4.4.0", default-features = false }
 event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
 futures-util = { version = "0.3.27", default-features = false }

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -28,17 +28,6 @@ pub(crate) struct Client<TPlat: smoldot_light::platform::PlatformRef, TChain> {
 
     /// List of all chains that have been added by the user.
     pub(crate) chains: slab::Slab<Chain>,
-
-    pub(crate) periodically_yield: bool,
-
-    pub(crate) max_divided_by_rate_limit_minus_one: f64,
-
-    /// Instead of sleeping regularly for short amounts of time, we instead continue running only
-    /// until the time we have to sleep reaches a certain threshold.
-    pub(crate) sleep_deprevation_sec: f64,
-
-    /// Prevent `main_task` from being called before this `Delay` is ready.
-    pub(crate) prevent_poll_until: crate::timers::Delay,
 }
 
 pub(crate) enum Chain {
@@ -68,8 +57,6 @@ pub(crate) enum Chain {
 pub(crate) fn init<TChain>(
     max_log_level: u32,
     enable_current_task: bool,
-    cpu_rate_limit: u32,
-    periodically_yield: bool,
 ) -> Client<platform::Platform, TChain> {
     // Try initialize the logging and the panic hook.
     let _ = log::set_boxed_logger(Box::new(Logger)).map(|()| {
@@ -145,20 +132,9 @@ pub(crate) fn init<TChain>(
         }),
     );
 
-    let max_divided_by_rate_limit_minus_one =
-        (f64::from(u32::max_value()) / f64::from(cpu_rate_limit)) - 1.0;
-    // Note that it is legal for `max_divided_by_rate_limit_minus_one` to be +infinite
-    debug_assert!(
-        !max_divided_by_rate_limit_minus_one.is_nan() && max_divided_by_rate_limit_minus_one >= 0.0
-    );
-
     Client {
         smoldot: smoldot_light::Client::new(platform),
         chains: slab::Slab::with_capacity(8),
-        periodically_yield,
-        max_divided_by_rate_limit_minus_one,
-        sleep_deprevation_sec: 0.0,
-        prevent_poll_until: crate::timers::Delay::new(Duration::new(0, 0)),
     }
 }
 

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -20,14 +20,12 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(unused_crate_dependencies)]
 
-use core::{num::NonZeroU32, pin::Pin, str, time::Duration};
-use futures_util::{stream, FutureExt as _, Stream as _, StreamExt as _};
+use core::{future, mem, num::NonZeroU32, pin::Pin, str, time::Duration};
+use futures_util::{stream, Stream as _, StreamExt as _};
 use smoldot_light::HandleRpcError;
 use std::{
-    future,
     sync::{Arc, Mutex},
     task,
-    time::Instant,
 };
 
 pub mod bindings;
@@ -49,30 +47,17 @@ fn start_timer_wrap(duration: Duration, closure: impl FnOnce() + 'static) {
 
 static CLIENT: Mutex<Option<init::Client<platform::Platform, ()>>> = Mutex::new(None);
 
-fn init(
-    max_log_level: u32,
-    enable_current_task: u32,
-    cpu_rate_limit: u32,
-    periodically_yield: u32,
-) {
-    let init_out = init::init(
-        max_log_level,
-        enable_current_task != 0,
-        cpu_rate_limit,
-        periodically_yield != 0,
-    );
+fn init(max_log_level: u32, enable_current_task: u32) {
+    let init_out = init::init(max_log_level, enable_current_task != 0);
 
     let mut client_lock = crate::CLIENT.lock().unwrap();
     assert!(client_lock.is_none());
     *client_lock = Some(init_out);
 }
 
-fn set_periodically_yield(periodically_yield: u32) {
-    CLIENT.lock().unwrap().as_mut().unwrap().periodically_yield = periodically_yield != 0;
-}
-
 fn start_shutdown() {
     // TODO: do this in a clean way
+    *EXECUTOR_EXECUTE.lock().unwrap() = ExecutionState::ShuttingDown;
     std::process::exit(0)
 }
 
@@ -416,57 +401,47 @@ impl task::Wake for JsonRpcResponsesNonEmptyWaker {
 // TODO: we use an Executor instead of LocalExecutor because it is planned to allow multithreading; if this plan is abandoned, switch to SendWrapper<LocalExecutor>
 static EXECUTOR: async_executor::Executor = async_executor::Executor::new();
 
-fn advance_execution() {
-    let mut client_lock = CLIENT.lock().unwrap();
-    let client_lock = client_lock.as_mut().unwrap();
+/// Optional future that never ends until the client is shutting down.
+static EXECUTOR_EXECUTE: Mutex<ExecutionState> = Mutex::new(ExecutionState::NotStarted);
 
-    loop {
-        if future::poll_fn(|cx| {
-            future::Future::poll(Pin::new(&mut client_lock.prevent_poll_until), cx)
-        })
-        .now_or_never()
-        .is_none()
-        {
-            break;
+enum ExecutionState {
+    NotStarted,
+    NotReady,
+    Ready(async_task::Runnable),
+    ShuttingDown,
+}
+
+fn advance_execution() -> u32 {
+    let runnable = {
+        let mut executor_execute_guard = EXECUTOR_EXECUTE.lock().unwrap();
+        match *executor_execute_guard {
+            ExecutionState::NotStarted => {
+                let (runnable, task) =
+                    async_task::spawn(EXECUTOR.run(future::pending::<()>()), |runnable| {
+                        let mut lock = EXECUTOR_EXECUTE.lock().unwrap();
+                        if !matches!(*lock, ExecutionState::NotReady) {
+                            return;
+                        }
+                        *lock = ExecutionState::Ready(runnable);
+                        unsafe {
+                            bindings::advance_execution_ready();
+                        }
+                    });
+
+                task.detach();
+                *executor_execute_guard = ExecutionState::NotReady;
+                runnable
+            }
+            ExecutionState::NotReady => return 1,
+            ExecutionState::ShuttingDown => return 0,
+            ExecutionState::Ready(_) => {
+                let ExecutionState::Ready(runnable) = mem::replace(&mut *executor_execute_guard, ExecutionState::NotReady)
+                    else { unreachable!() };
+                runnable
+            }
         }
+    };
 
-        let before_polling = Instant::now();
-
-        // Advance one background task.
-        // If nothing is actually executed, break out of the loop as there is nothing to do.
-        if !EXECUTOR.try_tick() {
-            break;
-        }
-
-        // Time it took to execute `try_tick`.
-        let after_polling = Instant::now();
-        let poll_duration = after_polling - before_polling;
-
-        // In order to enforce the rate limiting, we prevent `try_tick` from executing
-        // for a certain amount of time.
-        // The base equation here is: `(after_tick_sleep + poll_duration) * rate_limit == poll_duration * u32::max_value()`.
-        let after_tick_sleep =
-            poll_duration.as_secs_f64() * client_lock.max_divided_by_rate_limit_minus_one;
-        debug_assert!(after_tick_sleep >= 0.0 && !after_tick_sleep.is_nan());
-        client_lock.sleep_deprevation_sec += after_tick_sleep;
-
-        if client_lock.sleep_deprevation_sec > 0.005 {
-            client_lock.prevent_poll_until = crate::timers::Delay::new_at(
-                after_polling
-                    + Duration::try_from_secs_f64(client_lock.sleep_deprevation_sec)
-                        .unwrap_or(Duration::MAX),
-            );
-            client_lock.sleep_deprevation_sec = 0.0;
-        }
-
-        // If the task woke itself up (which means that it has more to execute), we continue
-        // looping provided that `periodically_yield` is `false`.
-        if !client_lock.periodically_yield {
-            continue;
-        }
-
-        // If the task woke itself up and `periodically_yield` is `true`, we use
-        // `setTimeout(..., 0)` to actually yield.
-        start_timer_wrap(Duration::new(0, 0), advance_execution);
-    }
+    runnable.run();
+    1
 }


### PR DESCRIPTION
This PR backports one of the changes of https://github.com/smol-dot/smoldot/pull/494

Instead of having `advance_execution` be called in all the callbacks called by the JS, we now have a separate JS task that is responsible only for executions. This JS task might get waken up by one of the callbacks.

Just like in #494, this allows moving the CPU rate limiting and periodic yield system to the JS code.

Contrary to #494, notifying that the execution is ready is done with a callback, and not by notifying a memory location. Callbacks are completely fine when things are single threaded, they just are inappropriate in case of multiple threads.

This PR de-spaghetifies the internals of smoldot. Everything is now in my opinion much more clear.
