### PR TITLE
Move "current task" system from client.ts to local-instance.ts

### DIFF
--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -59,12 +59,11 @@ export type Event =
     { ty: "add-chain-result", success: false, error: string } |
     { ty: "log", level: number, target: string, message: string } |
     { ty: "json-rpc-responses-non-empty", chainId: number } |
-    { ty: "current-task", taskName: string | null } |
     // Smoldot has crashed. Note that the public API of the instance can technically still be
     // used, as all functions will start running fallback code. Existing connections are *not*
     // closed. It is the responsibility of the API user to close all connections if they stop
     // using the instance.
-    { ty: "wasm-panic", message: string } |
+    { ty: "wasm-panic", message: string, currentTask: string | null } |
     { ty: "executor-shutdown" } |
     { ty: "new-connection", connectionId: number, address: ParsedMultiaddr } |
     { ty: "connection-reset", connectionId: number } |
@@ -115,7 +114,10 @@ export interface Instance {
 export async function startLocalInstance(config: Config, wasmModule: WebAssembly.Module, eventCallback: (event: Event) => void): Promise<Instance> {
     const state: {
         // Null before initialization and after a panic.
-        instance: SmoldotWasmInstance | null
+        instance: SmoldotWasmInstance | null,
+        // Name of the task currently being executed by smoldot. Used for diagnostics in case of
+        // a panic. `null` if not in a task.
+        currentTask: string | null,
         bufferIndices: Uint8Array[],
         advanceExecutionPromise: null | (() => void),
         stdoutBuffer: string,
@@ -123,6 +125,7 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
         onShutdownExecutorOrWasmPanic: () => void,
     } = {
         instance: null,
+        currentTask: null,
         bufferIndices: new Array(),
         advanceExecutionPromise: null,
         stdoutBuffer: "",
@@ -141,7 +144,7 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             len >>>= 0;
 
             const message = buffer.utf8BytesToString(new Uint8Array(instance.exports.memory.buffer), ptr, len);
-            eventCallback({ ty: "wasm-panic", message });
+            eventCallback({ ty: "wasm-panic", message, currentTask: state.currentTask });
             state.onShutdownExecutorOrWasmPanic();
             state.onShutdownExecutorOrWasmPanic = () => { };
             throw new Error();
@@ -281,11 +284,11 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             len >>>= 0;
 
             const taskName = buffer.utf8BytesToString(new Uint8Array(state.instance!.exports.memory.buffer), ptr, len);
-            eventCallback({ ty: "current-task", taskName });
+            state.currentTask = taskName;
         },
 
         current_task_exit: () => {
-            eventCallback({ ty: "current-task", taskName: null });
+            state.currentTask = null;
         }
     };
 
@@ -411,7 +414,11 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
         // Used by Rust in catastrophic situations, such as a double panic.
         proc_exit: (retCode: number) => {
             state.instance = null;
-            eventCallback({ ty: "wasm-panic", message: `proc_exit called: ${retCode}` });
+            eventCallback({
+                ty: "wasm-panic",
+                message: `proc_exit called: ${retCode}`,
+                currentTask: state.currentTask
+            });
             state.onShutdownExecutorOrWasmPanic();
             state.onShutdownExecutorOrWasmPanic = () => { };
             throw new Error();


### PR DESCRIPTION
Instead of sending tons of `current-task` messages/events, we now immediately process them.
This is not only better in terms of isolation, but also should improve the performance in case of a remote instance, as we currently send tons of these `current-task` messages through the `MessagePort`.
