### PR TITLE
Set resolver = "2" in the workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 default-members = ["lib", "full-node"]
 members = [
     "lib",


### PR DESCRIPTION
Seeing https://github.com/rust-lang/cargo/pull/10910 made me realize that we're not using the resolver v2 due to this Cargo weirdness.

This explains [this comment](https://github.com/smol-dot/smoldot/pull/431#issuecomment-1520002015).