### PR TITLE
Allow child-trie-friendly proofs

### DIFF
--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1204,7 +1204,6 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
             let decoded_downloaded_runtime =
                 match proof_decode::decode_and_verify_proof(proof_decode::Config {
                     proof: &downloaded_runtime[..],
-                    trie_root_hash: &header.state_root,
                 }) {
                     Ok(p) => p,
                     Err(err) => {
@@ -1422,7 +1421,6 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
                     let proof = proof.take().unwrap();
                     let decoded_proof =
                         match proof_decode::decode_and_verify_proof(proof_decode::Config {
-                            trie_root_hash: &header.state_root,
                             proof: proof.into_iter(),
                         }) {
                             Ok(d) => d,

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -118,7 +118,10 @@ impl PrefixScan {
                         QueryTy::Direction => &query_key[..query_key.len() - 1],
                     };
 
-                    match (decoded_proof.trie_node_info(info_of_node), query_ty) {
+                    match (
+                        decoded_proof.trie_node_info(&self.trie_root_hash, info_of_node),
+                        query_ty,
+                    ) {
                         (Some(info), QueryTy::Exact) => info,
                         (Some(info), QueryTy::Direction) => {
                             match info.children.child(query_key[query_key.len() - 1]) {

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -90,13 +90,11 @@ impl PrefixScan {
     ///
     /// Returns an error if the proof is invalid. In that case, `self` isn't modified.
     pub fn resume(mut self, proof: &[u8]) -> Result<ResumeOutcome, (Self, Error)> {
-        let decoded_proof = match proof_decode::decode_and_verify_proof(proof_decode::Config {
-            proof,
-            trie_root_hash: &self.trie_root_hash,
-        }) {
-            Ok(d) => d,
-            Err(err) => return Err((self, Error::InvalidProof(err))),
-        };
+        let decoded_proof =
+            match proof_decode::decode_and_verify_proof(proof_decode::Config { proof }) {
+                Ok(d) => d,
+                Err(err) => return Err((self, Error::InvalidProof(err))),
+            };
 
         let mut non_terminal_queries = mem::take(&mut self.next_queries);
 

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -603,11 +603,11 @@ mod tests {
             let proof = proof_builder.build_to_vec();
 
             // Verify the correctness of the proof.
-            proof_decode::decode_and_verify_proof(proof_decode::Config {
-                trie_root_hash: &trie_root_hash,
-                proof,
-            })
-            .unwrap();
+            let proof =
+                proof_decode::decode_and_verify_proof(proof_decode::Config { proof }).unwrap();
+            assert!(proof
+                .closest_descendant_merkle_value(&trie_root_hash, &[])
+                .is_some());
         }
     }
 
@@ -658,10 +658,6 @@ mod tests {
         // The proof builder should de-duplicate the two children, otherwise the proof is invalid.
         proof_decode::decode_and_verify_proof(proof_decode::Config {
             proof: proof_builder.build_to_vec(),
-            trie_root_hash: &[
-                198, 201, 55, 96, 115, 79, 43, 132, 215, 236, 180, 232, 125, 60, 98, 103, 17, 46,
-                150, 56, 154, 235, 33, 17, 222, 105, 142, 178, 235, 61, 88, 52,
-            ],
         })
         .unwrap();
     }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -861,7 +861,7 @@ impl<'a> RuntimeCall<'a> {
             Err(err) => return Err(err.clone()),
         };
 
-        match call_proof.storage_value(requested_key) {
+        match call_proof.storage_value(&self.block_state_root_hash, requested_key) {
             Some(v) => Ok(v),
             None => Err(RuntimeCallError::MissingProofEntry),
         }
@@ -891,7 +891,13 @@ impl<'a> RuntimeCall<'a> {
             Err(err) => return Err(err.clone()),
         };
 
-        match call_proof.next_key(key_before, or_equal, prefix, branch_nodes) {
+        match call_proof.next_key(
+            &self.block_state_root_hash,
+            key_before,
+            or_equal,
+            prefix,
+            branch_nodes,
+        ) {
             Some(v) => Ok(v),
             None => Err(RuntimeCallError::MissingProofEntry),
         }
@@ -911,7 +917,7 @@ impl<'a> RuntimeCall<'a> {
             Err(err) => return Err(err.clone()),
         };
 
-        match call_proof.closest_descendant_merkle_value(key) {
+        match call_proof.closest_descendant_merkle_value(&self.block_state_root_hash, key) {
             Some(Some(v)) => Ok(v),
             Some(None) | None => Err(RuntimeCallError::MissingProofEntry),
         }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -807,7 +807,6 @@ impl<TPlat: PlatformRef> RuntimeAccess<TPlat> {
         let call_proof = call_proof.and_then(|call_proof| {
             proof_decode::decode_and_verify_proof(proof_decode::Config {
                 proof: call_proof.decode().to_owned(), // TODO: to_owned() inefficiency, need some help from the networking to obtain the owned data
-                trie_root_hash: &self.block_state_root_hash,
             })
             .map_err(RuntimeCallError::StorageRetrieval)
         });

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -431,7 +431,6 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                     let decoded = outcome.decode();
                     let decoded = proof_decode::decode_and_verify_proof(proof_decode::Config {
                         proof: decoded,
-                        trie_root_hash: storage_trie_root,
                     })
                     .map_err(StorageQueryErrorDetail::ProofVerification)?;
 

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -439,7 +439,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                     for key in requested_keys.clone() {
                         result.push(
                             decoded
-                                .storage_value(key.as_ref())
+                                .storage_value(storage_trie_root, key.as_ref())
                                 .ok_or(StorageQueryErrorDetail::MissingProofEntry)?
                                 .map(|(v, _)| v.to_owned()),
                         );


### PR DESCRIPTION
cc #166 

At the moment, when decoding a proof, it is assumed that this proof only contains one trie, and the user is required to pass the expected trie root hash.

However, in the context of child tries, a proof can contain entries from multiple different tries (the main trie and child tries).

Normally, these tries are connected in the sense that the value of a main trie node starting with `:child_storage:default:` is equal to the root of another trie. However, I prefer to not put this assumption in the proof-related code.
Instead, I've adjusted the code to allow multiple different tries within the same proof, without checking whether these tries are connected to each other.

In terms of API changes, the API user no longer passes the expected trie root hash when decoding the proof, but instead passes the trie root hash whenever the proof is accessed. If the proof doesn't contain the requested trie, then `None` is returned, indicating an incomplete proof.
