### PR TITLE
Check request protocol inbound allowed value

### DIFF
--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -1312,6 +1312,7 @@ where
                         .request_response_protocols
                         .iter()
                         .enumerate()
+                        .filter(|(_, p)| p.inbound_allowed)
                         .find(|(_, p)| p.name == protocol_name)
                     {
                         self.messages_to_connections.push_back((

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - The parameter of `chainHead_unstable_follow` has been renamed from `runtimeUpdates` to `withRuntime` in accordance with the latest JSON-RPC specification changes. ([#624](https://github.com/smol-dot/smoldot/pull/624))
 
+### Fixed
+
+- Fix panic when receiving a networking request of a protocol not supported by smoldot.
+
 ## 1.0.7 - 2023-05-25
 
 ### Fixed


### PR DESCRIPTION
This little check has unfortunately been lost in the previous refactoring, leading to smoldot panicking if it receives a request of a protocol for which `inbound_allowed` is `false`.