### PR TITLE
Change `PlatformRef::spawn_task` to accept unboxed futures

### DIFF
--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -87,8 +87,11 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// The first parameter is the name of the task, which can be useful for debugging purposes.
     ///
     /// The `Future` must be run until it yields a value.
-    // TODO: accept plain futures, not boxed
-    fn spawn_task(&self, task_name: Cow<str>, task: future::BoxFuture<'static, ()>);
+    fn spawn_task(
+        &self,
+        task_name: Cow<str>,
+        task: impl future::Future<Output = ()> + Send + 'static,
+    );
 
     /// Value returned when a JSON-RPC client requests the name of the client, or when a peer
     /// performs an identification request. Reasonable value is `env!("CARGO_PKG_NAME")`.

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -81,7 +81,11 @@ impl PlatformRef for Arc<DefaultPlatform> {
         self.sleep(duration)
     }
 
-    fn spawn_task(&self, _task_name: Cow<str>, task: future::BoxFuture<'static, ()>) {
+    fn spawn_task(
+        &self,
+        _task_name: Cow<str>,
+        task: impl future::Future<Output = ()> + Send + 'static,
+    ) {
         smol::spawn(task).detach();
     }
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -96,7 +96,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     fn spawn_task(
         &self,
         task_name: Cow<str>,
-        task: pin::Pin<Box<dyn future::Future<Output = ()> + Send>>,
+        task: impl future::Future<Output = ()> + Send + 'static,
     ) {
         // The code below processes tasks that have names.
         #[pin_project::pin_project]


### PR DESCRIPTION
Minor clean-up breaking change to the `PlatformRef` trait.

cc @lexnv @skunert So you're not surprised if you update smoldot
