### PR TITLE
Use a BackgroundTaskConfig struct for the tx service background task

### DIFF
--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -148,21 +148,23 @@ impl<TPlat: PlatformRef> TransactionsService<TPlat> {
 
         config.platform.spawn_task(
             log_target.clone().into(),
-            Box::pin(background_task::<TPlat>(
+            Box::pin(background_task::<TPlat>(BackgroundTaskConfig {
                 log_target,
-                config.platform.clone(),
-                config.sync_service,
-                config.runtime_service,
-                config.network_service.0,
-                config.network_service.1,
+                platform: config.platform.clone(),
+                sync_service: config.sync_service,
+                runtime_service: config.runtime_service,
+                network_service: config.network_service.0,
+                network_chain_index: config.network_service.1,
                 from_foreground,
-                usize::try_from(config.max_concurrent_downloads.get())
+                max_concurrent_downloads: usize::try_from(config.max_concurrent_downloads.get())
                     .unwrap_or(usize::max_value()),
-                usize::try_from(config.max_pending_transactions.get())
+                max_pending_transactions: usize::try_from(config.max_pending_transactions.get())
                     .unwrap_or(usize::max_value()),
-                usize::try_from(config.max_concurrent_validations.get())
-                    .unwrap_or(usize::max_value()),
-            )),
+                max_concurrent_validations: usize::try_from(
+                    config.max_concurrent_validations.get(),
+                )
+                .unwrap_or(usize::max_value()),
+            })),
         );
 
         TransactionsService {
@@ -303,28 +305,31 @@ enum ToBackground {
     },
 }
 
-/// Background task running in parallel of the front service.
-async fn background_task<TPlat: PlatformRef>(
+/// Configuration for [`background_task`̀].
+struct BackgroundTaskConfig<TPlat: PlatformRef> {
     log_target: String,
     platform: TPlat,
     sync_service: Arc<sync_service::SyncService<TPlat>>,
     runtime_service: Arc<runtime_service::RuntimeService<TPlat>>,
     network_service: Arc<network_service::NetworkService<TPlat>>,
     network_chain_index: usize,
-    mut from_foreground: mpsc::Receiver<ToBackground>,
+    from_foreground: mpsc::Receiver<ToBackground>,
     max_concurrent_downloads: usize,
     max_pending_transactions: usize,
     max_concurrent_validations: usize,
-) {
-    let transactions_capacity = cmp::min(8, max_pending_transactions);
+}
+
+/// Background task running in parallel of the front service.
+async fn background_task<TPlat: PlatformRef>(mut config: BackgroundTaskConfig<TPlat>) {
+    let transactions_capacity = cmp::min(8, config.max_pending_transactions);
     let blocks_capacity = 32;
 
     let mut worker = Worker {
-        platform,
-        sync_service,
-        runtime_service,
-        network_service,
-        network_chain_index,
+        platform: config.platform,
+        sync_service: config.sync_service,
+        runtime_service: config.runtime_service,
+        network_service: config.network_service,
+        network_chain_index: config.network_chain_index,
         pending_transactions: light_pool::LightPool::new(light_pool::Config {
             transactions_capacity,
             blocks_capacity,
@@ -333,8 +338,8 @@ async fn background_task<TPlat: PlatformRef>(
         block_downloads: FuturesUnordered::new(),
         validations_in_progress: FuturesUnordered::new(),
         next_reannounce: FuturesUnordered::new(),
-        max_concurrent_downloads,
-        max_pending_transactions,
+        max_concurrent_downloads: config.max_concurrent_downloads,
+        max_pending_transactions: config.max_pending_transactions,
     };
 
     // TODO: must periodically re-send transactions that aren't included in block yet
@@ -393,7 +398,7 @@ async fn background_task<TPlat: PlatformRef>(
                 },
             );
             if block.is_new_best {
-                worker.set_best_block(&log_target, &hash);
+                worker.set_best_block(&config.log_target, &hash);
             }
         }
 
@@ -403,7 +408,7 @@ async fn background_task<TPlat: PlatformRef>(
         worker.next_reannounce.clear();
 
         log::debug!(
-            target: &log_target,
+            target: &config.log_target,
             "Reset(new_finalized={}. dropped-transactions={{{}}})",
             HashDisplay(&initial_finalized_block_hash),
             dropped_transactions
@@ -419,7 +424,7 @@ async fn background_task<TPlat: PlatformRef>(
             }
 
             // Start the validation process of transactions that need to be validated.
-            while worker.validations_in_progress.len() < max_concurrent_validations {
+            while worker.validations_in_progress.len() < config.max_concurrent_validations {
                 // Find a transaction that needs to be validated.
                 //
                 // While this is an `O(n)` process, in practice we pick the first transaction not
@@ -454,7 +459,7 @@ async fn background_task<TPlat: PlatformRef>(
 
                     // Make copies of everything in order to move the values into the future.
                     let runtime_service = worker.runtime_service.clone();
-                    let log_target = log_target.clone();
+                    let log_target = config.log_target.clone();
                     let relay_chain_sync_subscription_id = subscribe_all.new_blocks.id();
                     let scale_encoded_transaction = worker
                         .pending_transactions
@@ -512,7 +517,7 @@ async fn background_task<TPlat: PlatformRef>(
                     worker.pending_transactions.remove_transaction(tx_id);
 
                 log::debug!(
-                    target: &log_target,
+                    target: &config.log_target,
                     "Discarded(tx_hash={}, error={:?})",
                     HashDisplay(&blake2_hash(&tx_body)),
                     error,
@@ -585,7 +590,7 @@ async fn background_task<TPlat: PlatformRef>(
                     .downloading = true;
 
                 log::debug!(
-                    target: &log_target,
+                    target: &config.log_target,
                     "BlockDownloads <= Start(block={})",
                     HashDisplay(&block_hash)
                 );
@@ -601,7 +606,7 @@ async fn background_task<TPlat: PlatformRef>(
                     .await;
 
                 log::debug!(
-                    target: &log_target,
+                    target: &config.log_target,
                     "Finalized(block={}, body-transactions={{{}}})",
                     HashDisplay(&block.block_hash),
                     block
@@ -639,11 +644,11 @@ async fn background_task<TPlat: PlatformRef>(
                                 },
                             );
                             if new_block.is_new_best {
-                                worker.set_best_block(&log_target, &hash);
+                                worker.set_best_block(&config.log_target, &hash);
                             }
                         },
                         Some(runtime_service::Notification::Finalized { hash, best_block_hash, .. }) => {
-                            worker.set_best_block(&log_target, &best_block_hash);
+                            worker.set_best_block(&config.log_target, &best_block_hash);
                             for pruned in worker
                                 .pending_transactions
                                 .set_finalized_block(&hash)
@@ -657,7 +662,7 @@ async fn background_task<TPlat: PlatformRef>(
                             }
                         },
                         Some(runtime_service::Notification::BestBlockChanged { hash }) => {
-                            worker.set_best_block(&log_target, &hash);
+                            worker.set_best_block(&config.log_target, &hash);
                         },
                         None => continue 'channels_rebuild
                     }
@@ -690,7 +695,7 @@ async fn background_task<TPlat: PlatformRef>(
                             .collect::<Vec<_>>();
 
                         log::debug!(
-                            target: &log_target,
+                            target: &config.log_target,
                             "BlockDownloads => Success(block={}, included-transactions={{{}}})",
                             HashDisplay(&block_hash),
                             included_transactions.iter()
@@ -708,7 +713,7 @@ async fn background_task<TPlat: PlatformRef>(
 
                     } else {
                         log::debug!(
-                            target: &log_target,
+                            target: &config.log_target,
                             "BlockDownloads => Failed(block={})",
                             HashDisplay(&block_hash)
                         );
@@ -763,7 +768,7 @@ async fn background_task<TPlat: PlatformRef>(
                         )
                         .await;
                     log::debug!(
-                        target: &log_target,
+                        target: &config.log_target,
                         "NetworkService <= Announced(tx={}, peers={{{}}})",
                         HashDisplay(&blake2_hash(worker.pending_transactions.scale_encoding(maybe_reannounce_tx_id).unwrap())),
                         peers_sent.iter().join(", ")
@@ -804,7 +809,7 @@ async fn background_task<TPlat: PlatformRef>(
                     // that has already been finalized and removed from the pool.
                     if !worker.pending_transactions.has_block(&block_hash) {
                         log::debug!(
-                            target: &log_target,
+                            target: &config.log_target,
                             "TxValidations => ObsoleteBlock(tx={}, block={})",
                             HashDisplay(&tx_hash),
                             HashDisplay(&block_hash)
@@ -815,7 +820,7 @@ async fn background_task<TPlat: PlatformRef>(
                     let validation_result = match validation_result {
                         Ok(result) => {
                             log::debug!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "TxValidations => Success(tx={}, block={}, priority={}, longevity={}, propagate={:?})",
                                 HashDisplay(&tx_hash),
                                 HashDisplay(&block_hash),
@@ -825,7 +830,7 @@ async fn background_task<TPlat: PlatformRef>(
                             );
 
                             log::info!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "Successfully validated transaction {}",
                                 HashDisplay(&tx_hash)
                             );
@@ -844,7 +849,7 @@ async fn background_task<TPlat: PlatformRef>(
                         }
                         Err(ValidationError::InvalidOrError(InvalidOrError::Invalid(error))) => {
                             log::debug!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "TxValidations => Invalid(tx={}, block={}, error={:?})",
                                 HashDisplay(&tx_hash),
                                 HashDisplay(&block_hash),
@@ -852,7 +857,7 @@ async fn background_task<TPlat: PlatformRef>(
                             );
 
                             log::warn!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "Transaction {} invalid against block {}: {}",
                                 HashDisplay(&tx_hash),
                                 HashDisplay(&block_hash),
@@ -863,7 +868,7 @@ async fn background_task<TPlat: PlatformRef>(
                         }
                         Err(ValidationError::InvalidOrError(InvalidOrError::ValidateError(error))) => {
                             log::debug!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "TxValidations => Error(tx={}, block={}, error={:?})",
                                 HashDisplay(&tx_hash),
                                 HashDisplay(&block_hash),
@@ -871,7 +876,7 @@ async fn background_task<TPlat: PlatformRef>(
                             );
 
                             log::warn!(
-                                target: &log_target,
+                                target: &config.log_target,
                                 "Failed to validate transaction {}: {}",
                                 HashDisplay(&tx_hash),
                                 error
@@ -888,7 +893,7 @@ async fn background_task<TPlat: PlatformRef>(
                         .set_validation_result(maybe_validated_tx_id, &block_hash, validation_result);
                 },
 
-                message = from_foreground.next().fuse() => {
+                message = config.from_foreground.next().fuse() => {
                     let message = match message {
                         Some(msg) => msg,
                         None => return,


### PR DESCRIPTION
Makes the `background_task` function API saner with fewer parameters.