### PR TITLE
`--log-level` now defaults to DEBUG if no informant

### DIFF
--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -67,7 +67,7 @@ pub struct CliOptionsRun {
     /// Output to stdout: auto, none, informant, logs, logs-json.
     #[arg(long, default_value = "auto")]
     pub output: Output,
-    /// Level of logging: off, error, warn, info, debug, trace. Defaults to info.
+    /// Level of logging: off, error, warn, info, debug, trace.
     #[arg(long)]
     pub log_level: Option<LogLevel>,
     /// Coloring: auto, always, never

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -63,7 +63,14 @@ async fn run(cli_options: cli::CliOptionsRun) {
         cli::Output::None => Arc::new(|_level, _message| {}),
         cli::Output::Informant | cli::Output::Logs => {
             let color_choice = cli_options.color.clone();
-            let log_level = cli_options.log_level.clone().unwrap_or(cli::LogLevel::Info);
+            let log_level = cli_options.log_level.clone().unwrap_or(
+                if matches!(cli_output, cli::Output::Informant) {
+                    cli::LogLevel::Info
+                } else {
+                    cli::LogLevel::Debug
+                },
+            );
+
             Arc::new(move |level, message| {
                 match (&level, &log_level) {
                     (_, cli::LogLevel::Off) => return,
@@ -117,7 +124,10 @@ async fn run(cli_options: cli::CliOptionsRun) {
             }) as Arc<dyn smoldot_full_node::LogCallback + Send + Sync>
         }
         cli::Output::LogsJson => {
-            let log_level = cli_options.log_level.clone().unwrap_or(cli::LogLevel::Info);
+            let log_level = cli_options
+                .log_level
+                .clone()
+                .unwrap_or(cli::LogLevel::Debug);
             Arc::new(move |level, message| {
                 match (&level, &log_level) {
                     (_, cli::LogLevel::Off) => return,


### PR DESCRIPTION
If no `--log-level` is provided, it now defaults to INFO if the informant is shown or to DEBUG is no informant is shown.

This restores the behavior to what it was before https://github.com/smol-dot/smoldot/pull/755.
