### PR TITLE
Rework Cargo features and add a `wasmtime` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,20 @@ jobs:
     - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot --locked --no-default-features --features std
     - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features std
     - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features std
+    - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot --locked --no-default-features --features std --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot --locked --no-default-features --features std --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features std --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot --locked --no-default-features --features database-sqlite --features std --features wasmtime
     - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot-light --locked --no-default-features
     - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot-light --locked --no-default-features
     - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features std
     - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features std
+    - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target x86_64-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features std --features wasmtime
+    - run: RUSTFLAGS=-Dwarnings cargo check --target i686-unknown-linux-gnu --package smoldot-light --locked --no-default-features --features std --features wasmtime
 
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -34,5 +34,5 @@ serde = { version = "1.0.163", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["std"] }
 siphasher = { version = "0.3.10", default-features = false }
 smol = "1.3.0"
-smoldot = { version = "0.7.0", path = "../lib", default-features = false, features = ["database-sqlite", "std"] }
+smoldot = { version = "0.7.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.2.6"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,20 +10,23 @@ edition.workspace = true
 repository.workspace = true
 
 [features]
-default = ["database-sqlite", "std"]
+default = ["database-sqlite", "std", "wasmtime"]
 database-sqlite = [
-    "parking_lot",
-    "rusqlite",
+    "dep:parking_lot",
+    "dep:rusqlite",
     "std"   # A database stored on the filesystem can't reasonably work without a filesystem.
 ]
 std = [
     "futures-executor/thread-pool",
     "futures-util/io",
-    "pin-project",
+    "dep:pin-project",
     "schnorrkel/getrandom", # TODO: necessary for signing; clarify in docs and in source code
-    "smol",
-    "soketto",
-    "wasmtime",
+    "dep:smol",
+    "dep:soketto",
+]
+wasmtime = [
+    "dep:wasmtime",
+    "std"   # TODO: unfortunately doesn't compile without `std`, but could be fixed
 ]
 
 [dependencies]
@@ -88,7 +91,7 @@ soketto = { version = "0.7.1", optional = true }
 # This list of targets matches the tier 1 and tier 2 of platforms supported by wasmtime: <https://docs.wasmtime.dev/stability-tiers.html>
 # The arch and OS of a specific target can be found with the command `rustc +nightly -Z unstable-options --print target-spec-json --target ...`
 [target.'cfg(any(all(target_arch = "x86_64", any(target_os = "windows", target_os = "linux", target_os = "macos")), all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "s390x", target_os = "linux")))'.dependencies]
-# `std` feature
+# `wasmtime` feature
 wasmtime = { version = "9.0.3", default-features = false, features = ["async", "cranelift"], optional = true }
 
 [dev-dependencies]

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -75,7 +75,7 @@ mod interpreter;
         all(target_arch = "aarch64", target_os = "linux"),
         all(target_arch = "s390x", target_os = "linux")
     ),
-    feature = "std"
+    feature = "wasmtime"
 ))]
 mod jit;
 
@@ -119,7 +119,7 @@ enum VirtualMachinePrototypeInner {
             all(target_arch = "aarch64", target_os = "linux"),
             all(target_arch = "s390x", target_os = "linux")
         ),
-        feature = "std"
+        feature = "wasmtime"
     ))]
     Jit(jit::JitPrototype),
     Interpreter(interpreter::InterpreterPrototype),
@@ -143,7 +143,7 @@ impl VirtualMachinePrototype {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 ))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
@@ -157,7 +157,7 @@ impl VirtualMachinePrototype {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 )))]
                 ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Interpreter(
                     interpreter::InterpreterPrototype::new(config.module_bytes, config.symbols)?,
@@ -180,7 +180,7 @@ impl VirtualMachinePrototype {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 ))]
                 ExecHint::ForceWasmtime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
@@ -204,7 +204,7 @@ impl VirtualMachinePrototype {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.global_value(name),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.global_value(name),
@@ -225,7 +225,7 @@ impl VirtualMachinePrototype {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachinePrototypeInner::Jit(inner) => inner.memory_max_pages(),
             VirtualMachinePrototypeInner::Interpreter(inner) => inner.memory_max_pages(),
@@ -247,7 +247,7 @@ impl VirtualMachinePrototype {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachinePrototypeInner::Jit(inner) => Prepare {
                 inner: PrepareInner::Jit(inner.prepare()),
@@ -271,7 +271,7 @@ impl fmt::Debug for VirtualMachinePrototype {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachinePrototypeInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachinePrototypeInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
@@ -293,7 +293,7 @@ enum PrepareInner {
             all(target_arch = "aarch64", target_os = "linux"),
             all(target_arch = "s390x", target_os = "linux")
         ),
-        feature = "std"
+        feature = "wasmtime"
     ))]
     Jit(jit::Prepare),
     Interpreter(interpreter::Prepare),
@@ -313,7 +313,7 @@ impl Prepare {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 ))]
                 PrepareInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
@@ -337,7 +337,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Jit(inner) => inner.memory_size(),
             PrepareInner::Interpreter(inner) => inner.memory_size(),
@@ -362,7 +362,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
             #[cfg(all(
@@ -374,7 +374,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Interpreter(inner) => either::Right(inner.read_memory(offset, size)?),
             #[cfg(not(all(
@@ -386,7 +386,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             )))]
             PrepareInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
@@ -406,7 +406,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Jit(inner) => inner.write_memory(offset, value),
             PrepareInner::Interpreter(inner) => inner.write_memory(offset, value),
@@ -428,7 +428,7 @@ impl Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Jit(inner) => inner.grow_memory(additional),
             PrepareInner::Interpreter(inner) => inner.grow_memory(additional),
@@ -453,7 +453,7 @@ impl Prepare {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 ))]
                 PrepareInner::Jit(inner) => match inner.start(function_name, params) {
                     Ok(vm) => VirtualMachineInner::Jit(vm),
@@ -494,7 +494,7 @@ impl fmt::Debug for Prepare {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             PrepareInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             PrepareInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
@@ -516,7 +516,7 @@ enum VirtualMachineInner {
             all(target_arch = "aarch64", target_os = "linux"),
             all(target_arch = "s390x", target_os = "linux")
         ),
-        feature = "std"
+        feature = "wasmtime"
     ))]
     Jit(jit::Jit),
     Interpreter(interpreter::Interpreter),
@@ -541,7 +541,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => inner.run(value),
             VirtualMachineInner::Interpreter(inner) => inner.run(value),
@@ -562,7 +562,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => inner.memory_size(),
             VirtualMachineInner::Interpreter(inner) => inner.memory_size(),
@@ -587,7 +587,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => either::Left(inner.read_memory(offset, size)?),
             #[cfg(all(
@@ -599,7 +599,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Interpreter(inner) => {
                 either::Right(inner.read_memory(offset, size)?)
@@ -613,7 +613,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             )))]
             VirtualMachineInner::Interpreter(inner) => inner.read_memory(offset, size)?,
         })
@@ -633,7 +633,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => inner.write_memory(offset, value),
             VirtualMachineInner::Interpreter(inner) => inner.write_memory(offset, value),
@@ -655,7 +655,7 @@ impl VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => inner.grow_memory(additional),
             VirtualMachineInner::Interpreter(inner) => inner.grow_memory(additional),
@@ -675,7 +675,7 @@ impl VirtualMachine {
                         all(target_arch = "aarch64", target_os = "linux"),
                         all(target_arch = "s390x", target_os = "linux")
                     ),
-                    feature = "std"
+                    feature = "wasmtime"
                 ))]
                 VirtualMachineInner::Jit(inner) => {
                     VirtualMachinePrototypeInner::Jit(inner.into_prototype())
@@ -700,7 +700,7 @@ impl fmt::Debug for VirtualMachine {
                     all(target_arch = "aarch64", target_os = "linux"),
                     all(target_arch = "s390x", target_os = "linux")
                 ),
-                feature = "std"
+                feature = "wasmtime"
             ))]
             VirtualMachineInner::Jit(inner) => fmt::Debug::fmt(inner, f),
             VirtualMachineInner::Interpreter(inner) => fmt::Debug::fmt(inner, f),
@@ -737,7 +737,7 @@ pub enum ExecHint {
             all(target_arch = "aarch64", target_os = "linux"),
             all(target_arch = "s390x", target_os = "linux")
         ),
-        feature = "std"
+        feature = "wasmtime"
     ))]
     #[cfg_attr(
         docsrs,
@@ -750,7 +750,7 @@ pub enum ExecHint {
                 all(target_arch = "aarch64", target_os = "linux"),
                 all(target_arch = "s390x", target_os = "linux")
             ),
-            feature = "std"
+            feature = "wasmtime"
         )))
     )]
     ForceWasmtime,
@@ -775,7 +775,7 @@ impl ExecHint {
                 all(target_arch = "aarch64", target_os = "linux"),
                 all(target_arch = "s390x", target_os = "linux")
             ),
-            feature = "std"
+            feature = "wasmtime"
         ))]
         fn value() -> Option<ExecHint> {
             Some(ExecHint::ForceWasmtime)
@@ -789,7 +789,7 @@ impl ExecHint {
                 all(target_arch = "aarch64", target_os = "linux"),
                 all(target_arch = "s390x", target_os = "linux")
             ),
-            feature = "std"
+            feature = "wasmtime"
         )))]
         fn value() -> Option<ExecHint> {
             None
@@ -927,7 +927,7 @@ impl<'a> TryFrom<&'a wasmi::FuncType> for Signature {
         all(target_arch = "aarch64", target_os = "linux"),
         all(target_arch = "s390x", target_os = "linux")
     ),
-    feature = "std"
+    feature = "wasmtime"
 ))]
 impl<'a> TryFrom<&'a wasmtime::FuncType> for Signature {
     type Error = UnsupportedTypeError;
@@ -1045,7 +1045,7 @@ impl From<WasmValue> for wasmi::Value {
         all(target_arch = "aarch64", target_os = "linux"),
         all(target_arch = "s390x", target_os = "linux")
     ),
-    feature = "std"
+    feature = "wasmtime"
 ))]
 impl From<WasmValue> for wasmtime::Val {
     fn from(val: WasmValue) -> Self {
@@ -1065,7 +1065,7 @@ impl From<WasmValue> for wasmtime::Val {
         all(target_arch = "aarch64", target_os = "linux"),
         all(target_arch = "s390x", target_os = "linux")
     ),
-    feature = "std"
+    feature = "wasmtime"
 ))]
 impl<'a> TryFrom<&'a wasmtime::Val> for WasmValue {
     type Error = UnsupportedTypeError;
@@ -1109,7 +1109,7 @@ impl TryFrom<wasmi::core::ValueType> for ValueType {
         all(target_arch = "aarch64", target_os = "linux"),
         all(target_arch = "s390x", target_os = "linux")
     ),
-    feature = "std"
+    feature = "wasmtime"
 ))]
 impl TryFrom<wasmtime::ValType> for ValueType {
     type Error = UnsupportedTypeError;
@@ -1205,8 +1205,8 @@ pub enum NewErr {
 }
 
 // TODO: an implementation of the `Error` trait is required in order to interact with wasmtime, but it's not possible to implement this trait on non-std yet
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+#[cfg(feature = "wasmtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasmtime")))]
 impl std::error::Error for NewErr {}
 
 /// Error that can happen when calling [`Prepare::start`].

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -38,8 +38,9 @@ parking_lot = { version = "0.12.1", optional = true }
 smol = { version = "1.3.0", optional = true }
 
 [features]
-default = ["std"]
-std = ["parking_lot", "smol", "smoldot/std"]
+default = ["std", "wasmtime"]
+std = ["dep:parking_lot", "dep:smol", "smoldot/std"]
+wasmtime = ["smoldot/wasmtime"]
 
 [dev-dependencies]
 env_logger = "0.10.0"


### PR DESCRIPTION
This PR does two things:

- Adds `dep:` in front of every optional package name in the features list, so as to not expose them publicly.
- Adds a `wasmtime` feature to both `smoldot` and `smoldot-light`, enabled by default for both. If disabled, `wasmtime` isn't compiled or used.

The new `wasmtime` feature exists in order to solve the problem of linking errors if multiple different versions of `wasmtime` are used at the same time in the same binary.

cc #690 @skunert 
