### PR TITLE
Simplify the handling of shutdowns and fix `terminate` not waiting for the shutdown to finish

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- The `Promise` returned by `terminate()` now correctly waits for everything to be completely shut down before yielding instead of letting the shutdown continue happening in the background. ([#538](https://github.com/smol-dot/smoldot/pull/538))
+
 ## 1.0.5 - 2023-05-05
 
 It is now possible to run the CPU-heavy tasks of smoldot within a worker (WebWorker, worker threads, etc.). To do so, create two ports using `new MessageChannel()`, pass one of the two ports in the `ClientOptions.portToWorker` field and send the other port to a web worker, then call `run(port)` from within that worker. The `run` function can be found by importing `import { run } from 'smoldot/worker'`. If a `portToWorker` is provided, then the `cpuRateLimit` setting applies to the worker.

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -570,7 +570,7 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                 throw state.instance.error;
             if (state.instance.status !== "ready")
                 throw new Error(); // Internal error. Never supposed to happen.
-            state.instance.instance.startShutdown();
+            state.instance.instance.shutdownExecutor();
             state.instance = { status: "destroyed", error: new AlreadyDestroyedError() };
             state.connections.forEach((connec) => connec.reset());
             state.connections.clear();

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -256,6 +256,8 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
         // FIFO queue. When `addChain` is called, an entry is added to this queue. When the
         // instance notifies that a chain creation has succeeded or failed, an entry is popped.
         addChainResults: Array<(outcome: { success: true, chainId: number } | { success: false, error: string }) => void>,
+        /// Callback called when the `executor-shutdown` or `wasm-panic` event is received.
+        onExecutorShutdownOrWasmPanic: () => void,
         // List of all active chains. Keys are chainIDs assigned by the instance.
         chains: Map<number, {
             // Callbacks woken up when a JSON-RPC response is ready or when the chain is destroyed
@@ -268,6 +270,7 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
         currentTaskName: null,
         connections: new Map(),
         addChainResults: [],
+        onExecutorShutdownOrWasmPanic: () => {},
         chains: new Map(),
     };
 
@@ -306,7 +309,16 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
 
                 state.currentTaskName = null;
 
+                const cb = state.onExecutorShutdownOrWasmPanic;
+                state.onExecutorShutdownOrWasmPanic = () => {};
+                cb();
                 break
+            }
+            case "executor-shutdown": {
+                const cb = state.onExecutorShutdownOrWasmPanic;
+                state.onExecutorShutdownOrWasmPanic = () => {};
+                cb();
+                break;
             }
             case "log": {
                 logCallback(event.level, event.target, event.message)
@@ -586,6 +598,9 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
             }
             state.chains.clear();
             state.currentTaskName = null;
+
+            // Wait for the `executor-shutdown` event to be generated.
+            await new Promise<void>((resolve) => state.onExecutorShutdownOrWasmPanic = resolve);
         }
     }
 }

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -87,8 +87,6 @@ export async function connectToInstanceServer(config: ConnectConfig): Promise<in
         switch (message.ty) {
             case "wasm-panic":
             case "executor-shutdown": {
-                state.jsonRpcResponses.clear();
-                state.connections.clear();
                 portToServer.close();
                 initialPort.close();
                 break;
@@ -260,6 +258,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
     initPortToClient.close();
 
     const state: {
+        // Always set except at the very beginning.
         instance: instance.Instance | null,
         connections: Map<number, Set<number>>,
         acceptedJsonRpcResponses: Map<number, number>,
@@ -278,18 +277,8 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 }
                 break;
             }
-            case "executor-shutdown": {
-                if (state.onExecutorShutdownOrWasmPanic) {
-                    const cb = state.onExecutorShutdownOrWasmPanic;
-                    delete state.onExecutorShutdownOrWasmPanic
-                    cb();
-                }
-                break;
-            }
+            case "executor-shutdown":
             case "wasm-panic": {
-                state.instance = null;
-                state.connections.clear();
-                state.acceptedJsonRpcResponses.clear();
                 if (state.onExecutorShutdownOrWasmPanic) {
                     const cb = state.onExecutorShutdownOrWasmPanic;
                     delete state.onExecutorShutdownOrWasmPanic
@@ -302,12 +291,10 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 // from within the events callback itself.
                 // TODO: do better than setTimeout?
                 setTimeout(() => {
-                    if (!state.instance)
-                        return;
                     const numAccepted = state.acceptedJsonRpcResponses.get(event.chainId)!;
                     if (numAccepted == 0)
                         return;
-                    const response = state.instance.peekJsonRpcResponse(event.chainId);
+                    const response = state.instance!.peekJsonRpcResponse(event.chainId);
                     if (response) {
                         state.acceptedJsonRpcResponses.set(event.chainId, numAccepted - 1);
                         const msg: ServerToClient = { ty: "json-rpc-response", chainId: event.chainId, response };
@@ -334,6 +321,10 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
         portToClient.postMessage(ev);
     };
 
+    // We create the `Promise` ahead of time in order to potentially catch potential `wasm-panic`
+    // events as early as during initialization.
+    const execFinishedPromise = new Promise<void>((resolve) => state.onExecutorShutdownOrWasmPanic = resolve);
+
     state.instance = await instance.startLocalInstance({
         forbidTcp,
         forbidWs,
@@ -348,24 +339,21 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
     portToClient.onmessage = (messageEvent) => {
         const message = messageEvent.data as ClientToServer;
 
-        if (!state.instance)
-            return;
-
         switch (message.ty) {
             case "add-chain": {
-                state.instance.addChain(message.chainSpec, message.databaseContent, message.potentialRelayChains, message.disableJsonRpc);
+                state.instance!.addChain(message.chainSpec, message.databaseContent, message.potentialRelayChains, message.disableJsonRpc);
                 break;
             }
             case "remove-chain": {
-                state.instance.removeChain(message.chainId);
+                state.instance!.removeChain(message.chainId);
                 break;
             }
             case "request": {
-                state.instance.request(message.request, message.chainId); // TODO: return value unused
+                state.instance!.request(message.request, message.chainId); // TODO: return value unused
                 break;
             }
             case "accept-more-json-rpc-answers": {
-                const response = state.instance.peekJsonRpcResponse(message.chainId);
+                const response = state.instance!.peekJsonRpcResponse(message.chainId);
                 if (response) {
                     const msg: ServerToClient = { ty: "json-rpc-response", chainId: message.chainId, response };
                     portToClient.postMessage(msg);
@@ -376,21 +364,21 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 break;
             }
             case "shutdown": {
-                state.instance.shutdownExecutor();
+                state.instance!.shutdownExecutor();
                 break;
             }
             case "connection-reset": {
                 // The connection might have been reset locally in the past.
                 if (!state.connections.has(message.connectionId))
                     return;
-                state.instance.connectionReset(message.connectionId, message.message);
+                state.instance!.connectionReset(message.connectionId, message.message);
                 break;
             }
             case "connection-opened": {
                 // The connection might have been reset locally in the past.
                 if (!state.connections.has(message.connectionId))
                     return;
-                state.instance.connectionOpened(message.connectionId, message.info);
+                state.instance!.connectionOpened(message.connectionId, message.info);
                 break;
             }
             case "stream-message": {
@@ -400,7 +388,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 // The stream might have been reset locally in the past.
                 if (message.streamId && !state.connections.get(message.connectionId)!.has(message.streamId))
                     return;
-                state.instance.streamMessage(message.connectionId, message.message, message.streamId);
+                state.instance!.streamMessage(message.connectionId, message.message, message.streamId);
                 break;
             }
             case "stream-opened": {
@@ -408,7 +396,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 if (!state.connections.has(message.connectionId))
                     return;
                 state.connections.get(message.connectionId)!.add(message.streamId);
-                state.instance.streamOpened(message.connectionId, message.streamId, message.direction, message.initialWritableBytes);
+                state.instance!.streamOpened(message.connectionId, message.streamId, message.direction, message.initialWritableBytes);
                 break;
             }
             case "stream-writable-bytes": {
@@ -418,7 +406,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 // The stream might have been reset locally in the past.
                 if (message.streamId && !state.connections.get(message.connectionId)!.has(message.streamId))
                     return;
-                state.instance.streamWritableBytes(message.connectionId, message.numExtra, message.streamId);
+                state.instance!.streamWritableBytes(message.connectionId, message.numExtra, message.streamId);
                 break;
             }
             case "stream-reset": {
@@ -429,16 +417,13 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 if (message.streamId && !state.connections.get(message.connectionId)!.has(message.streamId))
                     return;
                 state.connections.get(message.connectionId)!.delete(message.streamId);
-                state.instance.streamReset(message.connectionId, message.streamId);
+                state.instance!.streamReset(message.connectionId, message.streamId);
                 break;
             }
         }
     };
 
-    // The instance might already have crashed. Handle this situation.
-    if (!state.instance)
-        return Promise.resolve();
-    return new Promise((resolve) => state.onExecutorShutdownOrWasmPanic = resolve);
+    return execFinishedPromise;
 }
 
 type InitialMessage = {

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -185,7 +185,7 @@ export async function connectToInstanceServer(config: ConnectConfig): Promise<in
             return item;
         },
 
-        startShutdown() {
+        shutdownExecutor() {
             const msg: ClientToServer = { ty: "shutdown" };
             portToServer.postMessage(msg);
         },
@@ -366,7 +366,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
             case "shutdown": {
                 if (state.onShutdown)
                     state.onShutdown();
-                state.instance.startShutdown();
+                state.instance.shutdownExecutor();
                 portToClient.close();
                 break;
             }

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -85,7 +85,8 @@ export async function connectToInstanceServer(config: ConnectConfig): Promise<in
 
         // Update some local state.
         switch (message.ty) {
-            case "wasm-panic": {
+            case "wasm-panic":
+            case "executor-shutdown": {
                 state.jsonRpcResponses.clear();
                 state.connections.clear();
                 portToServer.close();
@@ -277,7 +278,8 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 }
                 break;
             }
-            case "wasm-panic": {
+            case "wasm-panic":
+            case "executor-shutdown": {
                 state.instance = null;
                 state.connections.clear();
                 state.acceptedJsonRpcResponses.clear();
@@ -364,10 +366,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 break;
             }
             case "shutdown": {
-                if (state.onShutdown)
-                    state.onShutdown();
                 state.instance.shutdownExecutor();
-                portToClient.close();
                 break;
             }
             case "connection-reset": {

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -300,10 +300,8 @@ pub extern "C" fn init(max_log_level: u32) {
 ///
 /// After this function is called or during a call to this function, [`advance_execution_ready`]
 /// might be called, indicating that [`advance_execution`] should be called again.
-///
-/// Returns `0` if the client is shutting down, otherwise returns a non-zero value.
 #[no_mangle]
-pub extern "C" fn advance_execution() -> u32 {
+pub extern "C" fn advance_execution() {
     super::advance_execution()
 }
 

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -307,18 +307,6 @@ pub extern "C" fn advance_execution() -> u32 {
     super::advance_execution()
 }
 
-/// Instructs the client to start shutting down.
-///
-/// Later, the client will use `exit` to stop.
-///
-/// It is still legal to call all the other functions of these bindings. The client continues to
-/// operate normally until the call to `exit`, which happens at some point in the future.
-// TODO: can this be called multiple times?
-#[no_mangle]
-pub extern "C" fn start_shutdown() {
-    crate::start_shutdown();
-}
-
 /// Adds a chain to the client. The client will try to stay connected and synchronize this chain.
 ///
 /// Assign a so-called "buffer index" (a `u32`) representing the chain specification, database

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -355,7 +355,7 @@ enum ExecutionState {
     Ready(async_task::Runnable),
 }
 
-fn advance_execution() -> u32 {
+fn advance_execution() {
     let runnable = {
         let mut executor_execute_guard = EXECUTOR_EXECUTE.lock().unwrap();
         match *executor_execute_guard {
@@ -396,7 +396,7 @@ fn advance_execution() -> u32 {
                 *executor_execute_guard = ExecutionState::NotReady;
                 runnable
             }
-            ExecutionState::NotReady => return 1,
+            ExecutionState::NotReady => return,
             ExecutionState::Ready(_) => {
                 let ExecutionState::Ready(runnable) = mem::replace(&mut *executor_execute_guard, ExecutionState::NotReady)
                     else { unreachable!() };
@@ -406,5 +406,4 @@ fn advance_execution() -> u32 {
     };
 
     runnable.run();
-    1
 }


### PR DESCRIPTION
From the point of view of the `Instance`, the shutdown process now simply consists in stopping the background execution. All the connections remain alive and all the functions still work, and it is just the background execution that stops.

This simplifies the logic of the Rust and of `local.ts` and `remote.ts`.