### PR TITLE
Change the full node database path and correctly do migrations

### DIFF
--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -43,14 +43,12 @@ pub fn open(config: Config) -> Result<DatabaseOpen, InternalError> {
         rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX;
 
     let database = match config.ty {
-        ConfigTy::Disk(path) => {
-            // We put a `/v1/` behind the path in case we change the schema.
-            let path = path.join("v1");
+        ConfigTy::Disk(directory_path) => {
             // Ignoring errors in `create_dir_all`, in order to avoid making the API of this
             // function more complex. If `create_dir_all` fails, opening the database will most
             // likely fail too.
-            let _ = fs::create_dir_all(&path);
-            rusqlite::Connection::open_with_flags(path.join("database.sqlite"), flags)
+            let _ = fs::create_dir_all(directory_path);
+            rusqlite::Connection::open_with_flags(directory_path.join("database.sqlite"), flags)
         }
         ConfigTy::Memory => rusqlite::Connection::open_in_memory_with_flags(flags),
     }


### PR DESCRIPTION
The database is still completely unstable and can break any point. This PR just reorganizes the code a bit, but that doesn't mean that we'll do migrations yet.