### PR TITLE
Fix https://github.com/smol-dot/smoldot/issues/794 differently

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix not absorbing the JavaScript exception triggered by the browser when connecting to a `ws://` node when smoldot is embedded in a web page served over `https://`. ([#795](https://github.com/smol-dot/smoldot/pull/795))
+- Fix not absorbing the JavaScript exception triggered by the browser when connecting to a `ws://` node when smoldot is embedded in a web page served over `https://`. ([#795](https://github.com/smol-dot/smoldot/pull/795), [#800](https://github.com/smol-dot/smoldot/pull/800))
 
 ## 1.0.10 - 2023-06-19
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix not absorbing the JavaScript exception triggered by the browser when connecting to a `ws://` node when smoldot is embedded in a web page served over `https://`. ([#795](https://github.com/smol-dot/smoldot/pull/795))
+
 ## 1.0.10 - 2023-06-19
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- Fix not absorbing the JavaScript exception triggered by the browser when connecting to a `ws://` node when smoldot is embedded in a web page served over `https://`. ([#795](https://github.com/smol-dot/smoldot/pull/795))
-
 ## 1.0.10 - 2023-06-19
 
 ### Changed

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -27,7 +27,7 @@ export interface PlatformBindings {
      * Tries to open a new connection using the given configuration.
      *
      * @see Connection
-     * @throws {@link Error}
+     * @throws {@link ConnectionError} If the multiaddress couldn't be parsed or contains an invalid protocol.
      */
     connect(config: ConnectionConfig): Connection;
 
@@ -331,54 +331,40 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
             }
             case "new-connection": {
                 const connectionId = event.connectionId;
-
-                let connection;
-                try {
-                    connection = platformBindings.connect({
-                        address: event.address,
-                        onConnectionReset(message) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.connections.delete(connectionId);
-                            state.instance.instance.connectionReset(connectionId, message);
-                        },
-                        onMessage(message, streamId) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.instance.instance.streamMessage(connectionId, message, streamId);
-                        },
-                        onStreamOpened(streamId, direction, initialWritableBytes) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.instance.instance.streamOpened(connectionId, streamId, direction, initialWritableBytes);
-                        },
-                        onOpen(info) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.instance.instance.connectionOpened(connectionId, info);
-                        },
-                        onWritableBytes(numExtra, streamId) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.instance.instance.streamWritableBytes(connectionId, numExtra, streamId);
-                        },
-                        onStreamReset(streamId) {
-                            if (state.instance.status !== "ready")
-                                throw new Error();
-                            state.instance.instance.streamReset(connectionId, streamId);
-                        },
-                    });
-
-                } catch(error) {
-                    const errorMsg = error instanceof Error ? error.toString() : "Uncaught exception while connecting";
-                    setTimeout(() => {
-                        if (state.instance.status === 'ready')
-                            state.instance.instance.connectionReset(connectionId, errorMsg);
-                    }, 0);
-                    break;
-                }
-
-                state.connections.set(connectionId, connection);
+                state.connections.set(connectionId, platformBindings.connect({
+                    address: event.address,
+                    onConnectionReset(message) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.connections.delete(connectionId);
+                        state.instance.instance.connectionReset(connectionId, message);
+                    },
+                    onMessage(message, streamId) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.instance.instance.streamMessage(connectionId, message, streamId);
+                    },
+                    onStreamOpened(streamId, direction, initialWritableBytes) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.instance.instance.streamOpened(connectionId, streamId, direction, initialWritableBytes);
+                    },
+                    onOpen(info) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.instance.instance.connectionOpened(connectionId, info);
+                    },
+                    onWritableBytes(numExtra, streamId) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.instance.instance.streamWritableBytes(connectionId, numExtra, streamId);
+                    },
+                    onStreamReset(streamId) {
+                        if (state.instance.status !== "ready")
+                            throw new Error();
+                        state.instance.instance.streamReset(connectionId, streamId);
+                    },
+                }));
                 break;
             }
             case "connection-reset": {

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -27,7 +27,6 @@ export interface PlatformBindings {
      * Tries to open a new connection using the given configuration.
      *
      * @see Connection
-     * @throws {@link ConnectionError} If the multiaddress couldn't be parsed or contains an invalid protocol.
      */
     connect(config: ConnectionConfig): Connection;
 

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -81,6 +81,9 @@ export function startWithBytecode(options: ClientOptionsWithBytecode): Client {
  */
 function connect(config: ConnectionConfig): Connection {
     if (config.address.ty === "websocket") {
+        // Even though the WHATWG specification (<https://websockets.spec.whatwg.org/#dom-websocket-websocket>)
+        // doesn't mention it, `new WebSocket` can throw an exception if the URL is forbidden
+        // for security reasons. We absord this exception as soon as it is thrown.
         // `connection` can be either a `WebSocket` object (the normal case), or a string
         // indicating an error message that must be propagated with `onConnectionReset` as soon
         // as possible, or `null` if the API user considers the connection as reset.

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -81,11 +81,20 @@ export function startWithBytecode(options: ClientOptionsWithBytecode): Client {
  */
 function connect(config: ConnectionConfig): Connection {
     if (config.address.ty === "websocket") {
-        const connection = new WebSocket(config.address.url);
-        connection.binaryType = 'arraybuffer';
+        // `connection` can be either a `WebSocket` object (the normal case), or a string
+        // indicating an error message that must be propagated with `onConnectionReset` as soon
+        // as possible, or `null` if the API user considers the connection as reset.
+        let connection: WebSocket | string | null;
+        try {
+            connection = new WebSocket(config.address.url);
+        } catch(error) {
+            connection = error instanceof Error ? error.toString() : "Exception thrown by new WebSocket";
+        }
 
         const bufferedAmountCheck = { quenedUnreportedBytes: 0, nextTimeout: 10 };
         const checkBufferedAmount = () => {
+            if (!(connection instanceof WebSocket))
+                return;
             if (connection.readyState != 1)
                 return;
             // Note that we might expect `bufferedAmount` to always be <= the sum of the lengths
@@ -107,31 +116,46 @@ function connect(config: ConnectionConfig): Connection {
                 config.onWritableBytes(wasSent);
         };
 
-        connection.onopen = () => {
-            config.onOpen({
-                type: 'single-stream', handshake: 'multistream-select-noise-yamux',
-                initialWritableBytes: 1024 * 1024, writeClosable: false,
-            });
-        };
-        connection.onclose = (event) => {
-            const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
-            config.onConnectionReset(message);
-        };
-        connection.onmessage = (msg) => {
-            config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
-        };
+        if (connection instanceof WebSocket) {
+            connection.binaryType = 'arraybuffer';
+
+            connection.onopen = () => {
+                config.onOpen({
+                    type: 'single-stream', handshake: 'multistream-select-noise-yamux',
+                    initialWritableBytes: 1024 * 1024, writeClosable: false,
+                });
+            };
+            connection.onclose = (event) => {
+                const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
+                config.onConnectionReset(message);
+            };
+            connection.onmessage = (msg) => {
+                config.onMessage(new Uint8Array(msg.data as ArrayBuffer));
+            };
+        } else {
+            setTimeout(() => {
+                if (connection && !(connection instanceof WebSocket)) {
+                    config.onConnectionReset(connection);
+                    connection = null;
+                }
+            }, 1)
+        }
 
         return {
             reset: (): void => {
-                connection.onopen = null;
-                connection.onclose = null;
-                connection.onmessage = null;
-                connection.onerror = null;
-                connection.close();
+                if (connection instanceof WebSocket) {
+                    connection.onopen = null;
+                    connection.onclose = null;
+                    connection.onmessage = null;
+                    connection.onerror = null;
+                    connection.close();
+                }
+
+                connection = null;
             },
 
             send: (data: Uint8Array): void => {
-                connection.send(data);
+                (connection as WebSocket).send(data);
                 if (bufferedAmountCheck.quenedUnreportedBytes == 0) {
                     bufferedAmountCheck.nextTimeout = 10;
                     setTimeout(checkBufferedAmount, 10);


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/797 https://github.com/smol-dot/smoldot/issues/794

It turns out that https://github.com/smol-dot/smoldot/pull/795 isn't correct, because during the time before the timeout of `setTimeout` is invoked it is possible for smoldot to interrupt the connection.

I initially thought about fixing this in `client.ts`, however I think that it is better to not rely on exceptions altogether as they're an overcomplicated mechanism. Instead, exceptions should be absorbed as close as possible to where they are thrown.
