### PR TITLE
Fix periodic cargo update CI job

### DIFF
--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -12,7 +12,11 @@ jobs:
       image: rust:1.70
     steps:
     - uses: actions/checkout@v3
-    - run: cargo update --workspace
+    # Note: `cargo update --workspace` doesn't seem to have any effect.
+    - run: cargo update
+      working-directory: wasm-node/rust
+    - run: cargo update
+      working-directory: full-node
     - run: cargo update
       working-directory: fuzz
     - uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
I've noticed anecdotally that this periodic `cargo update` CI job only updates the `Cargo.lock` of the fuzzing tests.
It turns out that it's because `cargo update --workspace` doesn't seem to work at all.

This PR works around this issue.
