### PR TITLE
Simplify chain-head-related function implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "event-listener",
  "fnv",
  "futures-channel",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.0",
  "hex",

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -20,6 +20,7 @@ either = { version = "1.8.1", default-features = false }
 event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
 futures-channel = { version = "0.3.27", features = ["std", "sink"] }   # TODO: no-std-ize and remove "sink"
+futures-lite = { version = "1.13.0", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.27", default-features = false, features = ["std", "async-await", "async-await-macro", "channel", "sink"] }  # TODO: slim down these features
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -508,6 +508,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     }
                 });
                 let next_message = pin::pin!(messages_rx.next());
+                // TODO: doesn't check for unsubscription /!\
 
                 match future::select(next_block, next_message).await {
                     future::Either::Left((v, _)) => either::Left(v),

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -795,7 +795,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     // unsubscribes.
                     let outcome = match future
                         .map(Some)
-                        .race(subscription.wait_until_stale().map(|()| None))
+                        .or(subscription.wait_until_stale().map(|()| None))
                         .await
                     {
                         Some(v) => v,
@@ -944,7 +944,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     // unsubscribes.
                     let outcome = match future
                         .map(Some)
-                        .race(subscription.wait_until_stale().map(|()| None))
+                        .or(subscription.wait_until_stale().map(|()| None))
                         .await
                     {
                         Some(v) => v,
@@ -1090,7 +1090,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     );
 
                     // Drive the future, but cancel execution if the JSON-RPC client unsubscribes.
-                    match call_future.map(Some).race(subscription.wait_until_stale().map(|()| None)).await {
+                    match call_future.map(Some).or(subscription.wait_until_stale().map(|()| None)).await {
                         Some(v) => v,
                         None => return  // JSON-RPC client has unsubscribed in the meanwhile.
                     }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -430,28 +430,6 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             request.respond(methods::Response::chainHead_unstable_unpin(()));
         }
     }
-
-    /// Handles a call to [`methods::MethodCall::chainHead_unstable_finalizedDatabase`].
-    pub(super) async fn chain_head_unstable_finalized_database(
-        self: &Arc<Self>,
-        request: service::RequestProcess,
-    ) {
-        let methods::MethodCall::chainHead_unstable_finalizedDatabase { max_size_bytes } = request.request()
-            else { unreachable!() };
-
-        let response = crate::database::encode_database(
-            &self.network_service.0,
-            &self.sync_service,
-            &self.genesis_block_hash,
-            usize::try_from(max_size_bytes.unwrap_or(u64::max_value()))
-                .unwrap_or(usize::max_value()),
-        )
-        .await;
-
-        request.respond(methods::Response::chainHead_unstable_finalizedDatabase(
-            response.into(),
-        ));
-    }
 }
 
 fn convert_runtime_spec(

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -187,4 +187,26 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             (&self.system_version).into(),
         ));
     }
+
+    /// Handles a call to [`methods::MethodCall::chainHead_unstable_finalizedDatabase`].
+    pub(super) async fn chain_head_unstable_finalized_database(
+        self: &Arc<Self>,
+        request: service::RequestProcess,
+    ) {
+        let methods::MethodCall::chainHead_unstable_finalizedDatabase { max_size_bytes } = request.request()
+            else { unreachable!() };
+
+        let response = crate::database::encode_database(
+            &self.network_service.0,
+            &self.sync_service,
+            &self.genesis_block_hash,
+            usize::try_from(max_size_bytes.unwrap_or(u64::max_value()))
+                .unwrap_or(usize::max_value()),
+        )
+        .await;
+
+        request.respond(methods::Response::chainHead_unstable_finalizedDatabase(
+            response.into(),
+        ));
+    }
 }


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/605 https://github.com/smol-dot/smoldot/issues/798

This PR significantly simplifies the implementations of the various `chainHead` functions, notably by removing duplicate information and using early returns.

This is now possible thanks to https://github.com/smol-dot/smoldot/pull/793.

I'm still not happy with the complexity of the main implementation of `chainHead_follow`, but this PR is a big enough step that it's worth merging.
