### PR TITLE
Replace `cfg(all(X))` with just `cfg(X)`

### DIFF
--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -40,8 +40,8 @@
 //! >           questionable decisions that it has to keep for backwards compatibility reasons.
 //! >           This keystore, being newly-written, doesn't have to follow them.
 
-#![cfg(all(feature = "std"))]
-#![cfg_attr(docsrs, doc(cfg(all(feature = "std"))))]
+#![cfg(feature = "std")]
+#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use crate::{identity::seed_phrase, util::SipHasherBuild};
 

--- a/lib/src/json_rpc/websocket_server.rs
+++ b/lib/src/json_rpc/websocket_server.rs
@@ -110,8 +110,8 @@
 //! case of a (D)DoS attack on the WebSocket server, only up to one core of CPU processing power
 //! can be occupied by the attacker.
 
-#![cfg(all(feature = "std"))]
-#![cfg_attr(docsrs, doc(cfg(all(feature = "std"))))]
+#![cfg(feature = "std")]
+#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 #[cfg(test)]
 mod tests;

--- a/lib/src/libp2p/websocket.rs
+++ b/lib/src/libp2p/websocket.rs
@@ -18,8 +18,8 @@
 //! Implementation of a WebSocket client that wraps around an abstract representation of a TCP
 //! socket through the `AsyncRead` and `AsyncWrite` traits.
 
-#![cfg(all(feature = "std"))]
-#![cfg_attr(docsrs, doc(cfg(all(feature = "std"))))]
+#![cfg(feature = "std")]
+#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use futures_util::{future, AsyncRead, AsyncWrite, Future as _};
 


### PR DESCRIPTION
Detected by a new Clippy warning with Rust 1.70.