### PR TITLE
Make the proof_decode functions return Result instead of Option

### DIFF
--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1222,8 +1222,8 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
 
             let finalized_storage_code =
                 match decoded_downloaded_runtime.storage_value(&header.state_root, b":code") {
-                    Some(Some((code, _))) => code,
-                    Some(None) => {
+                    Ok(Some((code, _))) => code,
+                    Ok(None) => {
                         self.inner.phase = Phase::DownloadFragments {
                             previous_verifier_values: Some((
                                 header.clone(),
@@ -1232,7 +1232,7 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
                         };
                         return (WarpSync::InProgress(self.inner), Some(Error::MissingCode));
                     }
-                    None => {
+                    Err(proof_decode::IncompleteProofError { .. }) => {
                         self.inner.phase = Phase::DownloadFragments {
                             previous_verifier_values: Some((
                                 header.clone(),
@@ -1248,8 +1248,8 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
 
             let finalized_storage_heappages =
                 match decoded_downloaded_runtime.storage_value(&header.state_root, b":heappages") {
-                    Some(val) => val.map(|(v, _)| v),
-                    None => {
+                    Ok(val) => val.map(|(v, _)| v),
+                    Err(proof_decode::IncompleteProofError { .. }) => {
                         self.inner.phase = Phase::DownloadFragments {
                             previous_verifier_values: Some((
                                 header.clone(),
@@ -1451,8 +1451,8 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
                         let proof = calls.get(&get.call_in_progress()).unwrap();
                         let value =
                             match proof.storage_value(&header.state_root, get.key().as_ref()) {
-                                Some(v) => v.map(|(v, _)| v),
-                                None => {
+                                Ok(v) => v.map(|(v, _)| v),
+                                Err(proof_decode::IncompleteProofError { .. }) => {
                                     self.inner.phase = Phase::DownloadFragments {
                                         previous_verifier_values: Some((
                                             header.clone(),

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -671,7 +671,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     ///
     /// Returns an error if the proof doesn't contain enough information about this trie node.
     ///
-    /// This function might return `Some` even if there is no node in the trie for `key`, in which
+    /// This function will return `Ok` even if there is no node in the trie for `key`, in which
     /// case the returned [`TrieNodeInfo`] will indicate no storage value and no children.
     pub fn trie_node_info(
         &'_ self,

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -607,7 +607,7 @@ mod tests {
                 proof_decode::decode_and_verify_proof(proof_decode::Config { proof }).unwrap();
             assert!(proof
                 .closest_descendant_merkle_value(&trie_root_hash, &[])
-                .is_some());
+                .is_ok());
         }
     }
 

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1930,7 +1930,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         }
                         .to_json_call_object_parameters(None)
                     }
-                    Some(Err(runtime_service::RuntimeCallError::MissingProofEntry)) => {
+                    Some(Err(runtime_service::RuntimeCallError::MissingProofEntry(_error))) => {
                         methods::ServerToClient::chainHead_unstable_callEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::ChainHeadCallEvent::Error {

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -439,7 +439,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                         result.push(
                             decoded
                                 .storage_value(storage_trie_root, key.as_ref())
-                                .ok_or(StorageQueryErrorDetail::MissingProofEntry)?
+                                .map_err(|_| StorageQueryErrorDetail::MissingProofEntry)?
                                 .map(|(v, _)| v.to_owned()),
                         );
                     }


### PR DESCRIPTION
When the proof is incomplete, it is more idiomatic to return a `Result`.