### PR TITLE
Remove `is_bad_addr` from `connection_new`'s error

### DIFF
--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -238,7 +238,6 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
                 const mem = new Uint8Array(instance.exports.memory.buffer);
                 state.bufferIndices[0] = new TextEncoder().encode(result.error)
                 buffer.writeUInt32LE(mem, errorBufferIndexPtr, 0);
-                buffer.writeUInt8(mem, errorBufferIndexPtr + 4, 1);  // TODO: remove isBadAddress param since it's always true
                 return 1;
             }
         },

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -151,20 +151,20 @@ extern "C" {
     /// The `id` parameter is an identifier for this connection, as chosen by the Rust code. It
     /// must be passed on every interaction with this connection.
     ///
-    /// Returns 0 to indicate success, or 1 to indicate that an error happened. If an error is
-    /// returned, the `id` doesn't correspond to anything.
+    /// Returns 0 to indicate success, or 1 to indicate an error: the multiaddress couldn't be
+    /// parsed or that the protocol isn't supported. If an error is returned, the `id` doesn't
+    /// correspond to anything.
     ///
     /// > **Note**: If you implement this function using for example `new WebSocket()`, please
     /// >           keep in mind that exceptions should be caught and turned into an error code.
     ///
-    /// If an error happened, assign a so-called "buffer index" (a `u32`) representing the buffer
+    /// If 1 is returned, assign a so-called "buffer index" (a `u32`) representing the buffer
     /// containing the UTF-8 error message, then write this buffer index as little-endian to the
     /// memory of the WebAssembly indicated by `error_buffer_index_ptr`. The Rust code will call
     /// [`buffer_size`] and [`buffer_copy`] in order to obtain the content of this buffer. The
     /// buffer index should remain assigned and buffer alive until the next time the JavaScript
-    /// code retains control. Then, write at location `error_buffer_index_ptr + 4` a `1` if the
-    /// error is caused by the address being forbidden or unsupported, and `0` otherwise. If no
-    /// error happens, nothing should be written to `error_buffer_index_ptr`.
+    /// code retains control. If no error happens, nothing should be written to
+    /// `error_buffer_index_ptr`.
     ///
     /// At any time, a connection can be in one of the three following states:
     ///

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -153,14 +153,14 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         let connection_id = lock.next_connection_id;
         lock.next_connection_id += 1;
 
-        let mut error_buffer_index = [0u8; 5];
+        let mut error_buffer_index = [0u8; 4];
 
         let ret_code = unsafe {
             bindings::connection_new(
                 connection_id,
                 u32::try_from(url.as_bytes().as_ptr() as usize).unwrap(),
                 u32::try_from(url.as_bytes().len()).unwrap(),
-                u32::try_from(&mut error_buffer_index as *mut [u8; 5] as usize).unwrap(),
+                u32::try_from(&mut error_buffer_index as *mut [u8; 4] as usize).unwrap(),
             )
         };
 
@@ -170,7 +170,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
             ));
             Err(ConnectError {
                 message: str::from_utf8(&error_message).unwrap().to_owned(),
-                is_bad_addr: error_buffer_index[4] != 0,
+                is_bad_addr: true,
             })
         } else {
             let _prev_value = lock.connections.insert(


### PR DESCRIPTION
After https://github.com/smol-dot/smoldot/pull/529, the implementation of `connection_new` simply parses the multiaddress passed as parameter than notifies the upper layers that a connection must be opened.
If the connection couldn't be opened, the upper layers later call `connection_reset`.

The Rust code properly translates an error in `connection_new` as returning an error where `is_bad_addr: true`, and translates a later call to `connection_reset` as returning an error where `is_bad_addr: false`.

What this PR does is remove the fact that the error returned by `connection_new` can have `is_bad_addr: true`, as this is in practice never the case anymore.
