### PR TITLE
`as_chain_information` -> `to_chain_information`

### DIFF
--- a/full-node/src/run.rs
+++ b/full-node/src/run.rs
@@ -155,7 +155,7 @@ pub async fn run(cli_options: cli::CliOptionsRun) {
     };
 
     // TODO: don't unwrap?
-    let genesis_chain_information = chain_spec.as_chain_information().unwrap().0;
+    let genesis_chain_information = chain_spec.to_chain_information().unwrap().0;
 
     // If `chain_spec` define a parachain, also load the specs of the relay chain.
     let (relay_chain_spec, _parachain_id) =
@@ -189,7 +189,7 @@ pub async fn run(cli_options: cli::CliOptionsRun) {
     // TODO: don't unwrap?
     let relay_genesis_chain_information = relay_chain_spec
         .as_ref()
-        .map(|relay_chain_spec| relay_chain_spec.as_chain_information().unwrap().0);
+        .map(|relay_chain_spec| relay_chain_spec.to_chain_information().unwrap().0);
 
     // Create an executor where tasks are going to be spawned onto.
     let executor = Arc::new(smol::Executor::new());

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -28,7 +28,7 @@ fn block_building_works() {
     .unwrap();
     let genesis_storage = chain_specs.genesis_storage().into_genesis_items().unwrap();
 
-    let (chain_info, genesis_runtime) = chain_specs.as_chain_information().unwrap();
+    let (chain_info, genesis_runtime) = chain_specs.to_chain_information().unwrap();
     let genesis_hash = chain_info.as_ref().finalized_block_header.hash(4);
 
     let mut builder = super::build_block(super::Config {

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -88,7 +88,7 @@ impl ChainSpec {
     ///
     /// In addition to the information, also returns the virtual machine of the runtime of the
     /// genesis block.
-    pub fn as_chain_information(
+    pub fn to_chain_information(
         &self,
     ) -> Result<(ValidChainInformation, executor::host::HostVmPrototype), FromGenesisStorageError>
     {
@@ -420,7 +420,7 @@ fn convert_epoch(epoch: &light_sync_state::BabeEpoch) -> BabeEpochInformation {
 }
 
 impl LightSyncState {
-    pub fn as_chain_information(&self) -> ChainInformation {
+    pub fn to_chain_information(&self) -> ChainInformation {
         // Create a sorted list of all regular epochs that haven't been pruned from the sync state.
         let mut epochs: Vec<_> = self
             .inner

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -362,10 +362,10 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         // TODO: clean up that block
         let (chain_information, genesis_block_header, checkpoint_nodes) = {
             match (
-                chain_spec.as_chain_information().map(|(ci, _)| ci), // TODO: don't just throw away the runtime
+                chain_spec.to_chain_information().map(|(ci, _)| ci), // TODO: don't just throw away the runtime
                 chain_spec.light_sync_state().map(|s| {
                     chain::chain_information::ValidChainInformation::try_from(
-                        s.as_chain_information(),
+                        s.to_chain_information(),
                     )
                 }),
                 database::decode_database(


### PR DESCRIPTION
Rename `as_chain_information` to `to_chain_information`, as it does calculations and builds a new object.