### PR TITLE
Enable TCP NODELAY on Deno

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- TCP NODELAY is now enabled on Deno. The minimum required Deno version is now v1.29.0, which was released on 2022-12-14.
+- TCP NODELAY is now enabled on Deno. The minimum required Deno version is now v1.29.0, which was released on 2022-12-14. ([#665](https://github.com/smol-dot/smoldot/pull/665))
 
 ## 1.0.8 - 2023-06-05
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The parameter of `chainHead_unstable_follow` has been renamed from `runtimeUpdates` to `withRuntime` in accordance with the latest JSON-RPC specification changes. ([#624](https://github.com/smol-dot/smoldot/pull/624))
 - Errors while building the runtime and errors while building the consensus-related information that can happen during the warp syncing process are now printed in the logs. ([#644](https://github.com/smol-dot/smoldot/pull/644))
 - The `chainHead_unstable_storage` JSON-RPC method has been updated according to the latest changes to the JSON-RPC specification. These changes can be found [here](https://github.com/paritytech/json-rpc-interface-spec/pull/37). The `descendants-values`, `descendants-hashes`, and `closest-ancestor-merkle-value` types aren't implemented yet and produce an error. ([#647](https://github.com/smol-dot/smoldot/pull/647))
+- TCP NODELAY is now enabled on Deno. The minimum required Deno version is now v1.29.0, which was released on 2022-12-14.
 
 ### Fixed
 

--- a/wasm-node/javascript/src/no-auto-bytecode-deno.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-deno.ts
@@ -148,11 +148,10 @@ function connect(config: ConnectionConfig): Connection {
         };
 
         socket.inner = socket.inner.then((established) => {
-            // TODO: at the time of writing of this comment, `setNoDelay` is still unstable
-            //established.setNoDelay();
-
             if (socket.destroyed)
                 return established;
+
+            established?.setNoDelay();
             config.onOpen({ type: 'single-stream', handshake: 'multistream-select-noise-yamux', initialWritableBytes: 1024 * 1024, writeClosable: true });
 
             // Spawns an asynchronous task that continuously reads from the socket.
@@ -396,16 +395,12 @@ declare namespace Deno {
 
     export interface TcpConn extends Conn {
         /**
-         * **UNSTABLE**: new API, see https://github.com/denoland/deno/issues/13617.
+         * Enable/disable the use of Nagle's algorithm.
          *
-         * Enable/disable the use of Nagle's algorithm. Defaults to true.
+         * @param [noDelay=true]
          */
-        setNoDelay(nodelay?: boolean): void;
-        /**
-         * **UNSTABLE**: new API, see https://github.com/denoland/deno/issues/13617.
-         *
-         * Enable/disable keep-alive functionality.
-         */
-        setKeepAlive(keepalive?: boolean): void;
+        setNoDelay(noDelay?: boolean): void;
+        /** Enable/disable keep-alive functionality. */
+        setKeepAlive(keepAlive?: boolean): void;
     }
 }


### PR DESCRIPTION
Probably shouldn't be merged yet, even though the change is important, because Deno v1.29 isn't available on snap: https://snapcraft.io/deno

cc https://github.com/denoland/deno_install/issues/251