### PR TITLE
Replace `header::Header` with `Vec<u8>` in the full node

### DIFF
--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -613,16 +613,16 @@ impl SyncBackground {
                                 *is_disconnected = true;
                             }
                         },
-                        network_service::Event::BlockAnnounce { chain_index, peer_id, header, is_best }
+                        network_service::Event::BlockAnnounce { chain_index, peer_id, scale_encoded_header, is_best }
                             if chain_index == self.network_chain_index =>
                         {
                             let _jaeger_span = self
                                 .jaeger_service
-                                .block_announce_process_span(&header.hash(self.sync.block_number_bytes()));
+                                .block_announce_process_span(&header::hash_from_scale_encoded_header(&scale_encoded_header));
 
                             let id = *self.peers_source_id_map.get(&peer_id).unwrap();
                             // TODO: log the outcome
-                            match self.sync.block_announce(id, header.scale_encoding_vec(self.sync.block_number_bytes()), is_best) {
+                            match self.sync.block_announce(id, scale_encoded_header, is_best) {
                                 all::BlockAnnounceOutcome::HeaderVerify => {},
                                 all::BlockAnnounceOutcome::TooOld { .. } => {},
                                 all::BlockAnnounceOutcome::AlreadyInChain => {},

--- a/full-node/src/run/network_service.rs
+++ b/full-node/src/run/network_service.rs
@@ -129,7 +129,7 @@ pub enum Event {
     BlockAnnounce {
         chain_index: usize,
         peer_id: PeerId,
-        header: header::Header,
+        scale_encoded_header: Vec<u8>,
         is_best: bool,
     },
 }
@@ -811,7 +811,7 @@ async fn background_task(mut inner: Inner) {
                                     chain_index,
                                     peer_id,
                                     is_best: decoded.is_best,
-                                    header: decoded_header.into(), // TODO: somewhat wasteful allocation here
+                                    scale_encoded_header: decoded.scale_encoded_header.to_owned(), // TODO: somewhat wasteful to copy here, could pass the entire announce
                                 });
                             }
                             Err(error) => {


### PR DESCRIPTION
It avoids copies and goes in the direction of phasing out `header::Header`.