### PR TITLE
Rename `AsyncStdTcpWebSocket` to `DefaultPlatform`

### DIFF
--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -28,12 +28,11 @@ fn main() {
     // example, we provide `DefaultPlatform`, which are the "plug and play" default platform.
     // Any advance usage, such as embedding a client in WebAssembly, will likely require a custom
     // implementation of these bindings.
-    let mut client = smoldot_light::Client::new(
-        smoldot_light::platform::default::DefaultPlatform::new(
+    let mut client =
+        smoldot_light::Client::new(smoldot_light::platform::default::DefaultPlatform::new(
             env!("CARGO_PKG_NAME").into(),
             env!("CARGO_PKG_VERSION").into(),
-        ),
-    );
+        ));
 
     // Ask the client to connect to a chain.
     let smoldot_light::AddChainSuccess {

--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -25,11 +25,11 @@ fn main() {
 
     // Now initialize the client. This does nothing except allocate resources.
     // The `Client` struct requires a generic parameter that provides platform bindings. In this
-    // example, we provide `AsyncStdTcpWebSocket`, which are the "plug and play" default platform.
+    // example, we provide `DefaultPlatform`, which are the "plug and play" default platform.
     // Any advance usage, such as embedding a client in WebAssembly, will likely require a custom
     // implementation of these bindings.
     let mut client = smoldot_light::Client::new(
-        smoldot_light::platform::async_std::AsyncStdTcpWebSocket::new(
+        smoldot_light::platform::default::DefaultPlatform::new(
             env!("CARGO_PKG_NAME").into(),
             env!("CARGO_PKG_VERSION").into(),
         ),

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -19,7 +19,7 @@ use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{future::Future, ops, str, time::Duration};
 use futures_util::future;
 
-pub mod async_std;
+pub mod default;
 
 /// Access to a platform's capabilities.
 ///

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -34,22 +34,22 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-/// Implementation of the [`PlatformRef`] trait that uses the `async-std` library and provides TCP
-/// and WebSocket connections.
-#[derive(Clone)]
-pub struct AsyncStdTcpWebSocket {
-    client_name_version: Arc<(String, String)>,
+/// Implementation of the [`PlatformRef`] trait that leverages the operating system.
+pub struct DefaultPlatform {
+    client_name: String,
+    client_version: String,
 }
 
-impl AsyncStdTcpWebSocket {
-    pub fn new(client_name: String, client_version: String) -> Self {
-        AsyncStdTcpWebSocket {
-            client_name_version: Arc::new((client_name, client_version)),
-        }
+impl DefaultPlatform {
+    pub fn new(client_name: String, client_version: String) -> Arc<Self> {
+        Arc::new(DefaultPlatform {
+            client_name,
+            client_version,
+        })
     }
 }
 
-impl PlatformRef for AsyncStdTcpWebSocket {
+impl PlatformRef for Arc<DefaultPlatform> {
     type Delay = future::BoxFuture<'static, ()>;
     type Yield = future::Ready<()>;
     type Instant = std::time::Instant;
@@ -86,11 +86,11 @@ impl PlatformRef for AsyncStdTcpWebSocket {
     }
 
     fn client_name(&self) -> Cow<str> {
-        Cow::Borrowed(&self.client_name_version.0)
+        Cow::Borrowed(&self.client_name)
     }
 
     fn client_version(&self) -> Cow<str> {
-        Cow::Borrowed(&self.client_name_version.1)
+        Cow::Borrowed(&self.client_version)
     }
 
     fn yield_after_cpu_intensive(&self) -> Self::Yield {
@@ -409,7 +409,7 @@ impl PlatformRef for AsyncStdTcpWebSocket {
     }
 }
 
-/// Implementation detail of [`AsyncStdTcpWebSocket`].
+/// Implementation detail of [`DefaultPlatform`].
 pub struct Stream {
     socket: TcpOrWs,
     /// Read and write buffers of the connection, or `None` if the socket has been reset.


### PR DESCRIPTION
The name `AsyncStdTcpWebSocket` might scare ~~tokio users~~ people away for some reason, so I've decided to rename it to `DefaultPlatform`.
This conveys the intended meaning, which is "just use this if you want something that works".

Creating your custom platform is clearly an advanced use case that most people shouldn't ever care about.

Additionally, the `DefaultPlatform` now longer implements `Clone`. Instead, the `new` function returns an `Arc<DefaultPlatform>`, and you use a `Client<Arc<DefaultPlatform>>`.
