### PR TITLE
Remove "periodic yield" system

### DIFF
--- a/wasm-node/javascript/src/index-browser.ts
+++ b/wasm-node/javascript/src/index-browser.ts
@@ -54,13 +54,6 @@ export function start(options?: ClientOptions): Client {
     const wasmModule = WebAssembly.compile(inflate(classicDecode(wasmBase64)));
 
     return innerStart<ParsedAddress>(options, wasmModule, {
-        registerShouldPeriodicallyYield: (callback) => {
-            if (typeof document === 'undefined')   // We might be in a web worker.
-                return [false, () => { }];
-            const wrappedCallback = () => callback(document.visibilityState === 'visible');
-            document.addEventListener('visibilitychange', wrappedCallback);
-            return [document.visibilityState === 'visible', () => { document.removeEventListener('visibilitychange', wrappedCallback) }]
-        },
         performanceNow: () => {
             return performance.now()
         },

--- a/wasm-node/javascript/src/index-deno.ts
+++ b/wasm-node/javascript/src/index-deno.ts
@@ -50,9 +50,6 @@ export function start(options?: ClientOptions): Client {
     const wasmModule = zlibInflate(trustedBase64Decode(wasmBase64)).then(((bytecode) => WebAssembly.compile(bytecode)));
 
     return innerStart<ParsedAddress>(options || {}, wasmModule, {
-        registerShouldPeriodicallyYield: (_callback) => {
-            return [true, () => { }]
-        },
         performanceNow: () => {
             return performance.now()
         },

--- a/wasm-node/javascript/src/index-nodejs.ts
+++ b/wasm-node/javascript/src/index-nodejs.ts
@@ -61,9 +61,6 @@ export function start(options?: ClientOptions): Client {
     const wasmModule = WebAssembly.compile(inflate(Buffer.from(wasmBase64, 'base64')));
 
     return innerStart<ParsedAddress>(options || {}, wasmModule, {
-        registerShouldPeriodicallyYield: (_callback) => {
-            return [true, () => { }]
-        },
         performanceNow: () => {
             return performance.now()
         },


### PR DESCRIPTION
The "periodic yield" system exists in order to avoid calling `setTimeout(..., smallValue)` repeatedly in situations where it might take a long time, such as when the tab is in the background.
See https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#timeouts_in_inactive_tabs

This PR removes this system and instead automatically adjusts the behavior of the code based on much time `setTimeout` actually took. This is an overall cleaner and more robust way to do it.
