### PR TITLE
Add support for return the storage value to prefix_proof

### DIFF
--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -43,12 +43,17 @@ pub struct Config<'a> {
     ///
     /// > **Note**: The Merkle value and node value are always the same for the root node.
     pub trie_root_hash: [u8; 32],
+
+    /// If `true`, then the final result will only contain [`StorageValue::Value`] entries and no
+    /// [`StorageValue::Hash`] entry. If the remote doesn't .
+    pub full_storage_values_required: bool,
 }
 
 /// Start a new scanning process.
 pub fn prefix_scan(config: Config<'_>) -> PrefixScan {
     PrefixScan {
         trie_root_hash: config.trie_root_hash,
+        full_storage_values_required: config.full_storage_values_required,
         next_queries: vec![(
             nibble::bytes_to_nibbles(config.prefix.iter().copied()).collect(),
             QueryTy::Exact,
@@ -60,10 +65,11 @@ pub fn prefix_scan(config: Config<'_>) -> PrefixScan {
 /// Scan of a prefix in progress.
 pub struct PrefixScan {
     trie_root_hash: [u8; 32],
+    full_storage_values_required: bool,
     // TODO: we have lots of Vecs here; maybe find a way to optimize
     next_queries: Vec<(Vec<nibble::Nibble>, QueryTy)>,
     // TODO: we have lots of Vecs here; maybe find a way to optimize
-    final_result: Vec<Vec<u8>>,
+    final_result: Vec<(Vec<u8>, StorageValue)>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -84,6 +90,13 @@ impl PrefixScan {
         &'_ self,
     ) -> impl Iterator<Item = impl Iterator<Item = nibble::Nibble> + '_> + '_ {
         self.next_queries.iter().map(|(l, _)| l.iter().copied())
+    }
+
+    /// Returns whether the storage proof must include the storage values of the requested keys.
+    ///
+    /// > **Note**: This is always equal to [`Config::full_storage_values_required`].
+    pub fn request_storage_values(&self) -> bool {
+        self.full_storage_values_required
     }
 
     /// Injects the proof presumably containing the keys returned by [`PrefixScan::requested_keys`].
@@ -180,6 +193,45 @@ impl PrefixScan {
                     proof_decode::StorageValue::Known { .. }
                         | proof_decode::StorageValue::HashKnownValueMissing(_)
                 ) {
+                    //
+                    let value = match info.storage_value {
+                        proof_decode::StorageValue::HashKnownValueMissing(_)
+                            if self.full_storage_values_required && is_first_iteration =>
+                        {
+                            // Storage values are being explicitly requested, yet the proof
+                            // doesn't include the desired storage value.
+
+                            // Push all the non-processed queries back to `next_queries` before
+                            // returning the error, so that we can try again.
+                            self.next_queries.push((query_key, query_ty));
+                            self.next_queries.extend(non_terminal_queries);
+                            return Err((self, Error::MissingProofEntry));
+                        }
+                        proof_decode::StorageValue::HashKnownValueMissing(_)
+                            if self.full_storage_values_required =>
+                        {
+                            // Proof doesn't contain the storage value, but since we're not at
+                            // the first iteration we know that the key wasn't explicitly
+                            // requested and thus this doesn't constitue an invalid proof.
+                            debug_assert!(!is_first_iteration);
+
+                            // Node not in the proof. There's no point in adding this node to `next`
+                            // as we will fail again if we try to verify the proof again.
+                            // If `is_first_iteration`, it means that the proof is incorrect.
+                            self.next_queries.push((query_key, query_ty));
+                            continue;
+                        }
+                        proof_decode::StorageValue::HashKnownValueMissing(hash) => {
+                            debug_assert!(!self.full_storage_values_required);
+                            StorageValue::Hash(*hash)
+                        }
+                        proof_decode::StorageValue::Known { value, .. } => {
+                            // TODO: considering storing the storage proofs instead of copying individual storage values?
+                            StorageValue::Value(value.to_vec())
+                        }
+                        proof_decode::StorageValue::None => unreachable!(),
+                    };
+
                     // Trie nodes with a value are always aligned to "bytes-keys". In other words,
                     // the number of nibbles is always even.
                     debug_assert_eq!(query_key.len() % 2, 0);
@@ -189,8 +241,8 @@ impl PrefixScan {
                         .collect::<Vec<_>>();
 
                     // Insert in final results, making sure we check for duplicates.
-                    debug_assert!(!self.final_result.iter().any(|n| *n == key));
-                    self.final_result.push(key);
+                    debug_assert!(!self.final_result.iter().any(|(n, _)| *n == key));
+                    self.final_result.push((key, value));
                 }
 
                 // For each child of the node, put into `next` the key that goes towards this
@@ -215,7 +267,7 @@ impl PrefixScan {
             // Finished when nothing more to request.
             if next.is_empty() && self.next_queries.is_empty() {
                 return Ok(ResumeOutcome::Success {
-                    keys: self.final_result,
+                    entries: self.final_result,
                 });
             }
 
@@ -248,9 +300,20 @@ pub enum ResumeOutcome {
     InProgress(PrefixScan),
     /// Scan has succeeded.
     Success {
-        /// List of keys with the requested prefix.
-        keys: Vec<Vec<u8>>,
+        /// List of entries who key starts with the requested prefix.
+        entries: Vec<(Vec<u8>, StorageValue)>,
     },
+}
+
+/// Storage value of a trie entry. See [`ResumeOutcome::Success::entries`].
+#[derive(Debug)]
+pub enum StorageValue {
+    /// Value was found in the proof.
+    Value(Vec<u8>),
+    /// Only the hash of the value was found in the proof.
+    ///
+    /// Never happens if [`Config::full_storage_values_required`] was `true`.
+    Hash([u8; 32]),
 }
 
 /// Possible error returned by [`PrefixScan::resume`].

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -193,7 +193,7 @@ impl PrefixScan {
                     proof_decode::StorageValue::Known { .. }
                         | proof_decode::StorageValue::HashKnownValueMissing(_)
                 ) {
-                    //
+                    // Fetch the storage value of this node.
                     let value = match info.storage_value {
                         proof_decode::StorageValue::HashKnownValueMissing(_)
                             if self.full_storage_values_required && is_first_iteration =>

--- a/lib/src/trie/prefix_proof/tests.rs
+++ b/lib/src/trie/prefix_proof/tests.rs
@@ -14491,6 +14491,7 @@ fn regression_test_174() {
     let mut prefix_scan = prefix_scan(Config {
         prefix: REQUESTED,
         trie_root_hash: STATE_TRIE_ROOT,
+        full_storage_values_required: true,
     });
 
     for proof in PROOFS {
@@ -14499,11 +14500,14 @@ fn regression_test_174() {
                 prefix_scan = scan;
                 continue;
             }
-            Ok(ResumeOutcome::Success { mut keys }) => {
+            Ok(ResumeOutcome::Success { mut entries }) => {
                 let mut expected = EXPECTED.to_owned();
                 expected.sort();
-                keys.sort();
-                assert_eq!(keys, expected);
+                entries.sort_by(|(key1, _), (key2, _)| key1.cmp(&key2));
+                assert_eq!(
+                    entries.into_iter().map(|(key, _)| key).collect::<Vec<_>>(),
+                    expected
+                );
                 return;
             }
             Err((_, err)) => panic!("{err:?}"),

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -473,6 +473,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
         let mut prefix_scan = prefix_proof::prefix_scan(prefix_proof::Config {
             prefix,
             trie_root_hash: *storage_trie_root,
+            full_storage_values_required: false,
         });
 
         'main_scan: loop {
@@ -512,8 +513,9 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                                 prefix_scan = scan;
                                 continue 'main_scan;
                             }
-                            Ok(prefix_proof::ResumeOutcome::Success { keys }) => {
-                                return Ok(keys);
+                            Ok(prefix_proof::ResumeOutcome::Success { entries }) => {
+                                // TODO :overhead
+                                return Ok(entries.into_iter().map(|(key, _)| key).collect());
                             }
                             Err((scan, err)) => {
                                 prefix_scan = scan;


### PR DESCRIPTION
Preliminary step for https://github.com/smol-dot/smoldot/issues/605 and https://github.com/smol-dot/smoldot/issues/131

This PR modifies the `prefix_proof` code to also return the storage values that have been collected during the prefix iteration.
It also adds a new configuration option that allows considering as invalid proofs that only yield the storage value hash when the full value has been requested.
