### PR TITLE
Make `trie_root_calculator` generate events about trie changes

### DIFF
--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -902,6 +902,14 @@ impl Inner {
                                 ClosestDescendantMerkleValue { inner: self },
                             );
                         }
+                        trie_root_calculator::InProgress::TrieNodeInsertUpdateEvent(ev) => {
+                            self.vm = req.into();
+                            self.root_calculation = Some(ev.resume());
+                        }
+                        trie_root_calculator::InProgress::TrieNodeRemoveEvent(ev) => {
+                            self.vm = req.into();
+                            self.root_calculation = Some(ev.resume());
+                        }
                         trie_root_calculator::InProgress::Finished { trie_root_hash } => {
                             self.vm = req.resume(Some(&trie_root_hash));
                         }


### PR DESCRIPTION
First step towards #661.

The `trie_root_calculator` now generates events indicating the Merkle values updates of the trie nodes, and which trie nodes (including branch nodes) have been destroyed.

The roadmap is to propagate these events throughout the stack so that the `full_node::consensus_service` writes these events into the database.
