### PR TITLE
Log when a warp sync fragment is verified

### DIFF
--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -660,6 +660,12 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                             chain specification with a checkpoint past this forced change."
                         } else { "" }
                     );
+                } else {
+                    log::debug!(
+                        target: &self.log_target,
+                        "Sync => WarpSyncFragmentVerified(sender={})",
+                        sender_peer_id,
+                    );
                 }
             }
 


### PR DESCRIPTION
The change is not big enough to make it to a CHANGELOG entry I think.