### PR TITLE
Rename `PlatformRef::Connection` to `MultiStream`

### DIFF
--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -402,7 +402,7 @@ async fn single_stream_connection_task<TPlat: PlatformRef>(
 /// >           general-purpose.
 // TODO: a lot of logging disappeared
 async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
-    mut connection: TPlat::Connection,
+    mut connection: TPlat::MultiStream,
     shared: Arc<Shared<TPlat>>,
     connection_id: service::ConnectionId,
     mut connection_task: service::MultiStreamConnectionTask<TPlat::Instant, usize>,

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -43,9 +43,9 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// A multi-stream connection.
     ///
     /// This object is merely a handle. The underlying connection should be dropped only after
-    /// the `Connection` and all its associated substream objects ([`PlatformRef::Stream`]) have
+    /// the `MultiStream` and all its associated substream objects ([`PlatformRef::Stream`]) have
     /// been dropped.
-    type Connection: Send + Sync + 'static;
+    type MultiStream: Send + Sync + 'static;
     /// Opaque object representing either a single-stream connection or a substream in a
     /// multi-stream connection.
     ///
@@ -53,7 +53,7 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// should be abruptly dropped (i.e. RST) as well, unless its reading and writing sides
     /// have been gracefully closed in the past.
     type Stream: Send + 'static;
-    type ConnectFuture: Future<Output = Result<PlatformConnection<Self::Stream, Self::Connection>, ConnectError>>
+    type ConnectFuture: Future<Output = Result<PlatformConnection<Self::Stream, Self::MultiStream>, ConnectError>>
         + Unpin
         + Send
         + 'static;
@@ -120,7 +120,7 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// >           to open, as this is not supposed to happen. If you need to handle such a
     /// >           situation, either try again opening a substream again or reset the entire
     /// >           connection.
-    fn open_out_substream(&self, connection: &mut Self::Connection);
+    fn open_out_substream(&self, connection: &mut Self::MultiStream);
 
     /// Waits until a new incoming substream arrives on the connection.
     ///
@@ -128,11 +128,11 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// yielded once for every call to [`PlatformRef::open_out_substream`].
     ///
     /// The future can also return `None` if the connection has been killed by the remote. If
-    /// the future returns `None`, the user of the `PlatformRef` should drop the `Connection` and
+    /// the future returns `None`, the user of the `PlatformRef` should drop the `MultiStream` and
     /// all its associated `Stream`s as soon as possible.
     fn next_substream<'a>(
         &self,
-        connection: &'a mut Self::Connection,
+        connection: &'a mut Self::MultiStream,
     ) -> Self::NextSubstreamFuture<'a>;
 
     /// Synchronizes the stream with the "actual" stream.

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -53,11 +53,11 @@ impl PlatformRef for Arc<DefaultPlatform> {
     type Delay = future::BoxFuture<'static, ()>;
     type Yield = future::Ready<()>;
     type Instant = std::time::Instant;
-    type Connection = std::convert::Infallible;
+    type MultiStream = std::convert::Infallible;
     type Stream = Stream;
     type ConnectFuture = future::BoxFuture<
         'static,
-        Result<PlatformConnection<Self::Stream, Self::Connection>, ConnectError>,
+        Result<PlatformConnection<Self::Stream, Self::MultiStream>, ConnectError>,
     >;
     type StreamUpdateFuture<'a> = future::BoxFuture<'a, ()>;
     type NextSubstreamFuture<'a> =
@@ -221,13 +221,13 @@ impl PlatformRef for Arc<DefaultPlatform> {
         })
     }
 
-    fn open_out_substream(&self, c: &mut Self::Connection) {
+    fn open_out_substream(&self, c: &mut Self::MultiStream) {
         // This function can only be called with so-called "multi-stream" connections. We never
         // open such connection.
         match *c {}
     }
 
-    fn next_substream(&self, c: &'_ mut Self::Connection) -> Self::NextSubstreamFuture<'_> {
+    fn next_substream(&self, c: &'_ mut Self::MultiStream) -> Self::NextSubstreamFuture<'_> {
         // This function can only be called with so-called "multi-stream" connections. We never
         // open such connection.
         match *c {}

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -48,7 +48,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     type Delay = Delay;
     type Yield = Yield;
     type Instant = Instant;
-    type MultiStream = ConnectionWrapper; // Entry in the ̀`CONNECTIONS` map.
+    type MultiStream = MultiStreamWrapper; // Entry in the ̀`CONNECTIONS` map.
     type Stream = StreamWrapper; // Entry in the ̀`STREAMS` map and a read buffer.
     type ConnectFuture = pin::Pin<
         Box<
@@ -230,7 +230,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                     *connection_handles_alive += 1;
                     Ok(
                         smoldot_light::platform::PlatformConnection::MultiStreamWebRtc {
-                            connection: ConnectionWrapper(connection_id),
+                            connection: MultiStreamWrapper(connection_id),
                             local_tls_certificate_multihash: local_tls_certificate_multihash
                                 .clone(),
                             remote_tls_certificate_multihash: remote_tls_certificate_multihash
@@ -259,7 +259,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
 
     fn next_substream<'a>(
         &self,
-        ConnectionWrapper(connection_id): &'a mut Self::MultiStream,
+        MultiStreamWrapper(connection_id): &'a mut Self::MultiStream,
     ) -> Self::NextSubstreamFuture<'a> {
         let connection_id = *connection_id;
 
@@ -313,7 +313,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         })
     }
 
-    fn open_out_substream(&self, ConnectionWrapper(connection_id): &mut Self::MultiStream) {
+    fn open_out_substream(&self, MultiStreamWrapper(connection_id): &mut Self::MultiStream) {
         match STATE
             .try_lock()
             .unwrap()
@@ -600,9 +600,9 @@ impl Drop for StreamWrapper {
     }
 }
 
-pub(crate) struct ConnectionWrapper(u32);
+pub(crate) struct MultiStreamWrapper(u32);
 
-impl Drop for ConnectionWrapper {
+impl Drop for MultiStreamWrapper {
     fn drop(&mut self) {
         let mut lock = STATE.try_lock().unwrap();
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -48,13 +48,13 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     type Delay = Delay;
     type Yield = Yield;
     type Instant = Instant;
-    type Connection = ConnectionWrapper; // Entry in the ̀`CONNECTIONS` map.
+    type MultiStream = ConnectionWrapper; // Entry in the ̀`CONNECTIONS` map.
     type Stream = StreamWrapper; // Entry in the ̀`STREAMS` map and a read buffer.
     type ConnectFuture = pin::Pin<
         Box<
             dyn future::Future<
                     Output = Result<
-                        smoldot_light::platform::PlatformConnection<Self::Stream, Self::Connection>,
+                        smoldot_light::platform::PlatformConnection<Self::Stream, Self::MultiStream>,
                         ConnectError,
                     >,
                 > + Send,
@@ -256,7 +256,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
 
     fn next_substream<'a>(
         &self,
-        ConnectionWrapper(connection_id): &'a mut Self::Connection,
+        ConnectionWrapper(connection_id): &'a mut Self::MultiStream,
     ) -> Self::NextSubstreamFuture<'a> {
         let connection_id = *connection_id;
 
@@ -310,7 +310,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         })
     }
 
-    fn open_out_substream(&self, ConnectionWrapper(connection_id): &mut Self::Connection) {
+    fn open_out_substream(&self, ConnectionWrapper(connection_id): &mut Self::MultiStream) {
         match STATE
             .try_lock()
             .unwrap()

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -54,7 +54,10 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         Box<
             dyn future::Future<
                     Output = Result<
-                        smoldot_light::platform::PlatformConnection<Self::Stream, Self::MultiStream>,
+                        smoldot_light::platform::PlatformConnection<
+                            Self::Stream,
+                            Self::MultiStream,
+                        >,
                         ConnectError,
                     >,
                 > + Send,


### PR DESCRIPTION
Another small breaking change cleanup to the `PlatformRef` trait.

The name `Connection` is not great, because the object corresponds only to multistream connections. Single-stream connections (like TCP and WebSocket) are just a single `Stream` object.

Again cc @lexnv @skunert so you're not surprised if you update smoldot