### PR TITLE
Full node: move the storage handling and runtime handling to the consensus service

### DIFF
--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -875,13 +875,11 @@ impl SyncBackground {
                         let prefix = prefix_key.prefix().as_ref().to_vec();
                         let keys = parent_block_storage
                             .range(ops::Bound::Included(&prefix), ops::Bound::Unbounded)
-                            .filter(|node_index| {
-                                self.finalized_block_storage.is_storage(*node_index)
-                            })
+                            .filter(|node_index| parent_block_storage.is_storage(*node_index))
                             .map(|node_index| {
                                 // TODO: consider detecting if nibbles are uneven instead of ignoring the problem
                                 nibbles_to_bytes_suffix_extend(
-                                    self.finalized_block_storage
+                                    parent_block_storage
                                         .node_full_key_by_index(node_index)
                                         .unwrap(),
                                 )

--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -724,12 +724,15 @@ impl SyncBackground {
         // Actual block production now happening.
         let (new_block_header, new_block_body, authoring_logs) = {
             let parent_hash = self.sync.best_block_hash();
-            let parent_runtime_arc = {
-                // TODO: no, best block could be equal to finalized block
+            let parent_runtime_arc = if self.sync.best_block_number()
+                != self.sync.finalized_block_header().number
+            {
                 let NonFinalizedBlock::Verified {
                     runtime: parent_runtime_arc,
                 } = &self.sync[(self.sync.best_block_number(), &self.sync.best_block_hash())] else { unreachable!() };
                 parent_runtime_arc.clone()
+            } else {
+                self.finalized_runtime.clone()
             };
             let parent_runtime = parent_runtime_arc.try_lock().unwrap().take().unwrap();
 

--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -297,7 +297,7 @@ struct SyncBackground {
     /// if this is the "special source" representing the local block authoring. Only one source
     /// must contain `None` and its id must be [`SyncBackground::block_author_sync_source`].
     ///
-    /// Each block holds its runtime and the state of its storage if it has been verified.
+    /// Each block holds its runtime if it has been verified.
     ///
     /// Some of the sources can represent networking peers that have already been disconnected. If
     /// that is the case, no new request is started against these sources but existing requests
@@ -307,7 +307,6 @@ struct SyncBackground {
     ///
     /// Each on-going request has a corresponding background task that sends its result to
     /// [`SyncBackground::block_requests_finished_rx`].
-    // TODO: very unoptimized to have a copy of the storage for each block; store in db instead
     sync: all::AllSync<(), Option<NetworkSourceInfo>, NonFinalizedBlock>,
 
     /// Source within the [`SyncBackground::sync`] to use to import locally-authored blocks.

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -116,7 +116,12 @@ impl Builder {
 #[must_use]
 pub enum BuilderAuthoring {
     /// Error happened during the generation.
-    Error(Error),
+    Error {
+        /// Runtime of the parent block, as provided at initialization.
+        parent_runtime: host::HostVmPrototype,
+        /// The error in question.
+        error: Error,
+    },
 
     /// Block building is ready to accept extrinsics.
     ///
@@ -472,14 +477,22 @@ impl Shared {
                         self.block_number_bytes,
                     ) {
                         Ok(h) => h,
-                        Err(_) => break BuilderAuthoring::Error(Error::InvalidHeaderGenerated),
+                        Err(_) => {
+                            break BuilderAuthoring::Error {
+                                parent_runtime: block.parent_runtime,
+                                error: Error::InvalidHeaderGenerated,
+                            }
+                        }
                     };
 
                     // The `Seal` object created below assumes that there is no existing seal.
                     if decoded_header.digest.aura_seal().is_some()
                         || decoded_header.digest.babe_seal().is_some()
                     {
-                        break BuilderAuthoring::Error(Error::InvalidHeaderGenerated);
+                        break BuilderAuthoring::Error {
+                            parent_runtime: block.parent_runtime,
+                            error: Error::InvalidHeaderGenerated,
+                        };
                     }
 
                     break BuilderAuthoring::Seal(Seal {
@@ -487,8 +500,11 @@ impl Shared {
                         block,
                     });
                 }
-                runtime::BlockBuild::Finished(Err(error)) => {
-                    break BuilderAuthoring::Error(Error::Runtime(error))
+                runtime::BlockBuild::Finished(Err((error, parent_runtime))) => {
+                    break BuilderAuthoring::Error {
+                        parent_runtime,
+                        error: Error::Runtime(error),
+                    }
                 }
                 runtime::BlockBuild::InherentExtrinsics(a) => {
                     // Injecting the inherent is guaranteed to be done only once per block.

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -52,7 +52,7 @@ fn block_building_works() {
                 assert_eq!(*decoded.parent_hash, genesis_hash);
                 break;
             }
-            super::BlockBuild::Finished(Err(err)) => panic!("{}", err),
+            super::BlockBuild::Finished(Err((err, _))) => panic!("{}", err),
             super::BlockBuild::ApplyExtrinsic(ext) => builder = ext.finish(),
             super::BlockBuild::ApplyExtrinsicResult { .. } => unreachable!(),
             super::BlockBuild::InherentExtrinsics(ext) => {

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2524,9 +2524,12 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
         match inner {
             optimistic::BlockVerification::NewBest {
                 sync,
-                storage_main_trie_changes,
-                state_trie_version,
-                offchain_storage_changes,
+                full:
+                    Some(optimistic::BlockVerificationSuccessFull {
+                        storage_main_trie_changes,
+                        state_trie_version,
+                        offchain_storage_changes,
+                    }),
                 ..
             } => {
                 // TODO: transition to all_forks
@@ -2541,6 +2544,7 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                     },
                 }
             }
+            optimistic::BlockVerification::NewBest { full: None, .. } => unreachable!(),
             optimistic::BlockVerification::Reset { sync, reason, .. } => BlockVerification::Error {
                 sync: AllSync {
                     inner: AllSyncInner::Optimistic { inner: sync },

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1783,6 +1783,18 @@ impl<'a, TRq, TSrc, TBl> ops::Index<(u64, &'a [u8; 32])> for AllSync<TRq, TSrc, 
     }
 }
 
+impl<'a, TRq, TSrc, TBl> ops::IndexMut<(u64, &'a [u8; 32])> for AllSync<TRq, TSrc, TBl> {
+    #[track_caller]
+    fn index_mut(&mut self, (block_height, block_hash): (u64, &'a [u8; 32])) -> &mut TBl {
+        match &mut self.inner {
+            AllSyncInner::AllForks(inner) => inner[(block_height, block_hash)].as_mut().unwrap(),
+            AllSyncInner::Optimistic { inner, .. } => &mut inner[block_hash],
+            AllSyncInner::GrandpaWarpSync { .. } => panic!("unknown block"), // No block is ever stored during the warp syncing.
+            AllSyncInner::Poisoned => unreachable!(),
+        }
+    }
+}
+
 /// See [`AllSync::desired_requests`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -1122,6 +1122,22 @@ impl<TBl, TRq, TSrc> ops::IndexMut<SourceId> for AllForksSync<TBl, TRq, TSrc> {
     }
 }
 
+impl<'a, TBl, TRq, TSrc> ops::Index<(u64, &'a [u8; 32])> for AllForksSync<TBl, TRq, TSrc> {
+    type Output = TBl;
+
+    #[track_caller]
+    fn index(&self, (block_height, block_hash): (u64, &'a [u8; 32])) -> &TBl {
+        self.block_user_data(block_height, block_hash)
+    }
+}
+
+impl<'a, TBl, TRq, TSrc> ops::IndexMut<(u64, &'a [u8; 32])> for AllForksSync<TBl, TRq, TSrc> {
+    #[track_caller]
+    fn index_mut(&mut self, (block_height, block_hash): (u64, &'a [u8; 32])) -> &mut TBl {
+        self.block_user_data_mut(block_height, block_hash)
+    }
+}
+
 /// See [`AllForksSync::finish_ancestry_search`].
 pub struct FinishAncestrySearch<TBl, TRq, TSrc> {
     inner: AllForksSync<TBl, TRq, TSrc>,

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -580,8 +580,8 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
     /// If the state machine only handles light clients, that is if [`Config::full`] was `false`,
     /// then the values of [`RequestSuccessBlock::scale_encoded_extrinsics`] are silently ignored.
     ///
-    /// > **Note**: If [`Config::full`] is `false`, you are encouraged to not request the block's
-    /// >           body from the source altogether, and to fill the
+    /// > **Note**: If [`Config::full_mode`] is `false`, you are encouraged to not request the
+    /// >           block's body from the source altogether, and to fill the
     /// >           [`RequestSuccessBlock::scale_encoded_extrinsics`] fields with `Vec::new()`.
     ///
     /// # Panic
@@ -804,7 +804,7 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
         }
     }
 
-    /// Returns true if [`Config::full`] was `Some` at initialization.
+    /// Returns true if [`Config::full_mode`] was `true` at initialization.
     pub fn is_full_verification(&self) -> bool {
         self.inner.full_mode
     }
@@ -1000,7 +1000,7 @@ pub struct BlockVerificationSuccessFull {
     pub storage_main_trie_changes: storage_diff::TrieDiff,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`BlockVerification::NewBest::storage_main_trie_changes`] should store this version
+    /// [`BlockVerificationSuccessFull::storage_main_trie_changes`] should store this version
     /// alongside with them.
     pub state_trie_version: TrieEntryVersion,
 

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -577,8 +577,9 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
     ///
     /// Returns the user data that was associated to that request.
     ///
-    /// If the state machine only handles light clients, that is if [`Config::full`] was `false`,
-    /// then the values of [`RequestSuccessBlock::scale_encoded_extrinsics`] are silently ignored.
+    /// If the state machine only handles light clients, that is if [`Config::full_mode`] was
+    /// `false`, then the values of [`RequestSuccessBlock::scale_encoded_extrinsics`] are
+    /// silently ignored.
     ///
     /// > **Note**: If [`Config::full_mode`] is `false`, you are encouraged to not request the
     /// >           block's body from the source altogether, and to fill the

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -285,6 +285,17 @@ impl<TUd> TrieStructure<TUd> {
         }
     }
 
+    /// Returns the [`NodeIndex`] of the node with the given full key, if any is found.
+    pub fn node_by_full_key<TKIter>(&self, key: TKIter) -> Option<NodeIndex>
+    where
+        TKIter: Iterator<Item = Nibble> + Clone,
+    {
+        match self.existing_node_inner(key) {
+            ExistingNodeInnerResult::Found { node_index, .. } => Some(NodeIndex(node_index)),
+            ExistingNodeInnerResult::NotFound { .. } => None,
+        }
+    }
+
     /// Returns `true` if the node with the given index is a storage node. Returns `false` if it
     /// is a branch node.
     ///
@@ -1135,6 +1146,22 @@ impl<TUd: fmt::Debug> fmt::Debug for TrieStructure<TUd> {
                     .map(|idx| (idx, self.nodes.get(idx).unwrap())),
             )
             .finish()
+    }
+}
+
+impl<TUd> ops::Index<NodeIndex> for TrieStructure<TUd> {
+    type Output = TUd;
+
+    #[track_caller]
+    fn index(&self, node_index: NodeIndex) -> &TUd {
+        &self.nodes[node_index.0].user_data
+    }
+}
+
+impl<TUd> ops::IndexMut<NodeIndex> for TrieStructure<TUd> {
+    #[track_caller]
+    fn index_mut(&mut self, node_index: NodeIndex) -> &mut TUd {
+        &mut self.nodes[node_index.0].user_data
     }
 }
 

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -74,7 +74,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                 // is 5k.
                 NonZeroU32::new(5000).unwrap()
             },
-            full: None,
+            full_mode: false,
         }),
         network_up_to_date_best: true,
         network_up_to_date_finalized: true,


### PR DESCRIPTION
At the moment, the optimistic syncing strategy holds internally the diff between the finalized block and the best block, and holds internally the runtime of the finalized block and the best block, while the consensus service is only responsible for the storage of the finalized block.

While this makes a more convenient API, it is not a scalable solution as the diff between the finalized block and best block can in theory be huge. Instead, this diff should be stored (in some way or the other) in the database. This PR is a step in that direction by moving the handling of these diffs to the consensus service.

This is a preliminary step towards https://github.com/smol-dot/smoldot/issues/272, as for https://github.com/smol-dot/smoldot/issues/272 we will need to move the cache of Merkle value calculations outside of the `runtime_host`, and moving it to the syncing (where the entire trie isn't known) is way too complicated. The cache clearly must be owned by the consensus service.
This is also a step towards finishing the implementation of the `AllSync` for the full node, which is currently blocked because it is too complicated to handle these storage diffs in a tree fashion efficiently.

~~This PR is still a draft because, while everything works, the full node now OOMs. This is because the changes in the consensus service have been implemented in a naive way by duplicating the entire trie once per block. The Polkadot trie is around 70 MiB at the location where the syncing is on my machine, and because there's a justification only every 1024 blocks (I think?), one would need 70 GiB of RAM in order to sync, which I don't have.
Instead, the consensus service should now store the trie of non-finalized blocks in the database and then load values from the database.~~
