### PR TITLE
Remove PartialEq/Eq implementations from yamux::WriteQueue

### DIFF
--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -302,7 +302,7 @@ enum OutgoingGoAway {
     Sent,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 enum OutgoingSubstreamData {
     /// Data is coming from the given substream.
     ///
@@ -751,7 +751,7 @@ impl<T> Yamux<T> {
                     ..
                 },
                 SubstreamState::Healthy { write_queue, .. },
-            ) if *data == OutgoingSubstreamData::Healthy(substream_id) => {
+            ) if matches!(*data, OutgoingSubstreamData::Healthy(i) if i == substream_id) => {
                 *data = OutgoingSubstreamData::Obsolete { write_queue };
             }
             _ => {}
@@ -1151,10 +1151,7 @@ impl<T> Yamux<T> {
                                             ..
                                         },
                                         SubstreamState::Healthy { write_queue, .. },
-                                    ) if *data
-                                        == OutgoingSubstreamData::Healthy(SubstreamId(
-                                            *substream_id,
-                                        )) =>
+                                    ) if matches!(*data, OutgoingSubstreamData::Healthy(SubstreamId(i)) if i == *substream_id) =>
                                     {
                                         *data = OutgoingSubstreamData::Obsolete { write_queue };
                                     }
@@ -1242,8 +1239,8 @@ impl<T> Yamux<T> {
                                         ..
                                     },
                                     SubstreamState::Healthy { write_queue, .. },
-                                ) if *data
-                                    == OutgoingSubstreamData::Healthy(SubstreamId(stream_id)) =>
+                                ) if matches!(*data,
+                                    OutgoingSubstreamData::Healthy(SubstreamId(i)) if i == stream_id) =>
                                 {
                                     *data = OutgoingSubstreamData::Obsolete { write_queue };
                                 }

--- a/lib/src/libp2p/connection/yamux/write_queue.rs
+++ b/lib/src/libp2p/connection/yamux/write_queue.rs
@@ -26,8 +26,7 @@ impl AsRef<[u8]> for VecWithOffset {
     }
 }
 
-// TODO: PartialEq/Eq?!
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct WriteQueue {
     /// Buffer of buffers to be written out.
     // TODO: is it a good idea to have an unbounded VecDeque?


### PR DESCRIPTION
They were added in order to make it possible to derive it on `OutgoingSubstreamData`.
However, these implementations are incorrect as they don't compare the content of the buffers.
It's better to just remove them.