### PR TITLE
Make `runtime_host` return full trie diff, including of branch nodes

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1219,7 +1219,7 @@ impl SyncBackground {
                         all::BlockVerification::Success {
                             is_new_best,
                             sync: mut sync_out,
-                            storage_main_trie_changes,
+                            storage_changes,
                             state_trie_version,
                             parent_runtime,
                             new_runtime,
@@ -1332,9 +1332,7 @@ impl SyncBackground {
                                         &scale_encoded_header_to_verify,
                                         is_new_best,
                                         iter::empty::<Vec<u8>>(), // TODO:,no /!\
-                                        storage_main_trie_changes
-                                            .diff_iter_unordered()
-                                            .map(|(k, v, ())| (k, v)),
+                                        storage_changes.main_trie_storage_changes_iter_unordered(),
                                         u8::from(state_trie_version),
                                     );
 

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -48,7 +48,7 @@
 mod tests;
 
 use crate::{
-    executor::{host, runtime_host, storage_diff},
+    executor::{host, runtime_host},
     header, util,
     verify::inherents,
 };
@@ -56,7 +56,7 @@ use crate::{
 use alloc::{borrow::ToOwned as _, string::String, vec::Vec};
 use core::{iter, mem};
 
-pub use runtime_host::{Nibble, TrieEntryVersion};
+pub use runtime_host::{Nibble, StorageChanges, TrieEntryVersion};
 
 /// Configuration for a block generation.
 pub struct Config<'a> {
@@ -113,7 +113,7 @@ pub struct Success {
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
     /// List of changes to the storage main trie that the block performs.
-    pub storage_main_trie_changes: storage_diff::TrieDiff,
+    pub storage_changes: StorageChanges,
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
@@ -301,7 +301,7 @@ impl BlockBuild {
                     return BlockBuild::InherentExtrinsics(InherentExtrinsics {
                         shared,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_changes: success.storage_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
                     });
                 }
@@ -337,7 +337,7 @@ impl BlockBuild {
                         virtual_machine: success.virtual_machine.into_prototype(),
                         function_to_call: "BlockBuilder_apply_extrinsic",
                         parameter: iter::once(extrinsic),
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_main_trie_changes: success.storage_changes.into_main_trie_diff(),
                         offchain_storage_changes: success.offchain_storage_changes,
                         max_log_level: shared.max_log_level,
                     });
@@ -354,7 +354,7 @@ impl BlockBuild {
                     return BlockBuild::ApplyExtrinsic(ApplyExtrinsic {
                         shared,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_changes: success.storage_changes,
                         offchain_storage_changes: success.offchain_storage_changes,
                     });
                 }
@@ -437,7 +437,7 @@ impl BlockBuild {
                         resume: ApplyExtrinsic {
                             shared,
                             parent_runtime: success.virtual_machine.into_prototype(),
-                            storage_main_trie_changes: success.storage_main_trie_changes,
+                            storage_changes: success.storage_changes,
                             offchain_storage_changes: success.offchain_storage_changes,
                         },
                     };
@@ -453,7 +453,7 @@ impl BlockBuild {
                         scale_encoded_header,
                         body: shared.block_body,
                         parent_runtime: success.virtual_machine.into_prototype(),
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_changes: success.storage_changes,
                         state_trie_version: success.state_trie_version,
                         offchain_storage_changes: success.offchain_storage_changes,
                         logs: shared.logs,
@@ -498,7 +498,7 @@ enum Stage {
 pub struct InherentExtrinsics {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::TrieDiff,
+    storage_changes: StorageChanges,
     offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 
@@ -541,7 +541,7 @@ impl InherentExtrinsics {
                     .map(either::Left)
                     .chain(encoded_list.map(either::Right))
             },
-            storage_main_trie_changes: self.storage_main_trie_changes,
+            storage_main_trie_changes: self.storage_changes.into_main_trie_diff(),
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });
@@ -560,7 +560,7 @@ impl InherentExtrinsics {
 pub struct ApplyExtrinsic {
     shared: Shared,
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::TrieDiff,
+    storage_changes: StorageChanges,
     offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
 }
 
@@ -573,7 +573,7 @@ impl ApplyExtrinsic {
             virtual_machine: self.parent_runtime,
             function_to_call: "BlockBuilder_apply_extrinsic",
             parameter: iter::once(&extrinsic),
-            storage_main_trie_changes: self.storage_main_trie_changes,
+            storage_main_trie_changes: self.storage_changes.into_main_trie_diff(),
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });
@@ -596,7 +596,7 @@ impl ApplyExtrinsic {
             virtual_machine: self.parent_runtime,
             function_to_call: "BlockBuilder_finalize_block",
             parameter: iter::empty::<&[u8]>(),
-            storage_main_trie_changes: self.storage_main_trie_changes,
+            storage_main_trie_changes: self.storage_changes.into_main_trie_diff(),
             offchain_storage_changes: self.offchain_storage_changes,
             max_log_level: self.shared.max_log_level,
         });

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -115,7 +115,7 @@ pub struct Success {
     /// List of changes to the storage main trie that the block performs.
     pub storage_changes: StorageChanges,
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
+    /// [`Success::storage_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     chain::{chain_information, fork_tree},
-    executor::{host, storage_diff},
+    executor::host,
     header, verify,
 };
 
@@ -34,7 +34,7 @@ use super::{
 use alloc::boxed::Box;
 use core::cmp::Ordering;
 
-pub use verify::header_body::{Nibble, TrieEntryVersion};
+pub use verify::header_body::{Nibble, StorageChanges, TrieEntryVersion};
 
 impl<T> NonFinalizedTree<T> {
     /// Verifies the given block.
@@ -619,7 +619,7 @@ impl<T> VerifyContext<T> {
                 BodyVerifyStep2::Finished {
                     parent_runtime: success.parent_runtime,
                     new_runtime: success.new_runtime,
-                    storage_main_trie_changes: success.storage_main_trie_changes,
+                    storage_changes: success.storage_changes,
                     state_trie_version: success.state_trie_version,
                     offchain_storage_changes: success.offchain_storage_changes,
                     insert: BodyInsert(Box::new(BodyInsertInner {
@@ -866,7 +866,7 @@ pub enum BodyVerifyStep2<T> {
         /// been modified. Contains the new runtime.
         new_runtime: Option<host::HostVmPrototype>,
         /// List of changes to the storage main trie that the block performs.
-        storage_main_trie_changes: storage_diff::TrieDiff,
+        storage_changes: StorageChanges,
         /// State trie version indicated by the runtime. All the storage changes indicated by
         /// [`BodyVerifyStep2::Finished::storage_main_trie_changes`] should store this version
         /// alongside with them.

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -861,14 +861,14 @@ pub enum BodyVerifyStep2<T> {
     Finished {
         /// Value that was passed to [`BodyVerifyRuntimeRequired::resume`].
         parent_runtime: host::HostVmPrototype,
-        /// Contains `Some` if and only if [`BodyVerifyStep2::Finished::storage_main_trie_changes`]
+        /// Contains `Some` if and only if [`BodyVerifyStep2::Finished::storage_changes`]
         /// contains a change in the `:code` or `:heappages` keys, indicating that the runtime has
         /// been modified. Contains the new runtime.
         new_runtime: Option<host::HostVmPrototype>,
         /// List of changes to the storage main trie that the block performs.
         storage_changes: StorageChanges,
         /// State trie version indicated by the runtime. All the storage changes indicated by
-        /// [`BodyVerifyStep2::Finished::storage_main_trie_changes`] should store this version
+        /// [`BodyVerifyStep2::Finished::storage_changes`] should store this version
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -854,7 +854,7 @@ struct PendingStorageChanges {
 
     /// List of tries (`None` for the main trie and `Some` for child tries) whose root hash must
     /// be recalculated (and for child tries stored into the main trie).
-    /// This is necessary in order to populate [`PendingStorageChanges::tries_nodes_changes`].
+    /// This is necessary in order to populate [`PendingStorageChanges::tries_changes`].
     stale_child_tries_root_hashes: hashbrown::HashSet<Option<Vec<u8>>, fnv::FnvBuildHasher>,
 
     /// Changes to the trie nodes of all the tries.

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -61,7 +61,7 @@ pub struct Config<'a, TParams> {
     /// actual input.
     pub parameter: TParams,
 
-    /// Initial state of [`Success::storage_main_trie_changes`]. The changes made during this
+    /// Initial state of [`Success::storage_changes`]. The changes made during this
     /// execution will be pushed over the value in this field.
     // TODO: consider accepting a different type
     // TODO: accept also child trie modifications
@@ -123,7 +123,7 @@ pub struct Success {
     /// List of changes to the storage that the block performs.
     pub storage_changes: StorageChanges,
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
+    /// [`Success::storage_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
     /// List of changes to the off-chain storage that this block performs.
     pub offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
@@ -223,7 +223,7 @@ impl StorageChanges {
     }
 
     /// Returns a diff of the main trie.
-    // TODO: weird API, necessary to turn this object back to a value for Config::storage_main_trie_changes
+    // TODO: weird API, necessary to turn this object back to a value for Config::storage_changes
     pub fn into_main_trie_diff(mut self) -> storage_diff::TrieDiff {
         self.inner
             .trie_diffs

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -43,7 +43,12 @@ use crate::{
 };
 
 use alloc::{
-    borrow::ToOwned as _, boxed::Box, collections::BTreeMap, format, string::String, vec::Vec,
+    borrow::ToOwned as _,
+    boxed::Box,
+    collections::BTreeMap,
+    format,
+    string::{String, ToString as _},
+    vec::Vec,
 };
 use core::{fmt, iter, ops};
 

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -99,7 +99,11 @@ pub fn run(
             .run_vectored(config.function_to_call, config.parameter)?
             .into(),
         pending_storage_changes: PendingStorageChanges {
-            trie_diffs: hashbrown::HashMap::with_capacity_and_hasher(4, Default::default()),
+            trie_diffs: {
+                let mut hm = hashbrown::HashMap::with_capacity_and_hasher(4, Default::default());
+                hm.insert(None, config.storage_main_trie_changes);
+                hm
+            },
             stale_child_tries_root_hashes: hashbrown::HashSet::with_capacity_and_hasher(
                 4,
                 Default::default(),

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -181,7 +181,7 @@ impl StorageChanges {
                         partial_key,
                         children_merkle_values,
                     } => {
-                        debug_assert!(key.ends_with(&partial_key));
+                        debug_assert!(key.ends_with(partial_key));
 
                         let new_storage_value = if key.len() % 2 == 0 {
                             let key_bytes = trie::nibbles_to_bytes_truncate(key.iter().copied())
@@ -1254,7 +1254,7 @@ impl Inner {
                     });
                 }
 
-                host::HostVm::ExternalStorageRoot(req) => {
+                host::HostVm::ExternalStorageRoot(_) => {
                     // Handled above.
                     unreachable!()
                 }

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -42,7 +42,9 @@ use crate::{
     trie, util,
 };
 
-use alloc::{borrow::ToOwned as _, collections::BTreeMap, string::String, vec::Vec};
+use alloc::{
+    borrow::ToOwned as _, boxed::Box, collections::BTreeMap, format, string::String, vec::Vec,
+};
 use core::{fmt, iter, ops};
 
 pub use trie::{Nibble, TrieEntryVersion};
@@ -1101,6 +1103,7 @@ impl Inner {
                 }
 
                 host::HostVm::Finished(finished) => {
+                    debug_assert!(self.transactions_stack.is_empty()); // Guaranteed by `host`.
                     debug_assert!(self
                         .pending_storage_changes
                         .stale_child_tries_root_hashes

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -32,7 +32,7 @@
 
 use crate::{
     chain::{blocks_tree, chain_information},
-    executor::{host, storage_diff},
+    executor::host,
     header,
     sync::{all_forks, optimistic, warp_sync},
     verify,
@@ -47,7 +47,7 @@ use core::{
 };
 
 pub use crate::executor::vm::ExecHint;
-pub use optimistic::{Nibble, TrieEntryVersion};
+pub use optimistic::{Nibble, StorageChanges, TrieEntryVersion};
 pub use warp_sync::{FragmentError as WarpSyncFragmentError, WarpSyncFragment};
 
 /// Configuration for the [`AllSync`].
@@ -2791,7 +2791,7 @@ pub enum BlockVerification<TRq, TSrc, TBl> {
         /// True if the newly-verified block is considered the new best block.
         is_new_best: bool,
         /// Changes to the storage made by this block compared to its parent.
-        storage_main_trie_changes: storage_diff::TrieDiff,
+        storage_changes: StorageChanges,
         /// State trie version indicated by the runtime. All the storage changes indicated by
         /// [`BlockVerification::Success::storage_main_trie_changes`] should store this version
         /// alongside with them.
@@ -2863,7 +2863,7 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                 sync,
                 full:
                     Some(optimistic::BlockVerificationSuccessFull {
-                        storage_main_trie_changes,
+                        storage_changes,
                         state_trie_version,
                         offchain_storage_changes,
                         parent_runtime,
@@ -2874,7 +2874,7 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                 // TODO: transition to all_forks
                 BlockVerification::Success {
                     is_new_best: true,
-                    storage_main_trie_changes,
+                    storage_changes,
                     state_trie_version,
                     offchain_storage_changes,
                     parent_runtime,

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2793,7 +2793,7 @@ pub enum BlockVerification<TRq, TSrc, TBl> {
         /// Changes to the storage made by this block compared to its parent.
         storage_changes: StorageChanges,
         /// State trie version indicated by the runtime. All the storage changes indicated by
-        /// [`BlockVerification::Success::storage_main_trie_changes`] should store this version
+        /// [`BlockVerification::Success::storage_changes`] should store this version
         /// alongside with them.
         state_trie_version: TrieEntryVersion,
         /// List of changes to the off-chain storage that this block performs.

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -994,7 +994,7 @@ pub struct BlockVerificationSuccessFull {
     pub storage_changes: StorageChanges,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`BlockVerificationSuccessFull::storage_main_trie_changes`] should store this version
+    /// [`BlockVerificationSuccessFull::storage_changes`] should store this version
     /// alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
@@ -1057,7 +1057,9 @@ impl<TRq, TSrc, TBl> BlockVerification<TRq, TSrc, TBl> {
                     debug_assert_eq!(
                         new_runtime.is_some(),
                         storage_changes.main_trie_diff_get(&b":code"[..]).is_some()
-                            || storage_changes.main_trie_diff_get(&b":heappages"[..]).is_some()
+                            || storage_changes
+                                .main_trie_diff_get(&b":heappages"[..])
+                                .is_some()
                     );
 
                     let chain = {

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -458,7 +458,7 @@ impl Query {
                             iter::once(info.scale_encoded_transaction),
                             info.transaction_source,
                         ),
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_main_trie_changes: success.storage_changes.into_main_trie_diff(),
                         offchain_storage_changes: success.offchain_storage_changes,
                         max_log_level: info.max_log_level,
                     });

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     chain::chain_information,
-    executor::{self, host, runtime_host, storage_diff, vm},
+    executor::{self, host, runtime_host, vm},
     header, util,
     verify::{aura, babe, inherents},
 };
@@ -25,7 +25,7 @@ use crate::{
 use alloc::{string::String, vec::Vec};
 use core::{iter, num::NonZeroU64, time::Duration};
 
-pub use runtime_host::{Nibble, TrieEntryVersion};
+pub use runtime_host::{Nibble, StorageChanges, TrieEntryVersion};
 
 /// Configuration for a block verification.
 pub struct Config<'a, TBody> {
@@ -123,7 +123,7 @@ pub struct Success {
     pub consensus: SuccessConsensus,
 
     /// List of changes to the storage main trie that the block performs.
-    pub storage_main_trie_changes: storage_diff::TrieDiff,
+    pub storage_changes: StorageChanges,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
     /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
@@ -462,7 +462,9 @@ impl VerifyInner {
                             virtual_machine: success.virtual_machine.into_prototype(),
                             function_to_call: "Core_execute_block",
                             parameter: iter::once(&execute_block_parameters),
-                            storage_main_trie_changes: success.storage_main_trie_changes,
+                            storage_main_trie_changes: success
+                                .storage_changes
+                                .into_main_trie_diff(),
                             offchain_storage_changes: success.offchain_storage_changes,
                             max_log_level: 0,
                         });
@@ -494,14 +496,14 @@ impl VerifyInner {
                     }
 
                     match (
-                        success.storage_main_trie_changes.diff_get(&b":code"[..]),
+                        success.storage_changes.main_trie_diff_get(&b":code"[..]),
                         parent_code,
                         success
-                            .storage_main_trie_changes
-                            .diff_get(&b":heappages"[..]),
+                            .storage_changes
+                            .main_trie_diff_get(&b":heappages"[..]),
                     ) {
                         (None, _, None) => {}
-                        (Some((None, ())), _, _) => {
+                        (Some(None), _, _) => {
                             return Verify::Finished(Err((
                                 Error::CodeKeyErased,
                                 success.virtual_machine.into_prototype(),
@@ -519,12 +521,12 @@ impl VerifyInner {
                                 success.virtual_machine.into_prototype(),
                             )))
                         }
-                        (Some((Some(_), ())), parent_code, heap_pages)
+                        (Some(Some(_)), parent_code, heap_pages)
                         | (_, parent_code @ Some(Some(_)), heap_pages) => {
                             let parent_runtime = success.virtual_machine.into_prototype();
 
                             let heap_pages = match heap_pages {
-                                Some((heap_pages, ())) => {
+                                Some(heap_pages) => {
                                     match executor::storage_heap_pages_to_value(heap_pages) {
                                         Ok(hp) => hp,
                                         Err(err) => {
@@ -545,7 +547,7 @@ impl VerifyInner {
                                 parent_code,
                                 logs: success.logs,
                                 offchain_storage_changes: success.offchain_storage_changes,
-                                storage_main_trie_changes: success.storage_main_trie_changes,
+                                storage_changes: success.storage_changes,
                                 state_trie_version: success.state_trie_version,
                             });
                         }
@@ -555,7 +557,7 @@ impl VerifyInner {
                         parent_runtime: success.virtual_machine.into_prototype(),
                         new_runtime: None,
                         consensus: self.consensus_success,
-                        storage_main_trie_changes: success.storage_main_trie_changes,
+                        storage_changes: success.storage_changes,
                         state_trie_version: success.state_trie_version,
                         offchain_storage_changes: success.offchain_storage_changes,
                         logs: success.logs,
@@ -766,7 +768,7 @@ impl StorageNextKey {
 #[must_use]
 pub struct RuntimeCompilation {
     parent_runtime: host::HostVmPrototype,
-    storage_main_trie_changes: storage_diff::TrieDiff,
+    storage_changes: StorageChanges,
     state_trie_version: TrieEntryVersion,
     offchain_storage_changes: hashbrown::HashMap<Vec<u8>, Option<Vec<u8>>, fnv::FnvBuildHasher>,
     logs: String,
@@ -780,9 +782,8 @@ impl RuntimeCompilation {
     pub fn build(self) -> Verify {
         // A `RuntimeCompilation` object is built only if `:code` is available.
         let code = self
-            .storage_main_trie_changes
-            .diff_get(&b":code"[..])
-            .map(|(value, _)| value)
+            .storage_changes
+            .main_trie_diff_get(&b":code"[..])
             .or(self.parent_code.as_ref().map(|v| v.as_deref()))
             .unwrap()
             .unwrap();
@@ -806,7 +807,7 @@ impl RuntimeCompilation {
             parent_runtime: self.parent_runtime,
             new_runtime: Some(new_runtime),
             consensus: self.consensus_success,
-            storage_main_trie_changes: self.storage_main_trie_changes,
+            storage_changes: self.storage_changes,
             state_trie_version: self.state_trie_version,
             offchain_storage_changes: self.offchain_storage_changes,
             logs: self.logs,

--- a/lib/src/verify/header_body.rs
+++ b/lib/src/verify/header_body.rs
@@ -114,7 +114,7 @@ pub struct Success {
     /// Runtime that was passed by [`Config`].
     pub parent_runtime: host::HostVmPrototype,
 
-    /// Contains `Some` if and only if [`Success::storage_main_trie_changes`] contains a change in
+    /// Contains `Some` if and only if [`Success::storage_changes`] contains a change in
     /// the `:code` or `:heappages` keys, indicating that the runtime has been modified. Contains
     /// the new runtime.
     pub new_runtime: Option<host::HostVmPrototype>,
@@ -126,7 +126,7 @@ pub struct Success {
     pub storage_changes: StorageChanges,
 
     /// State trie version indicated by the runtime. All the storage changes indicated by
-    /// [`Success::storage_main_trie_changes`] should store this version alongside with them.
+    /// [`Success::storage_changes`] should store this version alongside with them.
     pub state_trie_version: TrieEntryVersion,
 
     /// List of changes to the off-chain storage that this block performs.


### PR DESCRIPTION
cc #661 #741 

This PR extracts some changes from #741 but did it more properly.

The `runtime_host` module now returns the full trie diffs of not only the main trie but also child tries.

