### PR TITLE
Simplify the timers API

### DIFF
--- a/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
+++ b/wasm-node/javascript/src/instance/bindings-smoldot-light.ts
@@ -308,7 +308,7 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
         },
 
         // Must call `timer_finished` after the given number of milliseconds has elapsed.
-        start_timer: (id: number, ms: number) => {
+        start_timer: (ms: number) => {
             if (killedTracked.killed) return;
 
             const instance = config.instance!;
@@ -327,14 +327,14 @@ export default function (config: Config): { imports: WebAssembly.ModuleImports, 
                 setImmediate(() => {
                     if (killedTracked.killed) return;
                     try {
-                        instance.exports.timer_finished(id);
+                        instance.exports.timer_finished();
                     } catch (_error) { }
                 })
             } else {
                 setTimeout(() => {
                     if (killedTracked.killed) return;
                     try {
-                        instance.exports.timer_finished(id);
+                        instance.exports.timer_finished();
                     } catch (_error) { }
                 }, ms)
             }

--- a/wasm-node/javascript/src/instance/bindings.ts
+++ b/wasm-node/javascript/src/instance/bindings.ts
@@ -34,7 +34,7 @@ export interface SmoldotWasmExports extends WebAssembly.Exports {
     json_rpc_send: (textBufferIndex: number, chainId: number) => number,
     json_rpc_responses_peek: (chainId: number) => number,
     json_rpc_responses_pop: (chainId: number) => void,
-    timer_finished: (timerId: number) => void,
+    timer_finished: () => void,
     connection_open_single_stream: (connectionId: number, handshakeTy: number, initialWritableBytes: number, writeClosable: number) => void,
     connection_open_multi_stream: (connectionId: number, handshakeTyBufferIndex: number) => void,
     stream_writable_bytes: (connectionId: number, streamId: number, numBytes: number) => void,

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -134,8 +134,7 @@ extern "C" {
     /// [`advance_execution`] should be called again immediately after it returns.
     pub fn advance_execution_ready();
 
-    /// After at least `milliseconds` milliseconds have passed, must call [`timer_finished`] with
-    /// the `id` passed as parameter.
+    /// After at least `milliseconds` milliseconds have passed, [`timer_finished`] must be called.
     ///
     /// It is not a logic error to call [`timer_finished`] *before* `milliseconds` milliseconds
     /// have passed, and this will likely cause smoldot to restart a new timer for the remainder
@@ -147,7 +146,7 @@ extern "C" {
     /// If `milliseconds` is 0, [`timer_finished`] should be called as soon as possible.
     ///
     /// `milliseconds` never contains a negative number, `NaN` or infinite.
-    pub fn start_timer(id: u32, milliseconds: f64);
+    pub fn start_timer(milliseconds: f64);
 
     /// Must initialize a new connection that tries to connect to the given multiaddress.
     ///
@@ -481,8 +480,8 @@ pub extern "C" fn json_rpc_responses_pop(chain_id: u32) {
 
 /// Must be called in response to [`start_timer`] after the given duration has passed.
 #[no_mangle]
-pub extern "C" fn timer_finished(timer_id: u32) {
-    crate::timers::timer_finished(timer_id);
+pub extern "C" fn timer_finished() {
+    crate::timers::timer_finished();
 }
 
 /// Called by the JavaScript code if the connection switches to the `Open` state. The connection

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -20,7 +20,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(unused_crate_dependencies)]
 
-use core::{future, mem, num::NonZeroU32, pin::Pin, str, time::Duration};
+use core::{future, mem, num::NonZeroU32, pin::Pin, str};
 use futures_util::{stream, Stream as _, StreamExt as _};
 use smoldot_light::HandleRpcError;
 use std::{
@@ -34,16 +34,6 @@ mod alloc;
 mod init;
 mod platform;
 mod timers;
-
-/// Uses the environment to invoke `closure` after at least `duration` has elapsed.
-fn start_timer_wrap(duration: Duration, closure: impl FnOnce() + 'static) {
-    let callback: Box<Box<dyn FnOnce() + 'static>> = Box::new(Box::new(closure));
-    let timer_id = u32::try_from(Box::into_raw(callback) as usize).unwrap();
-    // Note that ideally `duration` should be rounded up in order to make sure that it is not
-    // truncated, but the precision of an `f64` is so high and the precision of the operating
-    // system generally so low that this is not worth dealing with.
-    unsafe { bindings::start_timer(timer_id, duration.as_secs_f64() * 1000.0) }
-}
 
 static CLIENT: Mutex<Option<init::Client<platform::Platform, ()>>> = Mutex::new(None);
 


### PR DESCRIPTION
Now that #505 is in, `start_timer_wrap` is only ever called from within the `timers` module. This makes the `timerId` parameter quite useless. As such, this PR removes it.

Note that we could in theory pass "now" to `timer_finished` in order to save a function call, but this would punch through abstraction layers given that `Instant` is in the stdlib.
