### PR TITLE
Split the multiaddress parsing from the connecting

### DIFF
--- a/wasm-node/javascript/src/client.ts
+++ b/wasm-node/javascript/src/client.ts
@@ -370,7 +370,7 @@ export interface AddChainOptions {
 // This function is similar to the `start` function found in `index.ts`, except with an extra
 // parameter containing the platform-specific bindings.
 // Contrary to the one within `index.js`, this function is not supposed to be directly used.
-export function start(options: ClientOptions, wasmModule: Promise<WebAssembly.Module>, platformBindings: PlatformBindings): Client {
+export function start<A>(options: ClientOptions, wasmModule: Promise<WebAssembly.Module>, platformBindings: PlatformBindings<A>): Client {
     const logCallback = options.logCallback || ((level, target, message) => {
         // The first parameter of the methods of `console` has some printf-like substitution
         // capabilities. We don't really need to use this, but not using it means that the logs might

--- a/wasm-node/javascript/src/index-deno.ts
+++ b/wasm-node/javascript/src/index-deno.ts
@@ -156,7 +156,7 @@ function trustedBase64Decode(base64: string): Uint8Array {
  */
 function connect(config: ConnectionConfig<ParsedAddress>): Connection {
     if (config.address.ty === "websocket") {
-        const socket = new WebSocket(config.address.ty);
+        const socket = new WebSocket(config.address.url);
         socket.binaryType = 'arraybuffer';
 
         const bufferedAmountCheck = { quenedUnreportedBytes: 0, nextTimeout: 10 };

--- a/wasm-node/javascript/src/index-deno.ts
+++ b/wasm-node/javascript/src/index-deno.ts
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { Client, ClientOptions, start as innerStart } from './client.js'
-import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
+import { Connection, ConnectionConfig } from './instance/instance.js';
 import { default as wasmBase64 } from './instance/autogen/wasm.js';
 
 export {
@@ -49,7 +49,7 @@ export function start(options?: ClientOptions): Client {
     // cross-platform cross-bundler approach.
     const wasmModule = zlibInflate(trustedBase64Decode(wasmBase64)).then(((bytecode) => WebAssembly.compile(bytecode)));
 
-    return innerStart(options || {}, wasmModule, {
+    return innerStart<ParsedAddress>(options || {}, wasmModule, {
         registerShouldPeriodicallyYield: (_callback) => {
             return [true, () => { }]
         },
@@ -62,11 +62,45 @@ export function start(options?: ClientOptions): Client {
                 throw new Error('randomness not available');
             crypto.getRandomValues(buffer);
         },
+        parseMultiaddr: (address) => {
+            const wsParsed = address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|tls\/ws)$/);
+            const tcpParsed = address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)$/);
+
+            if (wsParsed != null) {
+                const proto = (wsParsed[4] == 'ws') ? 'ws' : 'wss';
+                if (
+                    (proto == 'ws' && options?.forbidWs) ||
+                    (proto == 'ws' && wsParsed[2] != 'localhost' && wsParsed[2] != '127.0.0.1' && options?.forbidNonLocalWs) ||
+                    (proto == 'wss' && options?.forbidWss)
+                ) {
+                    return { success: false, error: 'TCP connections not available' }
+                }
+
+                const url = (wsParsed[1] == 'ip6') ?
+                    (proto + "://[" + wsParsed[2] + "]:" + wsParsed[3]) :
+                    (proto + "://" + wsParsed[2] + ":" + wsParsed[3]);
+
+                return { success: true, address: { ty: "websocket", url } }
+            } else if (tcpParsed != null) {
+                if (options?.forbidTcp) {
+                    return { success: false, error: 'TCP connections not available' }
+                }
+
+                return { success: true, address: { ty: "tcp", hostname: tcpParsed[2]!, port: parseInt(tcpParsed[3]!) } }
+
+            } else {
+                return { success: false, error: 'Unrecognized multiaddr format' }
+            }
+        },
         connect: (config) => {
-            return connect(config, options?.forbidTcp || false, options?.forbidWs || false, options?.forbidNonLocalWs || false, options?.forbidWss || false)
+            return connect(config)
         }
     })
 }
+
+type ParsedAddress =
+    { ty: "tcp", hostname: string, port: number } |
+    { ty: "websocket", url: string }
 
 /**
  * Applies the zlib inflate algorithm on the buffer.
@@ -120,27 +154,9 @@ function trustedBase64Decode(base64: string): Uint8Array {
  * @see Connection
  * @throws {@link ConnectionError} If the multiaddress couldn't be parsed or contains an invalid protocol.
  */
-function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean, forbidNonLocalWs: boolean, forbidWss: boolean): Connection {
-    // Attempt to parse the multiaddress.
-    // TODO: remove support for `/wss` in a long time (https://github.com/paritytech/smoldot/issues/1940)
-    const wsParsed = config.address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|tls\/ws)$/);
-    const tcpParsed = config.address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)$/);
-
-    if (wsParsed != null) {
-        const proto = (wsParsed[4] == 'ws') ? 'ws' : 'wss';
-        if (
-            (proto == 'ws' && forbidWs) ||
-            (proto == 'ws' && wsParsed[2] != 'localhost' && wsParsed[2] != '127.0.0.1' && forbidNonLocalWs) ||
-            (proto == 'wss' && forbidWss)
-        ) {
-            throw new ConnectionError('Connection type not allowed');
-        }
-
-        const url = (wsParsed[1] == 'ip6') ?
-            (proto + "://[" + wsParsed[2] + "]:" + wsParsed[3]) :
-            (proto + "://" + wsParsed[2] + ":" + wsParsed[3]);
-
-        const socket = new WebSocket(url);
+function connect(config: ConnectionConfig<ParsedAddress>): Connection {
+    if (config.address.ty === "websocket") {
+        const socket = new WebSocket(config.address.ty);
         socket.binaryType = 'arraybuffer';
 
         const bufferedAmountCheck = { quenedUnreportedBytes: 0, nextTimeout: 10 };
@@ -206,16 +222,12 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
             openOutSubstream: () => { throw new Error('Wrong connection type') }
         };
 
-    } else if (tcpParsed != null) {
-        if (forbidTcp) {
-            throw new ConnectionError('TCP connections not available');
-        }
-
+    } else {
         const socket = {
             destroyed: false,
             inner: Deno.connect({
-                hostname: tcpParsed[2],
-                port: parseInt(tcpParsed[3]!, 10),
+                hostname: config.address.hostname,
+                port: config.address.port,
             }).catch((error) => {
                 socket.destroyed = true;
                 config.onConnectionReset(error.toString());
@@ -308,9 +320,6 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
 
             openOutSubstream: () => { throw new Error('Wrong connection type') }
         };
-
-    } else {
-        throw new ConnectionError('Unrecognized multiaddr format');
     }
 }
 

--- a/wasm-node/javascript/src/index-nodejs.ts
+++ b/wasm-node/javascript/src/index-nodejs.ts
@@ -20,7 +20,7 @@
 // with both at the same time.
 
 import { Client, ClientOptions, start as innerStart } from './client.js'
-import { Connection, ConnectionError, ConnectionConfig } from './instance/instance.js';
+import { Connection, ConnectionConfig } from './instance/instance.js';
 import { default as wasmBase64 } from './instance/autogen/wasm.js';
 
 import { WebSocket } from 'ws';
@@ -60,7 +60,7 @@ export function start(options?: ClientOptions): Client {
     // cross-platform cross-bundler approach.
     const wasmModule = WebAssembly.compile(inflate(Buffer.from(wasmBase64, 'base64')));
 
-    return innerStart(options || {}, wasmModule, {
+    return innerStart<ParsedAddress>(options || {}, wasmModule, {
         registerShouldPeriodicallyYield: (_callback) => {
             return [true, () => { }]
         },
@@ -72,11 +72,45 @@ export function start(options?: ClientOptions): Client {
                 throw new Error('getRandomValues buffer too large')
             randomFillSync(buffer)
         },
+        parseMultiaddr: (address) => {
+            const wsParsed = address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|tls\/ws)$/);
+            const tcpParsed = address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)$/);
+
+            if (wsParsed != null) {
+                const proto = (wsParsed[4] == 'ws') ? 'ws' : 'wss';
+                if (
+                    (proto == 'ws' && options?.forbidWs) ||
+                    (proto == 'ws' && wsParsed[2] != 'localhost' && wsParsed[2] != '127.0.0.1' && options?.forbidNonLocalWs) ||
+                    (proto == 'wss' && options?.forbidWss)
+                ) {
+                    return { success: false, error: 'TCP connections not available' }
+                }
+
+                const url = (wsParsed[1] == 'ip6') ?
+                    (proto + "://[" + wsParsed[2] + "]:" + wsParsed[3]) :
+                    (proto + "://" + wsParsed[2] + ":" + wsParsed[3]);
+
+                return { success: true, address: { ty: "websocket", url } }
+            } else if (tcpParsed != null) {
+                if (options?.forbidTcp) {
+                    return { success: false, error: 'TCP connections not available' }
+                }
+
+                return { success: true, address: { ty: "tcp", hostname: tcpParsed[2]!, port: parseInt(tcpParsed[3]!) } }
+
+            } else {
+                return { success: false, error: 'Unrecognized multiaddr format' }
+            }
+        },
         connect: (config) => {
-            return connect(config, options?.forbidTcp || false, options?.forbidWs || false, options?.forbidNonLocalWs || false, options?.forbidWss || false)
+            return connect(config)
         }
     })
 }
+
+type ParsedAddress =
+    { ty: "tcp", hostname: string, port: number } |
+    { ty: "websocket", url: string }
 
 /**
  * Tries to open a new connection using the given configuration.
@@ -84,27 +118,9 @@ export function start(options?: ClientOptions): Client {
  * @see Connection
  * @throws {@link ConnectionError} If the multiaddress couldn't be parsed or contains an invalid protocol.
  */
-function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean, forbidNonLocalWs: boolean, forbidWss: boolean): Connection {
-    // Attempt to parse the multiaddress.
-    // TODO: remove support for `/wss` in a long time (https://github.com/paritytech/smoldot/issues/1940)
-    const wsParsed = config.address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|tls\/ws)$/);
-    const tcpParsed = config.address.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)$/);
-
-    if (wsParsed != null) {
-        const proto = (wsParsed[4] == 'ws') ? 'ws' : 'wss';
-        if (
-            (proto == 'ws' && forbidWs) ||
-            (proto == 'ws' && wsParsed[2] != 'localhost' && wsParsed[2] != '127.0.0.1' && forbidNonLocalWs) ||
-            (proto == 'wss' && forbidWss)
-        ) {
-            throw new ConnectionError('Connection type not allowed');
-        }
-
-        const url = (wsParsed[1] == 'ip6') ?
-            (proto + "://[" + wsParsed[2] + "]:" + wsParsed[3]) :
-            (proto + "://" + wsParsed[2] + ":" + wsParsed[3]);
-
-        const socket = new WebSocket(url);
+function connect(config: ConnectionConfig<ParsedAddress>): Connection {
+    if (config.address.ty === "websocket") {
+        const socket = new WebSocket(config.address.url);
         socket.binaryType = 'arraybuffer';
 
         const bufferedAmountCheck = { quenedUnreportedBytes: 0, nextTimeout: 10 };
@@ -176,15 +192,10 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
             openOutSubstream: () => { throw new Error('Wrong connection type') }
         };
 
-    } else if (tcpParsed != null) {
-        // `net` module will be missing when we're not in NodeJS.
-        if (forbidTcp) {
-            throw new ConnectionError('TCP connections not available');
-        }
-
+    } else {
         const socket = nodeCreateConnection({
-            host: tcpParsed[2],
-            port: parseInt(tcpParsed[3]!, 10),
+            host: config.address.hostname,
+            port: config.address.port,
         });
 
         // Number of bytes queued using `socket.write` and where `write` has returned false.
@@ -241,8 +252,5 @@ function connect(config: ConnectionConfig, forbidTcp: boolean, forbidWs: boolean
             },
             openOutSubstream: () => { throw new Error('Wrong connection type') }
         };
-
-    } else {
-        throw new ConnectionError('Unrecognized multiaddr format');
     }
 }

--- a/wasm-node/javascript/src/instance/instance.ts
+++ b/wasm-node/javascript/src/instance/instance.ts
@@ -20,7 +20,7 @@ import * as instance from './raw-instance.js';
 import { SmoldotWasmInstance } from './bindings.js';
 import { AlreadyDestroyedError } from '../client.js';
 
-export { PlatformBindings, ConnectionError, ConnectionConfig, Connection } from './raw-instance.js';
+export { PlatformBindings, ConnectionConfig, Connection } from './raw-instance.js';
 
 /**
  * Thrown in case the underlying client encounters an unexpected crash.
@@ -69,7 +69,7 @@ export interface Instance {
     startShutdown: () => void
 }
 
-export function start(configMessage: Config, platformBindings: instance.PlatformBindings): Instance {
+export function start<A>(configMessage: Config, platformBindings: instance.PlatformBindings<A>): Instance {
 
     // This variable represents the state of the instance, and serves two different purposes:
     //


### PR DESCRIPTION
Opening a connection is now done in two calls: one to parse the multiaddress and one to actually connect.

This change is done in anticipation of a later change, when we will want to parse the address immediately then send the parsed address over a port and then only connect.

It also removes a current hack where we check `error instanceof ConnectionError` to determine whether it's a bad address issue or something else.
