### PR TITLE
Backport changes to `chainHead_unstable_storage`

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -460,7 +460,7 @@ define_methods! {
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
         hash: HashHexString,
         key: HexString,
-        #[rename = "childKey"] child_key: Option<HexString>,
+        #[rename = "childTrie"] child_trie: Option<HexString>,
         #[rename = "networkConfig"] network_config: Option<NetworkConfig>
     ) -> Cow<'a, str>,
     chainHead_unstable_unfollow(

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -461,6 +461,7 @@ define_methods! {
         hash: HashHexString,
         key: HexString,
         #[rename = "childTrie"] child_trie: Option<HexString>,
+        #[rename = "type"] ty: ChainHeadStorageType,
         #[rename = "networkConfig"] network_config: Option<NetworkConfig>
     ) -> Cow<'a, str>,
     chainHead_unstable_unfollow(
@@ -723,10 +724,36 @@ pub enum ChainHeadCallEvent<'a> {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum ChainHeadStorageType {
+    #[serde(rename = "value")]
+    Value,
+    #[serde(rename = "hash")]
+    Hash,
+    #[serde(rename = "closest-ancestor-merkle-value")]
+    ClosestAncestorMerkleValue,
+    #[serde(rename = "descendants-values")]
+    DescendantsValues,
+    #[serde(rename = "descendants-hashes")]
+    DescendantsHashes,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "event")]
 pub enum ChainHeadStorageEvent<'a> {
+    #[serde(rename = "item")]
+    Item {
+        key: HexString,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<HexString>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hash: Option<HexString>,
+        #[serde(rename = "merkle-value", skip_serializing_if = "Option::is_none")]
+        merkleValue: Option<HexString>
+    },
     #[serde(rename = "done")]
-    Done { value: Option<String> },
+    Done,
+    #[serde(rename = "waiting-for-continue")]
+    WaitingForContinue,
     #[serde(rename = "inaccessible")]
     Inaccessible {},
     #[serde(rename = "error")]

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -748,7 +748,7 @@ pub enum ChainHeadStorageEvent<'a> {
         #[serde(skip_serializing_if = "Option::is_none")]
         hash: Option<HexString>,
         #[serde(rename = "merkle-value", skip_serializing_if = "Option::is_none")]
-        merkleValue: Option<HexString>
+        merkleValue: Option<HexString>,
     },
     #[serde(rename = "done")]
     Done,

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -464,6 +464,9 @@ define_methods! {
         #[rename = "type"] ty: ChainHeadStorageType,
         #[rename = "networkConfig"] network_config: Option<NetworkConfig>
     ) -> Cow<'a, str>,
+    chainHead_unstable_storageContinue(
+        #[rename = "subscription"] subscription: Cow<'a, str>
+    ) -> (),
     chainHead_unstable_unfollow(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>
     ) -> (),
@@ -748,7 +751,7 @@ pub enum ChainHeadStorageEvent<'a> {
         #[serde(skip_serializing_if = "Option::is_none")]
         hash: Option<HexString>,
         #[serde(rename = "merkle-value", skip_serializing_if = "Option::is_none")]
-        merkleValue: Option<HexString>,
+        merkle_value: Option<HexString>,
     },
     #[serde(rename = "done")]
     Done,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -160,6 +160,9 @@ pub(super) enum SubscriptionMessage {
         child_trie: Option<methods::HexString>,
         ty: methods::ChainHeadStorageType,
     },
+    ChainHeadStorageContinue {
+        continue_request_id: (String, requests_subscriptions::RequestId),
+    },
     ChainHeadBody {
         hash: methods::HashHexString,
         get_request_id: (String, requests_subscriptions::RequestId),
@@ -525,6 +528,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             | methods::MethodCall::chainHead_unstable_stopCall { .. }
             | methods::MethodCall::chainHead_unstable_stopStorage { .. }
             | methods::MethodCall::chainHead_unstable_storage { .. }
+            | methods::MethodCall::chainHead_unstable_storageContinue { .. }
             | methods::MethodCall::chainHead_unstable_unfollow { .. }
             | methods::MethodCall::chainHead_unstable_unpin { .. }
             | methods::MethodCall::chainSpec_unstable_chainName { .. }
@@ -811,6 +815,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     child_trie,
                     ty,
                     network_config,
+                )
+                .await;
+            }
+            methods::MethodCall::chainHead_unstable_storageContinue { subscription } => {
+                self.chain_head_storage_continue(
+                    (request_id, &state_machine_request_id),
+                    &subscription,
                 )
                 .await;
             }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -158,6 +158,7 @@ pub(super) enum SubscriptionMessage {
         network_config: methods::NetworkConfig,
         key: methods::HexString,
         child_trie: Option<methods::HexString>,
+        ty: methods::ChainHeadStorageType,
     },
     ChainHeadBody {
         hash: methods::HashHexString,
@@ -799,6 +800,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 hash,
                 key,
                 child_trie,
+                ty,
                 network_config,
             } => {
                 self.chain_head_storage(
@@ -807,6 +809,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     hash,
                     key,
                     child_trie,
+                    ty,
                     network_config,
                 )
                 .await;

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -157,7 +157,7 @@ pub(super) enum SubscriptionMessage {
         get_request_id: (String, requests_subscriptions::RequestId),
         network_config: methods::NetworkConfig,
         key: methods::HexString,
-        child_key: Option<methods::HexString>,
+        child_trie: Option<methods::HexString>,
     },
     ChainHeadBody {
         hash: methods::HashHexString,
@@ -798,7 +798,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 follow_subscription,
                 hash,
                 key,
-                child_key,
+                child_trie,
                 network_config,
             } => {
                 self.chain_head_storage(
@@ -806,7 +806,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     &follow_subscription,
                     hash,
                     key,
-                    child_key,
+                    child_trie,
                     network_config,
                 )
                 .await;

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -339,7 +339,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         follow_subscription: &str,
         hash: methods::HashHexString,
         key: methods::HexString,
-        child_key: Option<methods::HexString>,
+        child_trie: Option<methods::HexString>,
         network_config: Option<methods::NetworkConfig>,
     ) {
         let network_config = network_config.unwrap_or(methods::NetworkConfig {
@@ -360,7 +360,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     get_request_id: (request_id.0.to_owned(), request_id.1.clone()),
                     hash,
                     key,
-                    child_key,
+                    child_trie,
                     network_config,
                 },
             )
@@ -1051,7 +1051,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                 get_request_id,
                 network_config,
                 key,
-                child_key,
+                child_trie,
             } => {
                 // Obtain the header of the requested block.
                 // Contains `None` if the subscription is disjoint.
@@ -1069,7 +1069,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     (&get_request_id.0, &get_request_id.1),
                     hash,
                     key,
-                    child_key,
+                    child_trie,
                     network_config,
                     block_scale_encoded_header,
                 )
@@ -1367,11 +1367,12 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
         request_id: (&str, &requests_subscriptions::RequestId),
         hash: methods::HashHexString,
         key: methods::HexString,
-        child_key: Option<methods::HexString>,
+        child_trie: Option<methods::HexString>,
         network_config: methods::NetworkConfig,
         block_scale_encoded_header: Option<Vec<u8>>,
     ) {
-        if child_key.is_some() {
+        if child_trie.is_some() {
+            // TODO: implement this
             requests_subscriptions
                 .respond(
                     request_id.1,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The parameter of `chainHead_unstable_follow` has been renamed from `runtimeUpdates` to `withRuntime` in accordance with the latest JSON-RPC specification changes. ([#624](https://github.com/smol-dot/smoldot/pull/624))
 - Errors while building the runtime and errors while building the consensus-related information that can happen during the warp syncing process are now printed in the logs. ([#644](https://github.com/smol-dot/smoldot/pull/644))
+- The `chainHead_unstable_storage` JSON-RPC method has been updated according to the latest changes to the JSON-RPC specification. These changes can be found [here](https://github.com/paritytech/json-rpc-interface-spec/pull/37).
 
 ### Fixed
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - The parameter of `chainHead_unstable_follow` has been renamed from `runtimeUpdates` to `withRuntime` in accordance with the latest JSON-RPC specification changes. ([#624](https://github.com/smol-dot/smoldot/pull/624))
 - Errors while building the runtime and errors while building the consensus-related information that can happen during the warp syncing process are now printed in the logs. ([#644](https://github.com/smol-dot/smoldot/pull/644))
-- The `chainHead_unstable_storage` JSON-RPC method has been updated according to the latest changes to the JSON-RPC specification. These changes can be found [here](https://github.com/paritytech/json-rpc-interface-spec/pull/37).
+- The `chainHead_unstable_storage` JSON-RPC method has been updated according to the latest changes to the JSON-RPC specification. These changes can be found [here](https://github.com/paritytech/json-rpc-interface-spec/pull/37). The `descendants-values`, `descendants-hashes`, and `closest-ancestor-merkle-value` types aren't implemented yet and produce an error. ([#647](https://github.com/smol-dot/smoldot/pull/647))
 
 ### Fixed
 


### PR DESCRIPTION
cc #605

This PR implements only the API changes and doesn't implement the `descendants-values`, `descendants-hashes`, and `closest-ancestor-merkle-value` types yet. For this reason I'm going to leave the issue open.
