### PR TITLE
Remove `CMD` from `Dockerfile`

### DIFF
--- a/full-node/Dockerfile
+++ b/full-node/Dockerfile
@@ -15,4 +15,3 @@ COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/full-node /u
 
 EXPOSE 30333
 ENTRYPOINT ["/usr/local/bin/full-node"]
-CMD ["run"]


### PR DESCRIPTION
After some tries, I find it confusing that `docker run <image>` runs the node, `docker run <image> --output json` prints an error, and you have to do `docker run <image> run --output json`.

Instead, you now have to pass `run` all the time.
