### PR TITLE
Properly handle when only :heappages is modified when verifying a block

### DIFF
--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -204,13 +204,16 @@ pub enum Error {
     NewRuntimeCompilationError(host::NewErr),
     /// Block being verified has erased the `:code` key from the storage.
     CodeKeyErased,
+    /// Parent storage has an empty `:code` key.
+    ///
+    /// > **Note**: This indicates that the parent block is invalid. This error is likely caused
+    /// >           by some kind of internal error or failed assumption somewhere in the API user's
+    /// >           code.
+    #[display(fmt = "Parent storage has an empty `:code` key")]
+    ParentCodeEmpty,
     /// Block has modified the `:heappages` key in a way that fails to parse.
     #[display(fmt = "Block has modified `:heappages` key in invalid way: {_0}")]
     HeapPagesParseError(executor::InvalidHeapPagesError),
-    /// Block has modified the `:heappages` key without modifying the `:code` key. This isn't
-    /// supported by smoldot.
-    // TODO: this is something that we should support but don't because it's annoying to implement and is clearly not worth the effort
-    HeapPagesOnlyModification,
 }
 
 /// Verifies whether a block is valid.
@@ -425,13 +428,18 @@ enum VerifyInnerPhase {
         /// Parameter to later pass when invoking `Core_execute_block`.
         execute_block_parameters: Vec<u8>,
     },
-    ExecuteBlock,
+    ExecuteBlock {
+        /// If the block modifies the `:heappages` but not the `:code`, we will need to fetch the
+        /// parent's `:code` in order to compile the new runtime. If that is the case, it will
+        /// be stored here.
+        parent_code: Option<Option<Vec<u8>>>,
+    },
 }
 
 impl VerifyInner {
     fn run(mut self) -> Verify {
         loop {
-            match (self.inner, &self.phase) {
+            match (self.inner, self.phase) {
                 (runtime_host::RuntimeHostVm::Finished(Err(err)), _) => {
                     break Verify::Finished(Err((Error::WasmVm(err.detail), err.prototype)))
                 }
@@ -456,7 +464,7 @@ impl VerifyInner {
                         let vm = runtime_host::run(runtime_host::Config {
                             virtual_machine: success.virtual_machine.into_prototype(),
                             function_to_call: "Core_execute_block",
-                            parameter: iter::once(execute_block_parameters),
+                            parameter: iter::once(&execute_block_parameters),
                             main_trie_root_calculation_cache: Some(
                                 success.main_trie_root_calculation_cache,
                             ),
@@ -475,14 +483,14 @@ impl VerifyInner {
 
                     self = VerifyInner {
                         consensus_success: self.consensus_success,
-                        phase: VerifyInnerPhase::ExecuteBlock,
+                        phase: VerifyInnerPhase::ExecuteBlock { parent_code: None },
                         inner: import_process,
                     };
                 }
 
                 (
                     runtime_host::RuntimeHostVm::Finished(Ok(success)),
-                    VerifyInnerPhase::ExecuteBlock,
+                    VerifyInnerPhase::ExecuteBlock { parent_code },
                 ) => {
                     if !success.virtual_machine.value().as_ref().is_empty() {
                         return Verify::Finished(Err((
@@ -493,24 +501,32 @@ impl VerifyInner {
 
                     match (
                         success.storage_main_trie_changes.diff_get(&b":code"[..]),
+                        parent_code,
                         success
                             .storage_main_trie_changes
                             .diff_get(&b":heappages"[..]),
                     ) {
-                        (None, None) => {}
-                        (Some((None, ())), _) => {
+                        (None, _, None) => {}
+                        (Some((None, ())), _, _) => {
                             return Verify::Finished(Err((
                                 Error::CodeKeyErased,
                                 success.virtual_machine.into_prototype(),
                             )))
                         }
-                        (None, Some(_)) => {
+                        (None, None, Some(_)) => {
+                            break Verify::StorageGet(StorageGet {
+                                inner: StorageGetInner::ParentCode { success },
+                                consensus_success: self.consensus_success,
+                            })
+                        }
+                        (None, Some(None), _) => {
                             return Verify::Finished(Err((
-                                Error::HeapPagesOnlyModification,
+                                Error::ParentCodeEmpty,
                                 success.virtual_machine.into_prototype(),
                             )))
                         }
-                        (Some((Some(_code), ())), heap_pages) => {
+                        (Some((Some(_), ())), parent_code, heap_pages)
+                        | (_, parent_code @ Some(Some(_)), heap_pages) => {
                             let parent_runtime = success.virtual_machine.into_prototype();
 
                             let heap_pages = match heap_pages {
@@ -532,6 +548,7 @@ impl VerifyInner {
                                 consensus_success: self.consensus_success,
                                 parent_runtime,
                                 heap_pages,
+                                parent_code,
                                 logs: success.logs,
                                 offchain_storage_changes: success.offchain_storage_changes,
                                 storage_main_trie_changes: success.storage_main_trie_changes,
@@ -554,29 +571,29 @@ impl VerifyInner {
                     }));
                 }
 
-                (runtime_host::RuntimeHostVm::StorageGet(inner), _) => {
+                (runtime_host::RuntimeHostVm::StorageGet(inner), phase) => {
                     break Verify::StorageGet(StorageGet {
-                        inner,
-                        phase: self.phase,
+                        inner: StorageGetInner::Execution { inner, phase },
                         consensus_success: self.consensus_success,
                     })
                 }
-                (runtime_host::RuntimeHostVm::PrefixKeys(inner), _) => {
+                (runtime_host::RuntimeHostVm::PrefixKeys(inner), phase) => {
                     break Verify::StoragePrefixKeys(StoragePrefixKeys {
                         inner,
-                        phase: self.phase,
+                        phase,
                         consensus_success: self.consensus_success,
                     })
                 }
-                (runtime_host::RuntimeHostVm::NextKey(inner), _) => {
+                (runtime_host::RuntimeHostVm::NextKey(inner), phase) => {
                     break Verify::StorageNextKey(StorageNextKey {
                         inner,
-                        phase: self.phase,
+                        phase,
                         consensus_success: self.consensus_success,
                     })
                 }
-                (runtime_host::RuntimeHostVm::SignatureVerification(sig), _) => {
+                (runtime_host::RuntimeHostVm::SignatureVerification(sig), phase) => {
                     self.inner = sig.verify_and_resume();
+                    self.phase = phase;
                 }
             }
         }
@@ -586,16 +603,28 @@ impl VerifyInner {
 /// Loading a storage value is required in order to continue.
 #[must_use]
 pub struct StorageGet {
-    inner: runtime_host::StorageGet,
-    /// See [`VerifyInner::phase`].
-    phase: VerifyInnerPhase,
+    inner: StorageGetInner,
     consensus_success: SuccessConsensus,
+}
+
+enum StorageGetInner {
+    Execution {
+        inner: runtime_host::StorageGet,
+        /// See [`VerifyInner::phase`].
+        phase: VerifyInnerPhase,
+    },
+    ParentCode {
+        success: runtime_host::Success,
+    },
 }
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
     pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
-        self.inner.key()
+        match &self.inner {
+            StorageGetInner::Execution { inner, .. } => either::Left(inner.key()),
+            StorageGetInner::ParentCode { .. } => either::Right(b":code"),
+        }
     }
 
     /// Injects the corresponding storage value.
@@ -603,12 +632,27 @@ impl StorageGet {
         self,
         value: Option<(impl Iterator<Item = impl AsRef<[u8]>>, TrieEntryVersion)>,
     ) -> Verify {
-        VerifyInner {
-            inner: self.inner.inject_value(value),
-            phase: self.phase,
-            consensus_success: self.consensus_success,
+        match self.inner {
+            StorageGetInner::Execution { inner, phase } => VerifyInner {
+                inner: inner.inject_value(value),
+                phase,
+                consensus_success: self.consensus_success,
+            }
+            .run(),
+            StorageGetInner::ParentCode { success } => VerifyInner {
+                inner: runtime_host::RuntimeHostVm::Finished(Ok(success)),
+                phase: VerifyInnerPhase::ExecuteBlock {
+                    parent_code: Some(value.map(|(val_iter, _)| {
+                        val_iter.fold(Vec::new(), |mut a, b| {
+                            a.extend_from_slice(b.as_ref());
+                            a
+                        })
+                    })),
+                },
+                consensus_success: self.consensus_success,
+            }
+            .run(),
         }
-        .run()
     }
 }
 
@@ -694,19 +738,20 @@ pub struct RuntimeCompilation {
     main_trie_root_calculation_cache: calculate_root::CalculationCache,
     logs: String,
     heap_pages: vm::HeapPages,
+    parent_code: Option<Option<Vec<u8>>>,
     consensus_success: SuccessConsensus,
 }
 
 impl RuntimeCompilation {
     /// Performs the runtime compilation.
     pub fn build(self) -> Verify {
-        // A `RuntimeCompilation` object is built only if `:code` has been modified and to a
-        // specific value.
+        // A `RuntimeCompilation` object is built only if `:code` is available.
         let code = self
             .storage_main_trie_changes
             .diff_get(&b":code"[..])
+            .map(|(value, _)| value)
+            .or(self.parent_code.as_ref().map(|v| v.as_deref()))
             .unwrap()
-            .0
             .unwrap();
 
         let new_runtime = match host::HostVmPrototype::new(host::Config {


### PR DESCRIPTION
When verifying a block, if this block modifies `:code` and/or `:heappages` we also compile the new runtime in order to make sure that this runtime is valid. If the new runtime isn't valid, then the block as a whole is considered not valid.

However, right now, due to implementation difficulty, if a block only modifies `:heappages` but not `:code` we would return a `HeapPagesOnlyModification` error.

This PR fixes that by emitting a `StorageGet(:code)` then compiling the new runtime with the parent runtime's code.

An alternative solution could have been to add a `set_heap_pages` function on the runtime. However, since the value of heap pages might be used for optimizations, this method isn't really appropriate.
