### PR TITLE
From<MerkleValueOutput> for [u8; 32] should be TryFrom

### DIFF
--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -313,7 +313,8 @@ impl CalcInner {
                         .unwrap();
 
                         return RootMerkleValueCalculation::Finished {
-                            hash: merkle_value.into(),
+                            // Guaranteed to never panic for the root node.
+                            hash: merkle_value.try_into().unwrap_or_else(|_| panic!()),
                             cache: self.cache,
                         };
                     }
@@ -345,7 +346,8 @@ impl CalcInner {
                         let mut root_node = trie_structure.root_node().unwrap();
                         let merkle_value = root_node.user_data().merkle_value.clone().unwrap();
                         return RootMerkleValueCalculation::Finished {
-                            hash: merkle_value.into(),
+                            // Guaranteed to never panic for the root node.
+                            hash: merkle_value.try_into().unwrap_or_else(|_| panic!()),
                             cache: self.cache,
                         };
                     }

--- a/lib/src/trie/trie_node.rs
+++ b/lib/src/trie/trie_node.rs
@@ -267,11 +267,17 @@ impl AsRef<[u8]> for MerkleValueOutput {
     }
 }
 
-impl From<MerkleValueOutput> for [u8; 32] {
-    fn from(output: MerkleValueOutput) -> Self {
-        let mut out = [0; 32];
-        out.copy_from_slice(output.as_ref());
-        out
+impl TryFrom<MerkleValueOutput> for [u8; 32] {
+    type Error = (); // TODO: proper error?
+
+    fn try_from(output: MerkleValueOutput) -> Result<Self, Self::Error> {
+        if output.as_ref().len() == 32 {
+            let mut out = [0; 32];
+            out.copy_from_slice(output.as_ref());
+            Ok(out)
+        } else {
+            Err(())
+        }
     }
 }
 


### PR DESCRIPTION
Right now, the `From<MerkleValueOutput> for [u8; 32]` impl panics if the `MerkleValueOutput` doesn't contain 32 bytes. This is wrong.