### PR TITLE
Use the browser native `DecompressionStream` API

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Within browsers, smoldot will now use the native `DecompressionStream` API in order to decompress the WebAssembly bytecode, instead of doing it manually in JavaScript. This should speed up the initialization and reduce the size of the package. The new `DecompressionStream` API has been stable since February 2020 on Chrome and Edge, since March 2023 on Safari, and since May 2023 on Firefox.
 - The parameter of `chainHead_unstable_follow` has been renamed from `runtimeUpdates` to `withRuntime` in accordance with the latest JSON-RPC specification changes. ([#624](https://github.com/smol-dot/smoldot/pull/624))
 
 ### Fixed

--- a/wasm-node/javascript/src/bytecode-browser.ts
+++ b/wasm-node/javascript/src/bytecode-browser.ts
@@ -15,9 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/// <reference lib="dom" />
+
 import { default as wasmBase64 } from './internals/bytecode/wasm.js';
 import { classicDecode } from './internals/base64.js'
-import { inflate } from 'pako';
 import { SmoldotBytecode } from './public-types.js';
 
 /**
@@ -28,6 +29,35 @@ export async function compileBytecode(): Promise<SmoldotBytecode> {
     // different file.
     // This is suboptimal compared to using `instantiateStreaming`, but it is the most
     // cross-platform cross-bundler approach.
-    return WebAssembly.compile(inflate(classicDecode(wasmBase64)))
+    return WebAssembly.compile(await zlibInflate(classicDecode(wasmBase64)))
         .then((m) => { return { wasm: m } });
+}
+
+/**
+ * Applies the zlib inflate algorithm on the buffer.
+ */
+async function zlibInflate(buffer: Uint8Array): Promise<Uint8Array> {
+    // This code has been copy-pasted from the official streams draft specification.
+    // At the moment, it is found here: https://wicg.github.io/compression/#example-deflate-compress
+    const ds = new DecompressionStream('deflate');
+    const writer = ds.writable.getWriter();
+    writer.write(buffer);
+    writer.close();
+    const output = [];
+    const reader = ds.readable.getReader();
+    let totalSize = 0;
+    while (true) {
+        const { value, done } = await reader.read();
+        if (done)
+            break;
+        output.push(value);
+        totalSize += value.byteLength;
+    }
+    const concatenated = new Uint8Array(totalSize);
+    let offset = 0;
+    for (const array of output) {
+        concatenated.set(array, offset);
+        offset += array.byteLength;
+    }
+    return concatenated;
 }

--- a/wasm-node/javascript/src/worker-browser.ts
+++ b/wasm-node/javascript/src/worker-browser.ts
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/// <reference lib="dom" />
+
 import * as instance from './internals/remote-instance.js'
 
 /**


### PR DESCRIPTION
Unfortunately, the DOM type definitions haven't been updated yet with the stabilization of `DecompressionStream`, so this PR doesn't compile. But eventually it will.