### PR TITLE
Always enable the "current task" system

### DIFF
--- a/wasm-node/javascript/src/client.ts
+++ b/wasm-node/javascript/src/client.ts
@@ -403,10 +403,6 @@ export function start(options: ClientOptions, wasmModule: Promise<WebAssembly.Mo
         // 0 = Logging disabled, 1 = Error, 2 = Warn, 3 = Info, 4 = Debug, 5 = Trace
         maxLogLevel: options.maxLogLevel || 3,
         logCallback,
-        // `enableCurrentTask` adds a small performance hit, but adds some additional information to
-        // crash reports. Whether this should be enabled is very opiniated and not that important. At
-        // the moment, we enable it all the time, except if the user has logging disabled altogether.
-        enableCurrentTask: options.maxLogLevel ? options.maxLogLevel >= 1 : true,
         cpuRateLimit: options.cpuRateLimit || 1.0,
     }, platformBindings);
 

--- a/wasm-node/javascript/src/instance/bindings.ts
+++ b/wasm-node/javascript/src/instance/bindings.ts
@@ -23,7 +23,7 @@
  */
 export interface SmoldotWasmExports extends WebAssembly.Exports {
     memory: WebAssembly.Memory,
-    init: (maxLogLevel: number, enableCurrentTask: number) => void,
+    init: (maxLogLevel: number) => void,
     advance_execution: () => number,
     start_shutdown: () => void,
     add_chain: (chainSpecBufferIndex: number, databaseContentBufferIndex: number, jsonRpcRunning: number, potentialRelayChainsBufferIndex: number) => number;

--- a/wasm-node/javascript/src/instance/instance.ts
+++ b/wasm-node/javascript/src/instance/instance.ts
@@ -58,7 +58,6 @@ export interface Config {
     wasmModule: Promise<WebAssembly.Module>,
     logCallback: (level: number, target: string, message: string) => void
     maxLogLevel: number;
-    enableCurrentTask: boolean;
     cpuRateLimit: number,
 }
 
@@ -129,7 +128,6 @@ export function start(configMessage: Config, platformBindings: instance.Platform
                 currentTask.name = taskName
             },
             cpuRateLimit: configMessage.cpuRateLimit,
-            enableCurrentTask: configMessage.enableCurrentTask,
             maxLogLevel: configMessage.maxLogLevel,
         };
 

--- a/wasm-node/javascript/src/instance/raw-instance.ts
+++ b/wasm-node/javascript/src/instance/raw-instance.ts
@@ -40,7 +40,6 @@ export interface Config {
     jsonRpcResponsesNonEmptyCallback: (chainId: number) => void,
     currentTaskCallback?: (taskName: string | null) => void,
     maxLogLevel: number;
-    enableCurrentTask: boolean;
     cpuRateLimit: number,
 }
 
@@ -137,7 +136,7 @@ export async function startInstance(config: Config, platformBindings: PlatformBi
 
     // Smoldot requires an initial call to the `init` function in order to do its internal
     // configuration.
-    instance.exports.init(config.maxLogLevel, config.enableCurrentTask ? 1 : 0);
+    instance.exports.init(config.maxLogLevel);
 
     (async () => {
         // In order to avoid calling `setTimeout` too often, we accumulate sleep up until

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -272,16 +272,12 @@ extern "C" {
     ///
     /// The name of the task is a UTF-8 string found in the memory of the WebAssembly virtual
     /// machine at offset `ptr` and with length `len`.
-    ///
-    /// This function is called only if `enable_current_task` was non-zero when calling [`init`].
     pub fn current_task_entered(ptr: u32, len: u32);
 
     /// Called when the Wasm execution leave the context of a certain task. This is useful for
     /// debugging purposes.
     ///
     /// Only one task can be currently executing at any time.
-    ///
-    /// This function is called only if `enable_current_task` was non-zero when calling [`init`].
     pub fn current_task_exit();
 }
 
@@ -293,13 +289,9 @@ extern "C" {
 ///
 /// The client will emit log messages by calling the [`log()`] function, provided the log level is
 /// inferior or equal to the value of `max_log_level` passed here.
-///
-/// If `enbable_current_task` is non-zero, smoldot will call the [`current_task_entered`] and
-/// [`current_task_exit`] functions to report when it enters and leaves tasks. This slightly
-/// slows everything down, but is useful for debugging purposes.
 #[no_mangle]
-pub extern "C" fn init(max_log_level: u32, enable_current_task: u32) {
-    crate::init(max_log_level, enable_current_task);
+pub extern "C" fn init(max_log_level: u32) {
+    crate::init(max_log_level);
 }
 
 /// Advances the execution of the client, performing CPU-heavy tasks.

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -54,10 +54,7 @@ pub(crate) enum Chain {
     },
 }
 
-pub(crate) fn init<TChain>(
-    max_log_level: u32,
-    enable_current_task: bool,
-) -> Client<platform::Platform, TChain> {
+pub(crate) fn init<TChain>(max_log_level: u32) -> Client<platform::Platform, TChain> {
     // Try initialize the logging and the panic hook.
     let _ = log::set_boxed_logger(Box::new(Logger)).map(|()| {
         log::set_max_level(match max_log_level {
@@ -85,7 +82,7 @@ pub(crate) fn init<TChain>(
     assert_ne!(rand::random::<u64>(), 0);
     assert_ne!(rand::random::<u64>(), rand::random::<u64>());
 
-    let platform = platform::Platform::new(enable_current_task);
+    let platform = platform::Platform::new();
 
     // Spawn a constantly-running task that periodically prints the total memory usage of
     // the node.

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -37,8 +37,8 @@ mod timers;
 
 static CLIENT: Mutex<Option<init::Client<platform::Platform, ()>>> = Mutex::new(None);
 
-fn init(max_log_level: u32, enable_current_task: u32) {
-    let init_out = init::init(max_log_level, enable_current_task != 0);
+fn init(max_log_level: u32) {
+    let init_out = init::init(max_log_level);
 
     let mut client_lock = crate::CLIENT.lock().unwrap();
     assert!(client_lock.is_none());


### PR DESCRIPTION
The "current tasks system" is, with the max log level, the only other thing that requires some global initialization.
This PR enables this system by default, so that you don't need to care about it.

At the moment, it is enabled unless the user disables logging altogether, which I assume nobody does. Changing this to always be enabled most likely doesn't actually influence actually.