### PR TITLE
Tweak the trie root calculator to not ask for the closest descendant key when not necessary

### DIFF
--- a/full-node/src/run/consensus_service.rs
+++ b/full-node/src/run/consensus_service.rs
@@ -840,7 +840,7 @@ impl SyncBackground {
                             )
                         }));
                     }
-                    author::build::BuilderAuthoring::MerkleValue(req) => {
+                    author::build::BuilderAuthoring::ClosestDescendantMerkleValue(req) => {
                         block_authoring = req.resume_unknown();
                     }
                     author::build::BuilderAuthoring::NextKey(req) => {

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -144,8 +144,9 @@ pub enum BuilderAuthoring {
     /// Loading a storage value from the parent storage is required in order to continue.
     StorageGet(StorageGet),
 
-    /// Obtaining the Merkle value of a trie node is required in order to continue.
-    MerkleValue(MerkleValue),
+    /// Obtaining the Merkle value of the closest descendant of a trie node is required in order
+    /// to continue.
+    ClosestDescendantMerkleValue(ClosestDescendantMerkleValue),
 
     /// Fetching the key that follows a given one in the parent storage is required in order to
     /// continue.
@@ -325,14 +326,14 @@ impl StorageGet {
     }
 }
 
-/// Obtaining the Merkle value of a trie node is required in order to continue.
+/// Obtaining the Merkle value of the closest descendant of a trie node is required in order
+/// to continue.
 #[must_use]
-pub struct MerkleValue(runtime::MerkleValue, Shared);
+pub struct ClosestDescendantMerkleValue(runtime::ClosestDescendantMerkleValue, Shared);
 
-impl MerkleValue {
-    /// Returns the key whose Merkle value must be passed to [`MerkleValue::inject_merkle_value`].
-    ///
-    /// The key is guaranteed to have been injected through [`NextKey::inject_key`] earlier.
+impl ClosestDescendantMerkleValue {
+    /// Returns the key whose closest descendant Merkle value must be passed to
+    /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
     pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
         self.0.key()
     }
@@ -346,9 +347,6 @@ impl MerkleValue {
     }
 
     /// Injects the corresponding Merkle value.
-    ///
-    /// Note that there is no way to indicate that the trie node doesn't exist. This is because
-    /// the node is guaranteed to have been injected through [`NextKey::inject_key`] earlier.
     pub fn inject_merkle_value(self, merkle_value: &[u8]) -> BuilderAuthoring {
         self.1
             .with_runtime_inner(self.0.inject_merkle_value(merkle_value))
@@ -534,8 +532,10 @@ impl Shared {
                 runtime::BlockBuild::StorageGet(inner) => {
                     break BuilderAuthoring::StorageGet(StorageGet(inner, self))
                 }
-                runtime::BlockBuild::MerkleValue(inner) => {
-                    break BuilderAuthoring::MerkleValue(MerkleValue(inner, self))
+                runtime::BlockBuild::ClosestDescendantMerkleValue(inner) => {
+                    break BuilderAuthoring::ClosestDescendantMerkleValue(
+                        ClosestDescendantMerkleValue(inner, self),
+                    )
                 }
                 runtime::BlockBuild::NextKey(inner) => {
                     break BuilderAuthoring::NextKey(NextKey(inner, self))

--- a/lib/src/author/runtime/tests.rs
+++ b/lib/src/author/runtime/tests.rs
@@ -64,7 +64,7 @@ fn block_building_works() {
                     .map(|(_, v)| iter::once(v));
                 builder = get.inject_value(value.map(|v| (v, super::TrieEntryVersion::V0)));
             }
-            super::BlockBuild::MerkleValue(req) => {
+            super::BlockBuild::ClosestDescendantMerkleValue(req) => {
                 builder = req.resume_unknown();
             }
             super::BlockBuild::NextKey(req) => {

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -173,8 +173,9 @@ pub enum RuntimeHostVm {
     Finished(Result<Success, Error>),
     /// Loading a storage value is required in order to continue.
     StorageGet(StorageGet),
-    /// Obtaining the Merkle value of a trie node is required in order to continue.
-    MerkleValue(MerkleValue),
+    /// Obtaining the Merkle value of the closest descendant of a trie node is required in order
+    /// to continue.
+    ClosestDescendantMerkleValue(ClosestDescendantMerkleValue),
     /// Fetching the key that follows a given one is required in order to continue.
     NextKey(NextKey),
     /// Verifying whether a signature is correct is required in order to continue.
@@ -188,7 +189,7 @@ impl RuntimeHostVm {
             RuntimeHostVm::Finished(Ok(inner)) => inner.virtual_machine.into_prototype(),
             RuntimeHostVm::Finished(Err(inner)) => inner.prototype,
             RuntimeHostVm::StorageGet(inner) => inner.inner.vm.into_prototype(),
-            RuntimeHostVm::MerkleValue(inner) => inner.inner.vm.into_prototype(),
+            RuntimeHostVm::ClosestDescendantMerkleValue(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::NextKey(inner) => inner.inner.vm.into_prototype(),
             RuntimeHostVm::SignatureVerification(inner) => inner.inner.vm.into_prototype(),
         }
@@ -466,16 +467,16 @@ impl NextKey {
     }
 }
 
-/// Obtaining the Merkle value of a trie node is required in order to continue.
+/// Obtaining the Merkle value of the closest descendant of a trie node is required in order to
+/// continue.
 #[must_use]
-pub struct MerkleValue {
+pub struct ClosestDescendantMerkleValue {
     inner: Inner,
 }
 
-impl MerkleValue {
-    /// Returns the key whose Merkle value must be passed to [`MerkleValue::inject_merkle_value`].
-    ///
-    /// The key is guaranteed to have been injected through [`NextKey::inject_key`] earlier.
+impl ClosestDescendantMerkleValue {
+    /// Returns the key whose closest descendant Merkle value must be passed to
+    /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
     pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
         debug_assert!(matches!(
             &self.inner.vm,
@@ -507,9 +508,6 @@ impl MerkleValue {
     }
 
     /// Injects the corresponding Merkle value.
-    ///
-    /// Note that there is no way to indicate that the trie node doesn't exist. This is because
-    /// the node is guaranteed to have been injected through [`NextKey::inject_key`] earlier.
     pub fn inject_merkle_value(mut self, merkle_value: &[u8]) -> RuntimeHostVm {
         debug_assert!(matches!(
             &self.inner.vm,
@@ -816,7 +814,9 @@ impl Inner {
                                     calc_req,
                                 ),
                             );
-                            return RuntimeHostVm::MerkleValue(MerkleValue { inner: self });
+                            return RuntimeHostVm::ClosestDescendantMerkleValue(
+                                ClosestDescendantMerkleValue { inner: self },
+                            );
                         }
                         trie_root_calculator::InProgress::Finished { trie_root_hash } => {
                             self.vm = req.resume(Some(&trie_root_hash));

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -482,7 +482,7 @@ impl MerkleValue {
             host::HostVm::ExternalStorageRoot(_)
         ));
 
-        let trie_root_calculator::InProgress::MerkleValue(request) =
+        let trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request) =
             self.inner.root_calculation.as_ref().unwrap()
             else { unreachable!() };
         request.key().flat_map(util::as_ref_iter)
@@ -498,7 +498,7 @@ impl MerkleValue {
             host::HostVm::ExternalStorageRoot(_)
         ));
 
-        let trie_root_calculator::InProgress::MerkleValue(request) =
+        let trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request) =
             self.inner.root_calculation.take().unwrap()
             else { unreachable!() };
 
@@ -516,7 +516,7 @@ impl MerkleValue {
             host::HostVm::ExternalStorageRoot(_)
         ));
 
-        let trie_root_calculator::InProgress::MerkleValue(request) =
+        let trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request) =
             self.inner.root_calculation.take().unwrap()
             else { unreachable!() };
 
@@ -807,10 +807,15 @@ impl Inner {
                                 self.root_calculation = Some(calc_req.inject_value(None));
                             }
                         }
-                        trie_root_calculator::InProgress::MerkleValue(calc_req) => {
+                        trie_root_calculator::InProgress::ClosestDescendantMerkleValue(
+                            calc_req,
+                        ) => {
                             self.vm = req.into();
-                            self.root_calculation =
-                                Some(trie_root_calculator::InProgress::MerkleValue(calc_req));
+                            self.root_calculation = Some(
+                                trie_root_calculator::InProgress::ClosestDescendantMerkleValue(
+                                    calc_req,
+                                ),
+                            );
                             return RuntimeHostVm::MerkleValue(MerkleValue { inner: self });
                         }
                         trie_root_calculator::InProgress::Finished { trie_root_hash } => {

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -106,7 +106,7 @@ pub enum InProgress {
     /// See [`StorageValue`].
     StorageValue(StorageValue),
     /// See [`MerkleValue`].
-    MerkleValue(MerkleValue),
+    ClosestDescendantMerkleValue(ClosestDescendantMerkleValue),
 }
 
 /// In order to continue the calculation, must find in the base trie the closest descendant
@@ -168,7 +168,7 @@ impl ClosestDescendant {
                 // we could in principle not ask for the Merkle value. However we do it anyway
                 // with the hope that the Merkle value is < 32 bytes and its partial key can be
                 // adjusted without having to recalculate the entire sub-tree.
-                return InProgress::MerkleValue(MerkleValue {
+                return InProgress::ClosestDescendantMerkleValue(ClosestDescendantMerkleValue {
                     inner: self.inner,
                     descendant_partial_key: closest_descendant.skip(iter_key_len).collect(),
                 });
@@ -435,12 +435,12 @@ impl StorageValue {
 ///
 /// It is possible to continue the calculation even if the Merkle value is unknown, in which case
 /// the calculation will walk down the trie in order to calculate the Merkle value manually.
-pub struct MerkleValue {
+pub struct ClosestDescendantMerkleValue {
     inner: Box<Inner>,
     descendant_partial_key: Vec<Nibble>,
 }
 
-impl MerkleValue {
+impl ClosestDescendantMerkleValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose Merkle value must be fetched.
     ///

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -116,8 +116,6 @@ pub struct ClosestDescendant {
     inner: Box<Inner>,
     /// Extra nibbles to append at the end of what `self.key()` returns.
     key_extra_nibbles: Vec<Nibble>,
-    /// `true` if the Merkle value of the descendant must always be recalculated.
-    force_recalculate: bool,
     /// `Some` if the diff inserts a value that is equal or a descendant of `self.key()`. If
     /// `Some`, contains the least common denominator shared amongst all these insertions.
     diff_inserts_lcd: Option<Vec<Nibble>>,
@@ -357,7 +355,6 @@ impl StorageValue {
                 InProgress::ClosestDescendant(ClosestDescendant {
                     inner: self.0,
                     key_extra_nibbles: partial_key,
-                    force_recalculate: true, // The partial key of the closest descendant has changed.
                     diff_inserts_lcd,
                 })
             }
@@ -447,7 +444,7 @@ impl ClosestDescendantMerkleValue {
     ///
     /// This function be used if you are unaware of the Merkle value. The algorithm will perform
     /// the calculation of this Merkle value manually, which takes more time.
-    pub fn resume_unknown(mut self) -> InProgress {
+    pub fn resume_unknown(self) -> InProgress {
         // The element currently being iterated was `Btcd`, and is now switched to being
         // `MaybeNodeKey`. Because a `MerkleValue` is only ever created if the diff doesn't
         // contain any entry that descends the currently iterated node, we know for sure that
@@ -455,7 +452,6 @@ impl ClosestDescendantMerkleValue {
         InProgress::ClosestDescendant(ClosestDescendant {
             inner: self.inner,
             key_extra_nibbles: Vec::new(),
-            force_recalculate: true,
             diff_inserts_lcd: None,
         })
     }
@@ -601,7 +597,6 @@ impl Inner {
         InProgress::ClosestDescendant(ClosestDescendant {
             inner: self,
             key_extra_nibbles: Vec::new(),
-            force_recalculate,
             diff_inserts_lcd,
         })
     }

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -383,7 +383,7 @@ impl ClosestDescendantMerkleValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose closest descendant Merkle value must be fetched.
     pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
-        // A `MerkleValue` is created directly in response to a `ClosestAncestor` without
+        // A `ClosestDescendantMerkleValue` is created directly in response to a `ClosestAncestor` without
         // updating the `Inner`.
         self.inner.current_node_full_key()
     }
@@ -403,7 +403,7 @@ impl ClosestDescendantMerkleValue {
     /// the calculation of this Merkle value manually, which takes more time.
     pub fn resume_unknown(self) -> InProgress {
         // The element currently being iterated was `Btcd`, and is now switched to being
-        // `MaybeNodeKey`. Because a `MerkleValue` is only ever created if the diff doesn't
+        // `MaybeNodeKey`. Because a `ClosestDescendantMerkleValue` is only ever created if the diff doesn't
         // contain any entry that descends the currently iterated node, we know for sure that
         // `MaybeNodeKey` is equal to `Btcd`.
         InProgress::ClosestDescendant(ClosestDescendant {
@@ -414,7 +414,7 @@ impl ClosestDescendantMerkleValue {
     }
 
     /// Indicate the Merkle value of closest descendant of the trie node indicated by
-    /// [`MerkleValue::key`] and resume the calculation.
+    /// [`ClosestDescendantMerkleValue::key`] and resume the calculation.
     pub fn inject_merkle_value(mut self, merkle_value: &[u8]) -> InProgress {
         // We are after a call to `BaseTrieClosestDescendantMerkleValue` in the algorithm shown
         // at the top.

--- a/lib/src/executor/trie_root_calculator/tests.rs
+++ b/lib/src/executor/trie_root_calculator/tests.rs
@@ -40,8 +40,8 @@ fn empty_trie_works() {
             InProgress::ClosestDescendant(req) => {
                 calculation = req.inject(None::<iter::Empty<_>>);
             }
-            InProgress::ClosestDescendantMerkleValue(_) => {
-                unreachable!()
+            InProgress::ClosestDescendantMerkleValue(req) => {
+                calculation = req.resume_unknown();
             }
             InProgress::StorageValue(req) => {
                 calculation = req.inject_value(None);
@@ -80,8 +80,8 @@ fn one_inserted_node_in_diff() {
             InProgress::ClosestDescendant(req) => {
                 calculation = req.inject(None::<iter::Empty<_>>);
             }
-            InProgress::ClosestDescendantMerkleValue(_) => {
-                unreachable!()
+            InProgress::ClosestDescendantMerkleValue(req) => {
+                calculation = req.resume_unknown();
             }
             InProgress::StorageValue(req) => {
                 calculation = req.inject_value(None);
@@ -297,14 +297,38 @@ fn fuzzing() {
                     }
                     InProgress::ClosestDescendantMerkleValue(req) => {
                         if rand::random::<bool>() {
-                            let merkle_value = if let trie::trie_structure::Entry::Occupied(e) =
-                                trie_before_diff.node(req.key_as_vec().into_iter())
-                            {
-                                e.into_user_data().1.as_ref().unwrap().clone()
+                            let mut next_node = trie_before_diff
+                                .range_iter(
+                                    ops::Bound::Included(req.key_as_vec().into_iter()),
+                                    ops::Bound::Unbounded::<iter::Empty<trie::Nibble>>,
+                                )
+                                .next();
+                            // Set `next_node` to `None` if it isn't a descendant of the demanded key.
+                            if next_node.map_or(false, |n| {
+                                !trie_before_diff
+                                    .node_full_key_by_index(n)
+                                    .unwrap()
+                                    .collect::<Vec<_>>()
+                                    .starts_with(&req.key_as_vec())
+                            }) {
+                                next_node = None;
+                            }
+
+                            if let Some(next_node) = next_node {
+                                calculator = req.inject_merkle_value(
+                                    trie_before_diff
+                                        .node_by_index(next_node)
+                                        .unwrap()
+                                        .into_user_data()
+                                        .1
+                                        .as_ref()
+                                        .unwrap()
+                                        .clone()
+                                        .as_ref(),
+                                );
                             } else {
-                                unreachable!()
-                            };
-                            calculator = req.inject_merkle_value(merkle_value.as_ref());
+                                calculator = req.resume_unknown();
+                            }
                         } else {
                             calculator = req.resume_unknown()
                         }

--- a/lib/src/executor/trie_root_calculator/tests.rs
+++ b/lib/src/executor/trie_root_calculator/tests.rs
@@ -40,7 +40,7 @@ fn empty_trie_works() {
             InProgress::ClosestDescendant(req) => {
                 calculation = req.inject(None::<iter::Empty<_>>);
             }
-            InProgress::MerkleValue(_) => {
+            InProgress::ClosestDescendantMerkleValue(_) => {
                 unreachable!()
             }
             InProgress::StorageValue(req) => {
@@ -80,7 +80,7 @@ fn one_inserted_node_in_diff() {
             InProgress::ClosestDescendant(req) => {
                 calculation = req.inject(None::<iter::Empty<_>>);
             }
-            InProgress::MerkleValue(_) => {
+            InProgress::ClosestDescendantMerkleValue(_) => {
                 unreachable!()
             }
             InProgress::StorageValue(req) => {
@@ -295,7 +295,7 @@ fn fuzzing() {
                             next_node.map(|n| trie_before_diff.node_full_key_by_index(n).unwrap()),
                         );
                     }
-                    InProgress::MerkleValue(req) => {
+                    InProgress::ClosestDescendantMerkleValue(req) => {
                         if rand::random::<bool>() {
                             let merkle_value = if let trie::trie_structure::Entry::Occupied(e) =
                                 trie_before_diff.node(req.key_as_vec().into_iter())

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -401,8 +401,9 @@ pub enum Verify {
     RuntimeCompilation(RuntimeCompilation),
     /// Loading a storage value is required in order to continue.
     StorageGet(StorageGet),
-    /// Obtaining the Merkle value of a trie node is required in order to continue.
-    StorageMerkleValue(StorageMerkleValue),
+    /// Obtaining the Merkle value of the closest descendant of a trie node is required in order
+    /// to continue.
+    StorageClosestDescendantMerkleValue(StorageClosestDescendantMerkleValue),
     /// Fetching the key that follows a given one is required in order to continue.
     StorageNextKey(StorageNextKey),
 }
@@ -561,12 +562,14 @@ impl VerifyInner {
                         consensus_success: self.consensus_success,
                     })
                 }
-                (runtime_host::RuntimeHostVm::MerkleValue(inner), phase) => {
-                    break Verify::StorageMerkleValue(StorageMerkleValue {
-                        inner,
-                        phase,
-                        consensus_success: self.consensus_success,
-                    })
+                (runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(inner), phase) => {
+                    break Verify::StorageClosestDescendantMerkleValue(
+                        StorageClosestDescendantMerkleValue {
+                            inner,
+                            phase,
+                            consensus_success: self.consensus_success,
+                        },
+                    )
                 }
                 (runtime_host::RuntimeHostVm::NextKey(inner), phase) => {
                     break Verify::StorageNextKey(StorageNextKey {
@@ -640,19 +643,18 @@ impl StorageGet {
     }
 }
 
-/// Obtaining the Merkle value of a trie node is required in order to continue.
+/// Obtaining the Merkle value of the closest descendant of a trie node is required in order
+/// to continue.
 #[must_use]
-pub struct StorageMerkleValue {
-    inner: runtime_host::MerkleValue,
+pub struct StorageClosestDescendantMerkleValue {
+    inner: runtime_host::ClosestDescendantMerkleValue,
     /// See [`VerifyInner::phase`].
     phase: VerifyInnerPhase,
     consensus_success: SuccessConsensus,
 }
 
-impl StorageMerkleValue {
-    /// Returns the key whose Merkle value must be passed back.
-    ///
-    /// The key is guaranteed to have been injected through [`StorageNextKey::inject_key`] earlier.
+impl StorageClosestDescendantMerkleValue {
+    /// Returns the key whose closest descendant Merkle value must be passed back.
     pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
         self.inner.key()
     }
@@ -671,10 +673,6 @@ impl StorageMerkleValue {
     }
 
     /// Injects the corresponding Merkle value.
-    ///
-    /// Note that there is no way to indicate that the trie node doesn't exist. This is because
-    /// the node is guaranteed to have been injected through [`StorageNextKey::inject_key`]
-    /// earlier.
     pub fn inject_merkle_value(self, merkle_value: &[u8]) -> Verify {
         VerifyInner {
             inner: self.inner.inject_merkle_value(merkle_value),

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -1362,10 +1362,12 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     runtime_call =
                         get.inject_value(storage_value.map(|(val, vers)| (iter::once(val), vers)));
                 }
-                runtime_host::RuntimeHostVm::MerkleValue(mv) => {
+                runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(mv) => {
                     // TODO:
-                    runtime_call_lock
-                        .unlock(runtime_host::RuntimeHostVm::MerkleValue(mv).into_prototype());
+                    runtime_call_lock.unlock(
+                        runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(mv)
+                            .into_prototype(),
+                    );
                     break Err(RuntimeCallError::NextKeyMerkleValueForbidden);
                 }
                 runtime_host::RuntimeHostVm::NextKey(nk) => {

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1843,10 +1843,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     .map(|(val, vers)| (iter::once(val), vers)),
                                             );
                                         }
-                                        runtime_host::RuntimeHostVm::MerkleValue(mv) => {
+                                        runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(mv) => {
                                             // TODO: implement somehow
                                             runtime_call_lock.unlock(
-                                                runtime_host::RuntimeHostVm::MerkleValue(mv)
+                                                runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(mv)
                                                     .into_prototype(),
                                             );
                                             break methods::ServerToClient::chainHead_unstable_callEvent {

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1226,9 +1226,10 @@ async fn validate_transaction<TPlat: PlatformRef>(
                 validation_in_progress =
                     get.inject_value(storage_value.map(|(val, vers)| (iter::once(val), vers)));
             }
-            validate::Query::MerkleValue(mv) => {
+            validate::Query::ClosestDescendantMerkleValue(mv) => {
                 // TODO:
-                runtime_call_lock.unlock(validate::Query::MerkleValue(mv).into_prototype());
+                runtime_call_lock
+                    .unlock(validate::Query::ClosestDescendantMerkleValue(mv).into_prototype());
                 break Err(ValidationError::InvalidOrError(
                     InvalidOrError::ValidateError(
                         ValidateTransactionError::NextKeyMerkleValueForbidden,


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/272

This is an amendment to #639.
Instead of asking first the key of the closest descendant then its Merkle value, we now ask them together. This makes it possible for the user to indicate this Merkle value even when the key of the closest descendant is unknown.
If the user is unable to provide this Merkle value (either because they don't know the closest descendant or don't know its Merkle value), we fall back to asking the key of the closest descendant and calculate it manually.

This makes it possible to actually plug this to reading a proof.

I've removed the small "optimization" that consists in asking for a Merkle value even if we know that this Merkle value is outdated, with the hopes that this Merkle value is < 32 bytes and thus can be modified in-place. Restoring this optimization would require storing the difference in partial key between the former parent and the new parent, which considerably complicates the algorithm. And after all, if the Merkle value is < 32 bytes, then the user should be able to comply with a closest descendant request.
