### PR TITLE
Use the SipHasher whenever needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "siphasher",
  "smol",
  "smoldot",
  "terminal_size",
@@ -2485,6 +2486,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "siphasher",
  "slab",
  "smoldot",
 ]

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -33,6 +33,7 @@ mick-jaeger = "0.1.8"
 rand = "0.8.5"
 serde = { version = "1.0.163", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["std"] }
+siphasher = { version = "0.3.10", default-features = false }
 smol = "1.3.0"
 smoldot = { version = "0.7.0", path = "../lib", default-features = false, features = ["database-sqlite", "std"] }
 terminal_size = "0.2.6"

--- a/full-node/src/run/network_service.rs
+++ b/full-node/src/run/network_service.rs
@@ -27,7 +27,10 @@
 // TODO: doc
 // TODO: re-review this once finished
 
-use crate::run::{database_thread, jaeger_service};
+use crate::{
+    run::{database_thread, jaeger_service},
+    util,
+};
 
 use core::{cmp, future::Future, mem, pin::Pin, task::Poll, time::Duration};
 use futures_channel::oneshot;
@@ -239,8 +242,7 @@ struct Inner {
     /// List of peer and chain index tuples for which no outbound slot should be assigned.
     ///
     /// The values are the moment when the ban expires.
-    // TODO: use SipHasher
-    slots_assign_backoff: HashMap<(PeerId, usize), Instant, fnv::FnvBuildHasher>,
+    slots_assign_backoff: HashMap<(PeerId, usize), Instant, util::SipHasherBuild>,
 
     process_network_service_events: bool,
 
@@ -338,7 +340,7 @@ impl NetworkService {
             network,
             slots_assign_backoff: hashbrown::HashMap::with_capacity_and_hasher(
                 50, // TODO: ?
-                Default::default(),
+                util::SipHasherBuild::new(rand::random()),
             ),
             active_connections: hashbrown::HashMap::with_capacity_and_hasher(
                 100, // TODO: ?

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -28,6 +28,7 @@ lru = { version = "0.10.0", default-features = false }  # TODO: there's no way t
 rand = "0.8.5"
 serde = { version = "1.0.163", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["alloc"] }
+siphasher = { version = "0.3.10", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smoldot = { version = "0.7.0", path = "../lib", default-features = false }
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -200,10 +200,9 @@ pub struct Client<TPlat: platform::PlatformRef, TChain = ()> {
     /// For each key, contains the services running for this chain plus the number of public API
     /// chains that correspond to it.
     ///
-    /// The [`ChainServices`] is within a `MaybeDone`. The variant will be `MaybeDone::Future` if
-    /// initialization is still in progress.
-    // TODO: use SipHasher
-    chains_by_key: HashMap<ChainKey, RunningChain<TPlat>, util::BuildHasherDefault<fnv::FnvHasher>>,
+    /// Because we use a `SipHasher`, this hashmap isn't created in the `new` function (as this
+    /// function is `const`) but lazily the first time it is needed.
+    chains_by_key: Option<HashMap<ChainKey, RunningChain<TPlat>, util::SipHasherBuild>>,
 }
 
 struct PublicApiChain<TChain> {
@@ -336,7 +335,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         Client {
             platform,
             public_api_chains: slab::Slab::new(),
-            chains_by_key: HashMap::with_hasher(util::BuildHasherDefault::new()),
+            chains_by_key: None,
         }
     }
 
@@ -347,6 +346,11 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         &mut self,
         config: AddChainConfig<'_, TChain, impl Iterator<Item = ChainId>>,
     ) -> Result<AddChainSuccess, AddChainError> {
+        // `chains_by_key` is created lazily whenever needed.
+        let chains_by_key = self
+            .chains_by_key
+            .get_or_insert_with(|| HashMap::with_hasher(util::SipHasherBuild::new(rand::random())));
+
         // Decode the chain specification.
         let chain_spec = match chain_spec::ChainSpec::from_json_bytes(config.specification) {
             Ok(cs) => cs,
@@ -585,8 +589,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         // This could in principle be done later on, but doing so raises borrow checker errors.
         let relay_chain_ready_future: Option<(future::MaybeDone<future::Shared<_>>, String)> =
             relay_chain_id.map(|relay_chain| {
-                let relay_chain = &self
-                    .chains_by_key
+                let relay_chain = &chains_by_key
                     .get(&self.public_api_chains.get(relay_chain.0).unwrap().key)
                     .unwrap();
 
@@ -626,7 +629,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                     base.clone()
                 };
 
-                if !self.chains_by_key.values().any(|c| *c.log_name == attempt) {
+                if !chains_by_key.values().any(|c| *c.log_name == attempt) {
                     break attempt;
                 }
 
@@ -638,7 +641,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         };
 
         // Start the services of the chain to add, or grab the services if they already exist.
-        let (services_init, log_name) = match self.chains_by_key.entry(new_chain_key.clone()) {
+        let (services_init, log_name) = match chains_by_key.entry(new_chain_key.clone()) {
             Entry::Occupied(mut entry) => {
                 // The chain to add always has a corresponding chain running. Simply grab the
                 // existing services and existing log name.
@@ -932,10 +935,18 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
     pub fn remove_chain(&mut self, id: ChainId) -> TChain {
         let removed_chain = self.public_api_chains.remove(id.0);
 
-        let running_chain = self.chains_by_key.get_mut(&removed_chain.key).unwrap();
+        // `chains_by_key` is created lazily when `add_chain` is called.
+        // Since we're removing a chain that has been added with `add_chain`, it is guaranteed
+        // that `chains_by_key` is set.
+        let chains_by_key = self
+            .chains_by_key
+            .as_mut()
+            .unwrap_or_else(|| unreachable!());
+
+        let running_chain = chains_by_key.get_mut(&removed_chain.key).unwrap();
         if running_chain.num_references.get() == 1 {
             log::info!(target: "smoldot", "Shutting down chain {}", running_chain.log_name);
-            self.chains_by_key.remove(&removed_chain.key);
+            chains_by_key.remove(&removed_chain.key);
         } else {
             running_chain.num_references =
                 NonZeroU32::new(running_chain.num_references.get() - 1).unwrap();

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -36,7 +36,7 @@
 //! [`NetworkService::new`]. These channels inform the foreground about updates to the network
 //! connectivity.
 
-use crate::platform::PlatformRef;
+use crate::{platform::PlatformRef, util};
 
 use alloc::{
     boxed::Box,
@@ -156,8 +156,7 @@ struct SharedGuarded<TPlat: PlatformRef> {
     /// List of peer and chain index tuples for which no outbound slot should be assigned.
     ///
     /// The values are the moment when the ban expires.
-    // TODO: use SipHasher
-    slots_assign_backoff: HashMap<(PeerId, usize), TPlat::Instant, fnv::FnvBuildHasher>,
+    slots_assign_backoff: HashMap<(PeerId, usize), TPlat::Instant, util::SipHasherBuild>,
 
     messages_from_connections_tx:
         mpsc::Sender<(service::ConnectionId, service::ConnectionToCoordinator)>,
@@ -258,7 +257,10 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                     handshake_timeout: Duration::from_secs(8),
                     randomness_seed: rand::random(),
                 }),
-                slots_assign_backoff: HashMap::with_capacity_and_hasher(32, Default::default()),
+                slots_assign_backoff: HashMap::with_capacity_and_hasher(
+                    32,
+                    util::SipHasherBuild::new(rand::random()),
+                ),
                 important_nodes: HashSet::with_capacity_and_hasher(16, Default::default()),
                 active_connections: HashMap::with_capacity_and_hasher(32, Default::default()),
                 messages_from_connections_tx,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::ToBackground;
-use crate::{network_service, platform::PlatformRef, runtime_service};
+use crate::{network_service, platform::PlatformRef, runtime_service, util};
 
 use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
 use core::{
@@ -73,7 +73,10 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                     .number,
             ),
             obsolete_finalized_parahead,
-            sync_sources_map: HashMap::with_capacity_and_hasher(0, fnv::FnvBuildHasher::default()),
+            sync_sources_map: HashMap::with_capacity_and_hasher(
+                0,
+                util::SipHasherBuild::new(rand::random()),
+            ),
             subscription_state: ParachainBackgroundState::NotSubscribed {
                 all_subscriptions: Vec::new(),
                 subscribe_future: {
@@ -139,8 +142,7 @@ struct ParachainBackgroundTask<TPlat: PlatformRef> {
     sync_sources: sources::AllForksSources<(PeerId, protocol::Role)>,
 
     /// Maps `PeerId`s to their indices within `sync_sources`.
-    // TODO: use SipHasher
-    sync_sources_map: HashMap<PeerId, sources::SourceId, fnv::FnvBuildHasher>,
+    sync_sources_map: HashMap<PeerId, sources::SourceId, util::SipHasherBuild>,
 
     /// Extra fields that are set after the subscription to the runtime service events has
     /// succeeded.

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{BlockNotification, FinalizedBlockRuntime, Notification, SubscribeAll, ToBackground};
-use crate::{network_service, platform::PlatformRef};
+use crate::{network_service, platform::PlatformRef, util};
 
 use alloc::{borrow::ToOwned as _, string::String, sync::Arc, vec::Vec};
 use core::{
@@ -88,7 +88,10 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
         log_target,
         network_service,
         network_chain_index,
-        peers_source_id_map: HashMap::with_capacity_and_hasher(0, Default::default()),
+        peers_source_id_map: HashMap::with_capacity_and_hasher(
+            0,
+            util::SipHasherBuild::new(rand::random()),
+        ),
         platform,
     };
 
@@ -337,8 +340,7 @@ struct Task<TPlat: PlatformRef> {
     known_finalized_runtime: Option<FinalizedBlockRuntime>,
 
     /// For each networking peer, the index of the corresponding peer within the [`Task::sync`].
-    // TODO: use SipHasher
-    peers_source_id_map: HashMap<libp2p::PeerId, all::SourceId, fnv::FnvBuildHasher>,
+    peers_source_id_map: HashMap<libp2p::PeerId, all::SourceId, util::SipHasherBuild>,
 
     /// `false` after the best block in the [`Task::sync`] has changed. Set back to `true`
     /// after the networking has been notified of this change.

--- a/light-base/src/util.rs
+++ b/light-base/src/util.rs
@@ -15,11 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::{
-    fmt::{self, Write as _},
-    hash::{BuildHasher, Hasher},
-    marker,
-};
+use core::fmt::{self, Write as _};
 
 /// Returns an opaque object implementing the `fmt::Display` trait. Truncates the given `char`
 /// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
@@ -49,51 +45,6 @@ pub fn truncated_str<'a>(
 
     Iter(input, limit)
 }
-
-/// Exactly the same as `BuildHasherDefault` from the standard library, except without the missing
-/// `new` `const` function that somehow requires needs a new language construct or something.
-// TODO remove after https://github.com/rust-lang/rust/issues/87864
-pub struct BuildHasherDefault<H>(marker::PhantomData<fn() -> H>);
-
-impl<H> BuildHasherDefault<H> {
-    pub const fn new() -> Self {
-        BuildHasherDefault(marker::PhantomData)
-    }
-}
-
-impl<H> fmt::Debug for BuildHasherDefault<H> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BuildHasherDefault").finish()
-    }
-}
-
-impl<H: Default + Hasher> BuildHasher for BuildHasherDefault<H> {
-    type Hasher = H;
-
-    fn build_hasher(&self) -> H {
-        H::default()
-    }
-}
-
-impl<H> Clone for BuildHasherDefault<H> {
-    fn clone(&self) -> BuildHasherDefault<H> {
-        BuildHasherDefault(marker::PhantomData)
-    }
-}
-
-impl<H> Default for BuildHasherDefault<H> {
-    fn default() -> BuildHasherDefault<H> {
-        BuildHasherDefault(marker::PhantomData)
-    }
-}
-
-impl<H> PartialEq for BuildHasherDefault<H> {
-    fn eq(&self, _other: &BuildHasherDefault<H>) -> bool {
-        true
-    }
-}
-
-impl<H> Eq for BuildHasherDefault<H> {}
 
 /// Implementation of the `BuildHasher` trait for the sip hasher.
 ///

--- a/light-base/src/util.rs
+++ b/light-base/src/util.rs
@@ -94,3 +94,23 @@ impl<H> PartialEq for BuildHasherDefault<H> {
 }
 
 impl<H> Eq for BuildHasherDefault<H> {}
+
+/// Implementation of the `BuildHasher` trait for the sip hasher.
+///
+/// Contrary to the one in the standard library, a seed is explicitly passed here, making the
+/// hashing predictable. This is a good thing for tests and no-std compatibility.
+pub struct SipHasherBuild([u8; 16]);
+
+impl SipHasherBuild {
+    pub fn new(seed: [u8; 16]) -> SipHasherBuild {
+        SipHasherBuild(seed)
+    }
+}
+
+impl core::hash::BuildHasher for SipHasherBuild {
+    type Hasher = siphasher::sip::SipHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        siphasher::sip::SipHasher::new_with_key(&self.0)
+    }
+}


### PR DESCRIPTION
The code has many TODOs at places where a HashMap should use a HashDos-resilient hasher rather than the FNV hasher.
This PR fixes all of them.