### PR TITLE
Deploy tests coverage report on the gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           name: code-coverage-report
           path: ./upload
-      - run: run: ls -R   # TODO: remove; for testing
+      - run: ls -R   # TODO: remove; for testing
       - run: mv code-coverage-report tests-coverage
         working-directory: ./upload
       - run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,10 +69,10 @@ jobs:
           RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
           RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
         working-directory: ./repo
-      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
-        # The last one one is to print on stdout so that it can be consulted within the PR.
-      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+      - run: |
+        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
+        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,10 +58,11 @@ jobs:
     container:
       image: rust:1.69
     steps:
+      - run: apt update && apt install -y jq
+      - run: rustup component add llvm-tools-preview
       - uses: actions/checkout@v3
         with:
           path: repo
-      - run: apt update && apt install -y jq
       - uses: Swatinem/rust-cache@v2
       - run: |
           mkdir -p ../coverage
@@ -69,7 +70,6 @@ jobs:
           RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
         working-directory: ./repo
       - run: |
-          rustup component add llvm-tools-preview
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: current
+      - run: apt install -y jq
       - run: npm install
         working-directory: ./repo/wasm-node/javascript
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,9 +70,9 @@ jobs:
           RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
         working-directory: ./repo
       - run: |
-        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
-        `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           path: repo
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./repo -> target
       - run: |
           mkdir -p ../coverage
           RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
@@ -96,6 +98,8 @@ jobs:
       - run: npm install
         working-directory: ./repo/wasm-node/javascript
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./repo -> target
       - run: cargo doc --verbose --all-features --no-deps --package smoldot --package smoldot-light
         working-directory: ./repo
       - run: npm run doc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,8 +142,6 @@ jobs:
           mkdir -p ./upload/doc-javascript
           mkdir -p ./upload/doc-rust
           mkdir -p ./upload/tests-coverage
-          mv ./repo/target/doc/* ./upload/doc-rust
-          mv ./repo/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
       - uses: actions/download-artifact@v3
         with:
           name: javascript-documentation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,10 +74,21 @@ jobs:
       - run: npm run doc
         working-directory: ./repo/wasm-node/javascript
       - run: |
+          mkdir -p ../coverage
+          RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
+        working-directory: ./repo
+      - run: |
           mkdir -p ./upload/doc-rust
           mkdir -p ./upload/doc-javascript
+          mkdir -p ./upload/tests-coverage
           mv ./repo/target/doc/* ./upload/doc-rust
           mv ./repo/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
+      - run: |
+          cargo install rustfilt
+          rustup component add llvm-tools-preview
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions \
+            $( for file in  $(  RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM -); do printf "%s %s " -object $file; done )
       - run: |
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: current
-      - run: apt install -y jq
+      - run: apt update && apt install -y jq
       - run: npm install
         working-directory: ./repo/wasm-node/javascript
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,33 @@ jobs:
     - run: docker push docker.pkg.github.com/smol-dot/smoldot/node:main
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
+  build-tests-coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.69
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: repo
+      - run: apt update && apt install -y jq
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          mkdir -p ../coverage
+          RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
+          RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
+        working-directory: ./repo
+      - run: |
+          rustup component add llvm-tools-preview
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: ./html-out/
+
   docs-publish:
     runs-on: ubuntu-latest
+    needs: build-tests-coverage
     permissions:
       contents: write   # Necessary to push on the `gh-pages` branch.
     container:
@@ -75,20 +100,17 @@ jobs:
       - run: npm run doc
         working-directory: ./repo/wasm-node/javascript
       - run: |
-          mkdir -p ../coverage
-          RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
-          RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
-        working-directory: ./repo
-      - run: |
           mkdir -p ./upload/doc-rust
           mkdir -p ./upload/doc-javascript
-          mkdir -p ./upload/tests-coverage
           mv ./repo/target/doc/* ./upload/doc-rust
           mv ./repo/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
-      - run: |
-          rustup component add llvm-tools-preview
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+      - uses: actions/download-artifact@v3
+        with:
+          name: code-coverage-report
+          path: ./upload
+      - run: run: ls -R   # TODO: remove; for testing
+      - run: mv code-coverage-report tests-coverage
+        working-directory: ./upload
       - run: |
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,8 @@ jobs:
         working-directory: ./repo
       - run: |
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,11 +84,9 @@ jobs:
           mv ./repo/target/doc/* ./upload/doc-rust
           mv ./repo/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
       - run: |
-          cargo install rustfilt
           rustup component add llvm-tools-preview
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions \
-            $( for file in  $(  RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM -); do printf "%s %s " -object $file; done )
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $( for file in  $(  RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM -); do printf "%s %s " -object $file; done )
       - run: |
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
       - run: |
           mkdir -p ../coverage
           RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
+          RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > binaries-list
         working-directory: ./repo
       - run: |
           mkdir -p ./upload/doc-rust
@@ -86,7 +87,7 @@ jobs:
       - run: |
           rustup component add llvm-tools-preview
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $( for file in  $(  RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM -); do printf "%s %s " -object $file; done )
+          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./upload/tests-coverage --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - run: |
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
       - run: |
           mkdir -p ../coverage
           RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
-          RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > binaries-list
+          RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
         working-directory: ./repo
       - run: |
           mkdir -p ./upload/doc-rust

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,9 +69,10 @@ jobs:
           RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="../coverage/default_%m_%p.profraw" cargo test --workspace --tests
           RUSTFLAGS="-C instrument-coverage" cargo test --tests --no-run --message-format=json | jq -r "select(.profile.test == true) | .filenames[]" | grep -v dSYM > ../coverage/binaries-list
         working-directory: ./repo
-      - run: |
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
-          `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
+      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
+        # The last one one is to print on stdout so that it can be consulted within the PR.
+      - run: `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='/.cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
       - uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,53 @@ jobs:
     - run: docker push docker.pkg.github.com/smol-dot/smoldot/node:main
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
+  build-js-doc:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.69
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: repo
+      - uses: actions/setup-node@v3.6.0
+        with:
+          node-version: current
+      - run: npm install
+        working-directory: ./repo/wasm-node/javascript
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./repo -> target
+      - run: npm run doc
+        working-directory: ./repo/wasm-node/javascript
+      - run: |
+          mkdir -p ./doc
+          mv ./repo/wasm-node/javascript/dist/doc/* ./doc
+      - uses: actions/upload-artifact@v3
+        with:
+          name: javascript-documentation
+          path: ./doc/
+
+  build-rust-doc:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:1.69
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: repo
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./repo -> target
+      - run: cargo doc --verbose --all-features --no-deps --package smoldot --package smoldot-light
+        working-directory: ./repo
+      - run: |
+          mkdir -p ./doc
+          mv ./repo/target/doc/* ./doc
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rust-documentation
+          path: ./doc/
+
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
@@ -82,40 +129,33 @@ jobs:
 
   docs-publish:
     runs-on: ubuntu-latest
-    needs: build-tests-coverage
+    needs: [build-js-doc, build-rust-doc, build-tests-coverage]
     permissions:
       contents: write   # Necessary to push on the `gh-pages` branch.
     container:
-      image: rust:1.69
+      image: rust:1.69  # TODO: overkill
     steps:
       - uses: actions/checkout@v3
         with:
           path: repo
-      - uses: actions/setup-node@v3.6.0
-        with:
-          node-version: current
-      - run: apt update && apt install -y jq
-      - run: npm install
-        working-directory: ./repo/wasm-node/javascript
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ./repo -> target
-      - run: cargo doc --verbose --all-features --no-deps --package smoldot --package smoldot-light
-        working-directory: ./repo
-      - run: npm run doc
-        working-directory: ./repo/wasm-node/javascript
       - run: |
-          mkdir -p ./upload/doc-rust
           mkdir -p ./upload/doc-javascript
+          mkdir -p ./upload/doc-rust
+          mkdir -p ./upload/tests-coverage
           mv ./repo/target/doc/* ./upload/doc-rust
           mv ./repo/wasm-node/javascript/dist/doc/* ./upload/doc-javascript
       - uses: actions/download-artifact@v3
         with:
+          name: javascript-documentation
+          path: ./upload/doc-javascript
+      - uses: actions/download-artifact@v3
+        with:
+          name: rust-documentation
+          path: ./upload/doc-rust
+      - uses: actions/download-artifact@v3
+        with:
           name: code-coverage-report
-          path: ./upload
-      - run: ls -R   # TODO: remove; for testing
-      - run: mv code-coverage-report tests-coverage
-        working-directory: ./upload
+          path: ./upload/tests-coverage
       - run: |
           git config user.email "github-action@users.noreply.github.com"
           git config user.name "GitHub Action"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the following components:
   - 📦 <https://crates.io/crates/smoldot>
   - 📚 <https://docs.rs/smoldot> (latest published version)
   - 📚 <https://smol-dot.github.io/smoldot/doc-rust/smoldot/index.html> (latest commit)
+  - Tests coverage: <https://smol-dot.github.io/smoldot/tests-coverage/index.html> (latest commit)
   - Has an unstable API.
 
 - `smoldot-light` (`/light-base`): A platform-agnostic Rust library that can connect to a Substrate-based chain as a light client. Serves as the base for the `smoldot-light-js` component explained above.


### PR DESCRIPTION
This PR generates HTML tests coverage information as described here: https://doc.rust-lang.org/rustc/instrument-coverage.html

It then deploys it onto the gh-pages for display.

This does **not** print a report on the PR about a change in the coverage or things like that, just a report about the `main` branch, which I think is more than enough.

