### PR TITLE
Do not send more than one request per peer at a time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,7 @@ version = "0.6.0"
 dependencies = [
  "async-lock",
  "blake2-rfc",
+ "crossbeam-queue",
  "derive_more",
  "either",
  "env_logger",

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -672,6 +672,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     /// Panics if the [`SourceId`] is invalid.
     ///
+    // TODO: this function is questionable, because in practice we send requests to sources that are outside the scope of syncing
     pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
         debug_assert!(self.shared.sources.contains(source_id.0));
 

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -14,6 +14,7 @@ required-features = ["std"]
 [dependencies]
 async-lock = { version = "2.7.0", default-features = false }  # TODO: no-std-ize; this is has been done and is just waiting for a release: https://github.com/smol-rs/event-listener/pull/34
 blake2-rfc = { version = "0.2.18", default-features = false }
+crossbeam-queue = { version = "0.3.8", default-features = false, features = ["alloc"] }
 derive_more = "0.99.17"
 either = { version = "1.8.1", default-features = false }
 event-listener = { version = "2.5.3" }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- A limit of one simultaneous request per peer is now enforced in order to limit the load that a light client induces on each full node it is connected to. This limit is theoretically part of the Polkadot networking protocol but in practice isn't properly enforced. Consequently, requests that were previously being executed in parallel might now execute more one after the other.
+
 ## 1.0.10 - 2023-06-19
 
 ### Changed


### PR DESCRIPTION
This PR introduces a "request lock" system to the `NetworkService` of the light client.
When a "request lock" is held, no other request lock with the same PeerId can be created. A "request lock" can then be used to start an actual request.

This causes the `sync_service` (and all parts of the node) to only start one request per peer at a time.
This effectively implements an existing requirement of the Polkadot networking protocol that isn't enforced by Substrate.

Further PRs will further refine this system.
