### PR TITLE
Replace `async-std` with `smol` in the `DefaultExecutor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,7 +2464,6 @@ name = "smoldot-light"
 version = "0.5.0"
 dependencies = [
  "async-lock",
- "async-std",
  "blake2-rfc",
  "derive_more",
  "either",
@@ -2484,6 +2483,7 @@ dependencies = [
  "serde_json",
  "siphasher",
  "slab",
+ "smol",
  "smoldot",
 ]
 

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -34,12 +34,12 @@ smoldot = { version = "0.7.0", path = "../lib", default-features = false }
 
 # `std` feature
 # Add here the crates that cannot function without the help of the operating system or environment.
-async-std = { version = "1.12.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
+smol = { version = "1.3.0", optional = true }
 
 [features]
 default = ["std"]
-std = ["async-std", "parking_lot", "smoldot/std"]
+std = ["parking_lot", "smol", "smoldot/std"]
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -103,7 +103,7 @@ fn main() {
 
     // Now block the execution forever and print the responses received on the channel of
     // JSON-RPC responses.
-    async_std::task::block_on(async move {
+    smol::block_on(async move {
         loop {
             let response = json_rpc_responses.next().await.unwrap();
             println!("JSON-RPC response: {response}");


### PR DESCRIPTION
Note that in principle `example/basic.rs` could continue using `async-std`, there's nothing wrong with that. I've switched it to `smol` as well as otherwise I'd need to add both `smol` and `async-std` as dependencies.