### PR TITLE
Remove the `lazy_static!` dependency from the `wasm-node`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,12 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,7 +2434,6 @@ dependencies = [
  "fnv",
  "futures-util",
  "hashbrown 0.14.0",
- "lazy_static",
  "log",
  "nom",
  "pin-project",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -18,7 +18,6 @@ event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
 futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false }
-lazy_static = "1.4.0"
 log = { version = "0.4.18", features = ["std"] }
 nom = { version = "7.1.3", default-features = false }
 pin-project = "1.1.0"

--- a/wasm-node/rust/src/timers.rs
+++ b/wasm-node/rust/src/timers.rs
@@ -235,6 +235,8 @@ fn process_timers() {
 
     // Wake up the expired timers.
     for timer in expired_timers {
+        debug_assert!(timer.when_from_time_zero <= now - *time_zero);
+        debug_assert!(!lock.timers[timer.timer_id].is_finished);
         lock.timers[timer.timer_id].is_finished = true;
         if let Some(waker) = lock.timers[timer.timer_id].waker.take() {
             waker.wake();

--- a/wasm-node/rust/src/timers.rs
+++ b/wasm-node/rust/src/timers.rs
@@ -141,13 +141,11 @@ impl Drop for Delay {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref TIMERS: Mutex<Timers> = Mutex::new(Timers {
-        timers_queue: BTreeSet::new(),
-        timers: slab::Slab::new(),
-        time_zero: None,
-    });
-}
+static TIMERS: Mutex<Timers> = Mutex::new(Timers {
+    timers_queue: BTreeSet::new(),
+    timers: slab::Slab::new(),
+    time_zero: None,
+});
 
 struct Timers {
     /// Same entries as `timer`, but ordered based on when they're finished (from soonest to


### PR DESCRIPTION
Close #64 

Since `lazy_static!` and similar mechanisms such as `OnceCell` requires some kind of mutex/futex, it is "dangerous" to use them in a browser context when you can never block.

This might become important for #91
