### PR TITLE
Turn `empty_trie_merkle_value()` into a static variable

### DIFF
--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -527,7 +527,7 @@ impl ChainInformationBuild {
                         parent_hash: &[0; 32],
                         number: 0,
                         state_root: &state_trie_root_hash,
-                        extrinsics_root: &trie::empty_trie_merkle_value(),
+                        extrinsics_root: &trie::EMPTY_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty(),
                     }
                     .scale_encoding_vec(inner.block_number_bytes);

--- a/lib/src/executor/read_only_runtime_host.rs
+++ b/lib/src/executor/read_only_runtime_host.rs
@@ -206,8 +206,6 @@ impl StorageGet {
             }
 
             host::HostVm::ExternalStorageRoot(req) => {
-                let empty_trie = trie::empty_trie_merkle_value(); // TODO: this function should be a static
-
                 let hash = match value.as_ref() {
                     Some(v) => match <&[u8; 32]>::try_from(&v[..]) {
                         Ok(v) => v,
@@ -218,7 +216,7 @@ impl StorageGet {
                             }));
                         }
                     },
-                    None => &empty_trie,
+                    None => &trie::EMPTY_TRIE_MERKLE_VALUE,
                 };
 
                 self.inner.vm = req.resume(hash);

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -806,8 +806,7 @@ impl Inner {
                         main_trie_key.extend_from_slice(DEFAULT_CHILD_STORAGE_SPECIAL_PREFIX);
                         main_trie_key.extend_from_slice(child_trie);
 
-                        if trie_root_hash != trie::empty_trie_merkle_value() {
-                            // TODO: `empty_trie_merkle_value` should be a static?
+                        if trie_root_hash != trie::EMPTY_TRIE_MERKLE_VALUE {
                             self.storage_changes.main_trie.diff_insert(
                                 main_trie_key,
                                 trie_root_hash.to_vec(),

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -200,7 +200,7 @@ impl ClosestDescendant {
                     } else {
                         // If the element doesn't have a parent, then the trie is completely empty.
                         InProgress::Finished {
-                            trie_root_hash: trie::empty_trie_merkle_value(),
+                            trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
                         }
                     };
                 }
@@ -339,7 +339,7 @@ impl StorageValue {
                 // This case is handled separately in order to not generate
                 // a `TrieNodeInsertUpdateEvent` for a node that doesn't actually exist.
                 InProgress::Finished {
-                    trie_root_hash: trie::empty_trie_merkle_value(),
+                    trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
                 }
             }
 
@@ -566,7 +566,7 @@ impl TrieNodeRemoveEvent {
                     self.inner.next()
                 } else {
                     InProgress::Finished {
-                        trie_root_hash: trie::empty_trie_merkle_value(),
+                        trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
                     }
                 }
             }

--- a/lib/src/executor/trie_root_calculator/tests.rs
+++ b/lib/src/executor/trie_root_calculator/tests.rs
@@ -34,7 +34,7 @@ fn empty_trie_works() {
     loop {
         match calculation {
             InProgress::Finished { trie_root_hash } => {
-                assert_eq!(trie_root_hash, trie::empty_trie_merkle_value());
+                assert_eq!(trie_root_hash, trie::EMPTY_TRIE_MERKLE_VALUE);
                 return;
             }
             InProgress::ClosestDescendant(req) => {
@@ -410,7 +410,7 @@ fn fuzzing() {
         let expected_hash = trie_after_diff
             .root_user_data()
             .map(|n| *<&[u8; 32]>::try_from(n.1.as_ref().unwrap().as_ref()).unwrap())
-            .unwrap_or(trie::empty_trie_merkle_value());
+            .unwrap_or(trie::EMPTY_TRIE_MERKLE_VALUE);
         if obtained_hash != expected_hash {
             panic!(
                 "\nexpected = {:?}\ncalculated = {:?}\ntrie_before = {:?}\ndiff = {:?}",

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -78,12 +78,10 @@
 //! ```
 //!
 
-use crate::trie::empty_trie_merkle_value;
-
 use super::{
     branch_search,
     nibble::{nibbles_to_bytes_suffix_extend, Nibble},
-    trie_node, TrieEntryVersion,
+    trie_node, TrieEntryVersion, EMPTY_TRIE_MERKLE_VALUE,
 };
 
 use alloc::vec::Vec;
@@ -271,7 +269,7 @@ impl NextKey {
                 } else {
                     // Trie is completely empty.
                     RootMerkleValueCalculation::Finished {
-                        hash: empty_trie_merkle_value(),
+                        hash: EMPTY_TRIE_MERKLE_VALUE,
                     }
                 }
             }

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -423,7 +423,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         parent_hash: [0; 32],
                         number: 0,
                         state_root: *chain_spec.genesis_storage().into_trie_root_hash().unwrap(),
-                        extrinsics_root: smoldot::trie::empty_trie_merkle_value(),
+                        extrinsics_root: smoldot::trie::EMPTY_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty().into(),
                     };
 
@@ -460,7 +460,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         parent_hash: [0; 32],
                         number: 0,
                         state_root: *chain_spec.genesis_storage().into_trie_root_hash().unwrap(),
-                        extrinsics_root: smoldot::trie::empty_trie_merkle_value(),
+                        extrinsics_root: smoldot::trie::EMPTY_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty().into(),
                     };
 


### PR DESCRIPTION
Given that its value never changes, it feels stupid to recalculate a hash every single time.

Having it as a static variable also solves some borrow checking difficulties.
