### PR TITLE
Use `nom` to parse the chain spec checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,12 +464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,17 +1413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,30 +1839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
-dependencies = [
- "arrayvec 0.7.2",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "parking"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,16 +2004,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -2478,7 +2427,6 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "parity-scale-codec",
  "parking_lot",
  "pbkdf2",
  "pin-project",
@@ -2812,23 +2760,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
 
 [[package]]
 name = "twox-hash"
@@ -3504,15 +3435,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "winnow"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-parser"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -85,10 +85,6 @@ parking_lot = { version = "0.12.1", optional = true }
 pin-project = { version = "1.1.0", optional = true }
 soketto = { version = "0.7.1", optional = true }
 
-# BELOW: DEPENDENCIES TO REMOVE
-# TODO:
-parity-scale-codec = { version = "3.5.0", features = ["derive"], default-features = false } # TODO: a lot of unnecessary overhead in terms of memory allocations
-
 # This list of targets matches the tier 1 and tier 2 of platforms supported by wasmtime: <https://docs.wasmtime.dev/stability-tiers.html>
 # The arch and OS of a specific target can be found with the command `rustc +nightly -Z unstable-options --print target-spec-json --target ...`
 [target.'cfg(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")))'.dependencies]

--- a/lib/src/chain_spec/light_sync_state.rs
+++ b/lib/src/chain_spec/light_sync_state.rs
@@ -19,7 +19,6 @@ use super::{ParseError, ParseErrorInner};
 use crate::header::BabeNextConfig;
 
 use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
-use parity_scale_codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,27 +36,36 @@ impl LightSyncState {
         &self,
         block_number_bytes: usize,
     ) -> Result<DecodedLightSyncState, ParseError> {
-        let mut grandpa_authority_set_slice = &self.grandpa_authority_set.0[..];
-        let mut babe_epoch_changes_slice = &self.babe_epoch_changes.0[..];
+        // We don't use `all_consuming` in order to remain compatible in case new fields are added
+        // in Substrate to these data structures.
+        // This really should be solved by having a proper format for checkpoints, but
+        // there isn't.
+        let grandpa_authority_set = match nom::Finish::finish(nom::combinator::complete(
+            authority_set::<nom::error::Error<&[u8]>>,
+        )(
+            &self.grandpa_authority_set.0[..]
+        )) {
+            Ok((_, v)) => v,
+            Err(_err) => return Err(ParseError(ParseErrorInner::Other)),
+        };
+        let babe_epoch_changes = match nom::Finish::finish(nom::combinator::complete(
+            epoch_changes::<nom::error::Error<&[u8]>>,
+        )(&self.babe_epoch_changes.0[..]))
+        {
+            Ok((_, v)) => v,
+            Err(_err) => return Err(ParseError(ParseErrorInner::Other)),
+        };
 
-        let decoded = DecodedLightSyncState {
+        Ok(DecodedLightSyncState {
             finalized_block_header: crate::header::decode(
                 &self.finalized_block_header.0[..],
                 block_number_bytes,
             )
             .map_err(|_| ParseError(ParseErrorInner::Other))?
             .into(),
-            // We use `decode` in order to remain compatible in case new fields are added in
-            // Substrate to these data structures.
-            // This really should be solved by having a proper format for checkpoints, but
-            // there isn't.
-            grandpa_authority_set: AuthoritySet::decode(&mut grandpa_authority_set_slice)
-                .map_err(|_| ParseError(ParseErrorInner::Other))?,
-            babe_epoch_changes: EpochChanges::decode(&mut babe_epoch_changes_slice)
-                .map_err(|_| ParseError(ParseErrorInner::Other))?,
-        };
-
-        Ok(decoded)
+            grandpa_authority_set,
+            babe_epoch_changes,
+        })
     }
 }
 
@@ -68,9 +76,9 @@ pub(super) struct DecodedLightSyncState {
     pub(super) grandpa_authority_set: AuthoritySet,
 }
 
-#[derive(Debug, Decode, Encode)]
+#[derive(Debug)]
 pub(super) struct EpochChanges {
-    inner: ForkTree<PersistedEpochHeader>,
+    _inner: ForkTree<PersistedEpochHeader>,
     pub(super) epochs: BTreeMap<([u8; 32], u32), PersistedEpoch>,
     // TODO: Substrate has added the field below to the checkpoints format ; it is commented out
     //       right now in order to maintain compatibility with checkpoints that were generated
@@ -78,32 +86,133 @@ pub(super) struct EpochChanges {
     // gap: Option<GapEpochs>,
 }
 
+fn epoch_changes<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], EpochChanges, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            fork_tree(persisted_epoch_header),
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(
+                    num_elems,
+                    num_elems,
+                    nom::sequence::tuple((
+                        nom::bytes::complete::take(32u32),
+                        nom::number::complete::le_u32,
+                        persisted_epoch,
+                    )),
+                )
+            }),
+        )),
+        move |(inner, epochs)| EpochChanges {
+            _inner: inner,
+            epochs: epochs
+                .into_iter()
+                .map(|(h, n, e)| ((*<&[u8; 32]>::try_from(h).unwrap(), n), e))
+                .collect(),
+        },
+    )(bytes)
+}
+
 #[allow(unused)]
-#[derive(Debug, Decode, Encode)]
+#[derive(Debug)]
 pub(super) struct GapEpochs {
     current: ([u8; 32], u32, PersistedEpoch),
     next: Option<([u8; 32], u32, BabeEpoch)>,
 }
 
-#[derive(Debug, Decode, Encode)]
+#[allow(unused)]
+fn gap_epochs<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], GapEpochs, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::sequence::tuple((
+                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                    *<&[u8; 32]>::try_from(b).unwrap()
+                }),
+                nom::number::complete::le_u32,
+                persisted_epoch,
+            )),
+            crate::util::nom_option_decode(nom::sequence::tuple((
+                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                    *<&[u8; 32]>::try_from(b).unwrap()
+                }),
+                nom::number::complete::le_u32,
+                babe_epoch,
+            ))),
+        )),
+        move |(current, next)| GapEpochs { current, next },
+    )(bytes)
+}
+
+#[derive(Debug)]
 pub(super) enum PersistedEpochHeader {
     Genesis(EpochHeader, EpochHeader),
     Regular(EpochHeader),
 }
 
-#[derive(Debug, Decode, Encode)]
-pub(super) struct EpochHeader {
-    start_slot: u64,
-    end_slot: u64,
+fn persisted_epoch_header<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], PersistedEpochHeader, E> {
+    nom::branch::alt((
+        nom::combinator::map(
+            nom::sequence::preceded(
+                nom::bytes::complete::tag(&[0]),
+                nom::sequence::tuple((epoch_header, epoch_header)),
+            ),
+            |(a, b)| PersistedEpochHeader::Genesis(a, b),
+        ),
+        nom::combinator::map(
+            nom::sequence::preceded(nom::bytes::complete::tag(&[1]), epoch_header),
+            PersistedEpochHeader::Regular,
+        ),
+    ))(bytes)
 }
 
-#[derive(Debug, Decode, Encode)]
+#[derive(Debug)]
+pub(super) struct EpochHeader {
+    _start_slot: u64,
+    _end_slot: u64,
+}
+
+fn epoch_header<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], EpochHeader, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((nom::number::complete::le_u64, nom::number::complete::le_u64)),
+        move |(start_slot, end_slot)| EpochHeader {
+            _start_slot: start_slot,
+            _end_slot: end_slot,
+        },
+    )(bytes)
+}
+
+#[derive(Debug)]
 pub(super) enum PersistedEpoch {
     Genesis(BabeEpoch, BabeEpoch),
     Regular(BabeEpoch),
 }
 
-#[derive(Debug, Decode, Encode)]
+fn persisted_epoch<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], PersistedEpoch, E> {
+    nom::branch::alt((
+        nom::combinator::map(
+            nom::sequence::preceded(
+                nom::bytes::complete::tag(&[0]),
+                nom::sequence::tuple((babe_epoch, babe_epoch)),
+            ),
+            |(a, b)| PersistedEpoch::Genesis(a, b),
+        ),
+        nom::combinator::map(
+            nom::sequence::preceded(nom::bytes::complete::tag(&[1]), babe_epoch),
+            PersistedEpoch::Regular,
+        ),
+    ))(bytes)
+}
+
+#[derive(Debug)]
 pub(super) struct BabeEpoch {
     pub(super) epoch_index: u64,
     pub(super) slot_number: u64,
@@ -113,7 +222,38 @@ pub(super) struct BabeEpoch {
     pub(super) config: BabeNextConfig,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode)]
+fn babe_epoch<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], BabeEpoch, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::number::complete::le_u64,
+            nom::number::complete::le_u64,
+            nom::number::complete::le_u64,
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(num_elems, num_elems, babe_authority)
+            }),
+            nom::bytes::complete::take(32u32),
+            |b| {
+                BabeNextConfig::from_slice(b)
+                    .map(|c| (&b[17..], c)) // TODO: hacky to use a constant
+                    .map_err(|_| {
+                        nom::Err::Error(nom::error::make_error(b, nom::error::ErrorKind::MapOpt))
+                    })
+            },
+        )),
+        move |(epoch_index, slot_number, duration, authorities, randomness, config)| BabeEpoch {
+            epoch_index,
+            slot_number,
+            duration,
+            authorities,
+            randomness: *<&[u8; 32]>::try_from(randomness).unwrap(),
+            config,
+        },
+    )(bytes)
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BabeAuthority {
     /// Sr25519 public key.
     pub public_key: [u8; 32],
@@ -124,33 +264,128 @@ pub struct BabeAuthority {
     pub weight: u64,
 }
 
-#[derive(Debug, Decode, Encode)]
+fn babe_authority<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], BabeAuthority, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::bytes::complete::take(32u32),
+            nom::number::complete::le_u64,
+        )),
+        move |(public_key, weight)| BabeAuthority {
+            public_key: *<&[u8; 32]>::try_from(public_key).unwrap(),
+            weight,
+        },
+    )(bytes)
+}
+
+#[derive(Debug)]
 pub(super) struct AuthoritySet {
     pub(super) current_authorities: Vec<GrandpaAuthority>,
     pub(super) set_id: u64,
-    pending_standard_changes: ForkTree<PendingChange>,
-    pending_forced_changes: Vec<PendingChange>,
+    _pending_standard_changes: ForkTree<PendingChange>,
+    _pending_forced_changes: Vec<PendingChange>,
     /// Note: this field didn't exist in Substrate before 2021-01-20. Light sync states that are
     /// older than that are missing it.
-    authority_set_changes: Vec<(u64, u32)>,
+    _authority_set_changes: Vec<(u64, u32)>,
 }
 
-#[derive(Debug, Decode, Encode)]
+fn authority_set<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], AuthoritySet, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(num_elems, num_elems, grandpa_authority)
+            }),
+            nom::number::complete::le_u64,
+            fork_tree(pending_change),
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(num_elems, num_elems, pending_change)
+            }),
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(
+                    num_elems,
+                    num_elems,
+                    nom::sequence::tuple((
+                        nom::number::complete::le_u64,
+                        nom::number::complete::le_u32,
+                    )),
+                )
+            }),
+        )),
+        move |(
+            current_authorities,
+            set_id,
+            pending_standard_changes,
+            pending_forced_changes,
+            authority_set_changes,
+        )| AuthoritySet {
+            current_authorities,
+            set_id,
+            _pending_standard_changes: pending_standard_changes,
+            _pending_forced_changes: pending_forced_changes,
+            _authority_set_changes: authority_set_changes,
+        },
+    )(bytes)
+}
+
+#[derive(Debug)]
 pub(super) struct PendingChange {
-    next_authorities: Vec<GrandpaAuthority>,
-    delay: u32,
-    canon_height: u32,
-    canon_hash: [u8; 32],
-    delay_kind: DelayKind,
+    _next_authorities: Vec<GrandpaAuthority>,
+    _delay: u32,
+    _canon_height: u32,
+    _canon_hash: [u8; 32],
+    _delay_kind: DelayKind,
 }
 
-#[derive(Debug, Decode, Encode)]
+fn pending_change<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], PendingChange, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
+                nom::multi::many_m_n(num_elems, num_elems, grandpa_authority)
+            }),
+            nom::number::complete::le_u32,
+            nom::number::complete::le_u32,
+            nom::bytes::complete::take(32u32),
+            delay_kind,
+        )),
+        move |(next_authorities, delay, canon_height, canon_hash, delay_kind)| PendingChange {
+            _next_authorities: next_authorities,
+            _delay: delay,
+            _canon_height: canon_height,
+            _canon_hash: *<&[u8; 32]>::try_from(canon_hash).unwrap(),
+            _delay_kind: delay_kind,
+        },
+    )(bytes)
+}
+
+#[derive(Debug)]
 pub(super) enum DelayKind {
     Finalized,
-    Best { median_last_finalized: u32 },
+    Best { _median_last_finalized: u32 },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode)]
+fn delay_kind<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], DelayKind, E> {
+    nom::branch::alt((
+        nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| DelayKind::Finalized),
+        nom::combinator::map(
+            nom::sequence::preceded(
+                nom::bytes::complete::tag(&[1]),
+                nom::number::complete::le_u32,
+            ),
+            |median_last_finalized| DelayKind::Best {
+                _median_last_finalized: median_last_finalized,
+            },
+        ),
+    ))(bytes)
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct GrandpaAuthority {
     /// Ed25519 public key.
     pub public_key: [u8; 32],
@@ -162,18 +397,110 @@ pub struct GrandpaAuthority {
     pub weight: u64,
 }
 
-#[derive(Debug, Decode, Encode)]
-pub(super) struct ForkTree<T> {
-    roots: Vec<ForkTreeNode<T>>,
-    best_finalized_number: Option<u32>,
+fn grandpa_authority<'a, E: nom::error::ParseError<&'a [u8]>>(
+    bytes: &'a [u8],
+) -> nom::IResult<&'a [u8], GrandpaAuthority, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::bytes::complete::take(32u32),
+            nom::number::complete::le_u64,
+        )),
+        move |(public_key, weight)| GrandpaAuthority {
+            public_key: *<&[u8; 32]>::try_from(public_key).unwrap(),
+            weight,
+        },
+    )(bytes)
 }
 
-#[derive(Debug, Decode, Encode)]
+#[derive(Debug)]
+pub(super) struct ForkTree<T> {
+    _roots: Vec<ForkTreeNode<T>>,
+    _best_finalized_number: Option<u32>,
+}
+
+fn fork_tree<'a, T, E: nom::error::ParseError<&'a [u8]>>(
+    mut inner: impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], T, E>,
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], ForkTree<T>, E> {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            // We do parsing manually due to borrow checking troubles regarding `inner`.
+            move |mut bytes| {
+                let (bytes_rest, num_roots) = match crate::util::nom_scale_compact_usize(bytes) {
+                    Ok(d) => d,
+                    Err(err) => return Err(err),
+                };
+                bytes = bytes_rest;
+
+                let mut roots = Vec::with_capacity(num_roots);
+                for _ in 0..num_roots {
+                    let (bytes_rest, child) = match fork_tree_node(&mut inner)(bytes) {
+                        Ok(d) => d,
+                        Err(err) => return Err(err),
+                    };
+                    bytes = bytes_rest;
+                    roots.push(child);
+                }
+
+                Ok((bytes, roots))
+            },
+            crate::util::nom_option_decode(nom::number::complete::le_u32),
+        )),
+        |(roots, best_finalized_number)| ForkTree {
+            _roots: roots,
+            _best_finalized_number: best_finalized_number,
+        },
+    )
+}
+
+#[derive(Debug)]
 pub(super) struct ForkTreeNode<T> {
-    hash: [u8; 32],
-    number: u32,
-    data: T,
-    children: Vec<Self>,
+    _hash: [u8; 32],
+    _number: u32,
+    _data: T,
+    _children: Vec<Self>,
+}
+
+fn fork_tree_node<'a, 'p, T, E: nom::error::ParseError<&'a [u8]>>(
+    inner: &'p mut dyn FnMut(&'a [u8]) -> nom::IResult<&'a [u8], T, E>,
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], ForkTreeNode<T>, E> + 'p {
+    nom::combinator::map(
+        nom::sequence::tuple((
+            nom::bytes::complete::take(32u32),
+            nom::number::complete::le_u32,
+            // We do parsing manually due to borrow checking troubles regarding `inner`.
+            move |mut bytes| {
+                let (bytes_rest, data) = match inner(bytes) {
+                    Ok(d) => d,
+                    Err(err) => return Err(err),
+                };
+                bytes = bytes_rest;
+
+                let (bytes_rest, num_children) = match crate::util::nom_scale_compact_usize(bytes) {
+                    Ok(d) => d,
+                    Err(err) => return Err(err),
+                };
+                bytes = bytes_rest;
+
+                let mut children = Vec::with_capacity(num_children);
+                for _ in 0..num_children {
+                    let (bytes_rest, child) = match fork_tree_node(&mut *inner)(bytes) {
+                        Ok(d) => d,
+                        Err(err) => return Err(err),
+                    };
+                    bytes = bytes_rest;
+                    children.push(child);
+                }
+
+                Ok((bytes, (data, children)))
+            },
+        )),
+        |(hash, number, (data, children))| ForkTreeNode {
+            _hash: *<&[u8; 32]>::try_from(hash).unwrap(),
+            _number: number,
+            _data: data,
+            _children: children,
+        },
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/lib/src/header/babe.rs
+++ b/lib/src/header/babe.rs
@@ -326,10 +326,7 @@ impl<'a> From<BabeAuthorityRef<'a>> for BabeAuthority {
 
 /// Information about the next epoch config, if changed. This is broadcast in the first
 /// block of the epoch, and applies using the same rules as `NextEpochDescriptor`.
-// TODO: remove the Encode & Decode trait derivation ; unfortunately used elsewhere
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, parity_scale_codec::Encode, parity_scale_codec::Decode,
-)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BabeNextConfig {
     /// Value of `c` in `BabeEpochConfiguration`.
     pub c: (u64, u64),
@@ -364,10 +361,7 @@ impl BabeNextConfig {
 }
 
 /// Types of allowed slots.
-// TODO: remove the Encode & Decode trait derivation ; unfortunately used elsewhere
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, parity_scale_codec::Encode, parity_scale_codec::Decode,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BabeAllowedSlots {
     /// Only allow primary slot claims.
     PrimarySlots,


### PR DESCRIPTION
Removes the dependency on `parity-scale-codec`.