### PR TITLE
Use a basic `HashMap` for `offchain_storage_changes`

### DIFF
--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -118,7 +118,7 @@ pub struct Success {
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::TrieDiff,
+    pub offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     /// Concatenation of all the log messages printed by the runtime.
     pub logs: String,
 }
@@ -499,7 +499,7 @@ pub struct InherentExtrinsics {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
     storage_main_trie_changes: storage_diff::TrieDiff,
-    offchain_storage_changes: storage_diff::TrieDiff,
+    offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 
 impl InherentExtrinsics {
@@ -561,7 +561,7 @@ pub struct ApplyExtrinsic {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
     storage_main_trie_changes: storage_diff::TrieDiff,
-    offchain_storage_changes: storage_diff::TrieDiff,
+    offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 
 impl ApplyExtrinsic {

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -872,7 +872,7 @@ pub enum BodyVerifyStep2<T> {
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.
-        offchain_storage_changes: storage_diff::TrieDiff,
+        offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
         /// Use to insert the block in the chain.
         insert: BodyInsert<T>,
     },

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2791,7 +2791,7 @@ pub enum BlockVerification<TRq, TSrc, TBl> {
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.
-        offchain_storage_changes: storage_diff::TrieDiff,
+        offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
         /// Runtime of the parent, as was provided at the start of the verification.
         parent_runtime: host::HostVmPrototype,
         /// If `Some`, the block has modified the runtime compared to its parent. Contains the new

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -999,7 +999,7 @@ pub struct BlockVerificationSuccessFull {
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::TrieDiff,
+    pub offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 
     /// Runtime of the parent, as was provided at the beginning of the verification.
     pub parent_runtime: host::HostVmPrototype,

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -333,7 +333,7 @@ pub fn validate_transaction(
                 }
                 .scale_encoding(config.block_number_bytes),
                 storage_main_trie_changes: storage_diff::TrieDiff::empty(),
-                offchain_storage_changes: storage_diff::TrieDiff::empty(),
+                offchain_storage_changes: Default::default(),
                 max_log_level: config.max_log_level,
             });
 
@@ -370,7 +370,7 @@ pub fn validate_transaction(
                     &header::hash_from_scale_encoded_header(config.scale_encoded_header),
                 ),
                 storage_main_trie_changes: storage_diff::TrieDiff::empty(),
-                offchain_storage_changes: storage_diff::TrieDiff::empty(),
+                offchain_storage_changes: Default::default(),
                 max_log_level: config.max_log_level,
             });
 

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -124,7 +124,7 @@ pub struct Success {
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.
-    pub offchain_storage_changes: storage_diff::TrieDiff,
+    pub offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 
     /// Concatenation of all the log messages printed by the runtime.
     pub logs: String,
@@ -762,7 +762,7 @@ pub struct RuntimeCompilation {
     parent_runtime: host::HostVmPrototype,
     storage_main_trie_changes: storage_diff::TrieDiff,
     state_trie_version: TrieEntryVersion,
-    offchain_storage_changes: storage_diff::TrieDiff,
+    offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     logs: String,
     heap_pages: vm::HeapPages,
     parent_code: Option<Option<Vec<u8>>>,


### PR DESCRIPTION
This is not related to a trie, and a basic `HashMap` is more appropriate anyway as there's no ordering in the items.

The reason for this change is that `TrieDiff` might get revamped/disappear in the future, since it now only primarily concerns the communication between `runtime_host` and `trie_root_calculator`.
