### PR TITLE
Add an event when a pending negotiation substream is reset

### DIFF
--- a/lib/src/libp2p/connection/established.rs
+++ b/lib/src/libp2p/connection/established.rs
@@ -93,6 +93,14 @@ pub enum Event<TSubUd> {
         protocol_name: String,
     },
 
+    /// An inbound substream that is waiting for a call to [`SingleStream::accept_inbound`],
+    /// [`SingleStream::reject_inbound`], [`MultiStream::accept_inbound`], or
+    /// [`MultiStream::reject_inbound`] has been abruptly closed.
+    InboundNegotiatedCancel {
+        /// Identifier of the substream.
+        id: SubstreamId,
+    },
+
     /// An inbound substream that was previously accepted using [`SingleStream::accept_inbound`]
     /// or [`MultiStream::accept_inbound`] was closed by the remote or has generated an error.
     InboundAcceptedCancel {

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -577,6 +577,10 @@ where
                 id: SubstreamId(SubstreamIdInner::MultiStream(substream_id)),
                 protocol_name,
             },
+            substream::Event::InboundNegotiatedCancel => Event::InboundAcceptedCancel {
+                id: SubstreamId(SubstreamIdInner::MultiStream(substream_id)),
+                user_data: substream_user_data.take().unwrap(),
+            },
             substream::Event::RequestIn { request } => Event::RequestIn {
                 id: SubstreamId(SubstreamIdInner::MultiStream(substream_id)),
                 request,

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -659,6 +659,9 @@ where
                 id: SubstreamId(SubstreamIdInner::SingleStream(substream_id)),
                 protocol_name,
             },
+            substream::Event::InboundNegotiatedCancel => Event::InboundNegotiatedCancel {
+                id: SubstreamId(SubstreamIdInner::SingleStream(substream_id)),
+            },
             substream::Event::RequestIn { request } => Event::RequestIn {
                 id: SubstreamId(SubstreamIdInner::SingleStream(substream_id)),
                 request,

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -1059,7 +1059,7 @@ where
         match self.inner {
             SubstreamInner::InboundNegotiating(_, _) => None,
             SubstreamInner::InboundNegotiatingAccept(_, _) => None,
-            SubstreamInner::InboundNegotiatingApiWait(_) => None,
+            SubstreamInner::InboundNegotiatingApiWait(_) => Some(Event::InboundNegotiatedCancel),
             SubstreamInner::InboundFailed => None,
             SubstreamInner::RequestOut { .. } => Some(Event::Response {
                 response: Err(RequestError::SubstreamReset),
@@ -1354,6 +1354,11 @@ pub enum Event {
     /// An inbound substream has successfully negotiated a protocol. Call
     /// [`Substream::accept_inbound`] or [`Substream::reject_inbound`] in order to resume.
     InboundNegotiated(String),
+
+    /// An inbound substream that had successfully negotiated a protocol got abruptly closed
+    /// while waiting for the call to [`Substream::accept_inbound`] or
+    /// [`Substream::reject_inbound`].
+    InboundNegotiatedCancel,
 
     /// Received a request in the context of a request-response protocol.
     RequestIn {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix panic when a remote opens a substream then immediately resets it before smoldot has been able to determine asynchronously whether to accept it or not.
+
 ## 1.0.4 - 2023-05-03
 
 ### Added

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix panic when a remote opens a substream then immediately resets it before smoldot has been able to determine asynchronously whether to accept it or not.
+- Fix panic when a remote opens a substream then immediately resets it before smoldot has been able to determine asynchronously whether to accept it or not. ([#521](https://github.com/smol-dot/smoldot/pull/521))
 
 ## 1.0.4 - 2023-05-03
 


### PR DESCRIPTION
Fix #506 

I'm not super happy about that fix. The way I fixed it is consistent with how the code is, but it definitely increases once again the complexity of all these events. Some kind of simplification is desperately needed, but I don't know which.
