### PR TITLE
Remove an obsolete TODO concerning the `lru` dependency

### DIFF
--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -24,7 +24,7 @@ hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.10.5"
 log = { version = "0.4.18", default-features = false }
-lru = { version = "0.10.0", default-features = false }  # TODO: there's no way to use a custom hasher; remove this dependency
+lru = { version = "0.10.0", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0.163", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This comment was true when the dependency was added, but it no longer is.