### PR TITLE
Fix connections being reset when they're already reset

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix not absorbing the JavaScript exception triggered by the browser when connecting to a `ws://` node when smoldot is embedded in a web page served over `https://`. ([#795](https://github.com/smol-dot/smoldot/pull/795))
+- Fix potential panic due to race condition when smoldot wants to abort connecting to a peer that we have just failed connecting to. ([#801](https://github.com/smol-dot/smoldot/pull/801))
 
 ## 1.0.10 - 2023-06-19
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -584,13 +584,7 @@ impl Drop for StreamWrapper {
                 ..
             } => {
                 *connection_handles_alive -= 1;
-                let remove_connection = *connection_handles_alive == 0;
-                if remove_connection {
-                    unsafe {
-                        bindings::reset_connection(self.connection_id);
-                    }
-                }
-                remove_connection
+                *connection_handles_alive == 0
             }
         };
 


### PR DESCRIPTION
This is a really stupid mistake, and this code should really be rewritten as the `TODO` in this module says should be done.