### PR TITLE
Rename runtime service *_lock to *_access or *_call

### DIFF
--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1105,7 +1105,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         }
 
                         self.runtime_service
-                            .pinned_block_runtime_lock(subscription_id, &hash.0)
+                            .pinned_block_runtime_access(subscription_id, &hash.0)
                             .await
                             .ok()
                     }
@@ -1569,7 +1569,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
         request_id: (&str, &requests_subscriptions::RequestId),
         function_to_call: &str,
         call_parameters: methods::HexString,
-        pre_runtime_call: Option<runtime_service::RuntimeLock<TPlat>>,
+        pre_runtime_call: Option<runtime_service::RuntimeAccess<TPlat>>,
         network_config: methods::NetworkConfig,
     ) {
         let (subscription_id, mut messages_rx, subscription_start) = match requests_subscriptions

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -1276,7 +1276,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         };
 
         let response = match self
-            .runtime_lock(&block_hash)
+            .runtime_access(&block_hash)
             .await
             .map(|l| l.specification())
         {

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1116,11 +1116,11 @@ async fn parahead<TPlat: PlatformRef>(
     // For each relay chain block, call `ParachainHost_persisted_validation_data` in
     // order to know where the parachains are.
     let precall = match relay_chain_sync
-        .pinned_block_runtime_lock(subscription_id, block_hash)
+        .pinned_block_runtime_access(subscription_id, block_hash)
         .await
     {
         Ok(p) => p,
-        Err(runtime_service::PinnedBlockRuntimeLockError::ObsoleteSubscription) => {
+        Err(runtime_service::PinnedBlockRuntimeAccessError::ObsoleteSubscription) => {
             return Err(ParaheadError::ObsoleteSubscription)
         }
     };

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1129,11 +1129,11 @@ async fn validate_transaction<TPlat: PlatformRef>(
     source: validate::TransactionSource,
 ) -> Result<validate::ValidTransaction, ValidationError> {
     let runtime_lock = match relay_chain_sync
-        .pinned_block_runtime_lock(relay_chain_sync_subscription_id, &block_hash)
+        .pinned_block_runtime_access(relay_chain_sync_subscription_id, &block_hash)
         .await
     {
         Ok(l) => l,
-        Err(runtime_service::PinnedBlockRuntimeLockError::ObsoleteSubscription) => {
+        Err(runtime_service::PinnedBlockRuntimeAccessError::ObsoleteSubscription) => {
             return Err(ValidationError::ObsoleteSubscription)
         }
     };


### PR DESCRIPTION
This PR renames some functions and structs of the runtime service, given that they no longer lock anything.