### PR TITLE
Boxify a few structs in blocks_tree/verify

### DIFF
--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -608,7 +608,10 @@ impl<T> VerifyContext<T> {
         (is_new_best, consensus, finality)
     }
 
-    fn with_body_verify(mut self: Box<Self>, inner: verify::header_body::Verify) -> BodyVerifyStep2<T> {
+    fn with_body_verify(
+        mut self: Box<Self>,
+        inner: verify::header_body::Verify,
+    ) -> BodyVerifyStep2<T> {
         match inner {
             verify::header_body::Verify::Finished(Ok(success)) => {
                 // TODO: lots of code in common with header verification


### PR DESCRIPTION
Wraps within `Box`es the structs that we move around a lot, in order to avoid copying their content all the time.