### PR TITLE
Fix and clarify the JSON-RPC queue full behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,6 @@ name = "smoldot"
 version = "0.8.0"
 dependencies = [
  "arrayvec 0.7.4",
- "async-channel",
  "async-lock",
  "atomic-take",
  "base64 0.21.2",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,7 +36,6 @@ wasmtime = [
 # theoretically be `no_std`-compatible (i.e. doesn't need the help of the operating system) but is
 # not, or if things are sketchy, please leave a comment next to it.
 arrayvec = { version = "0.7.3", default-features = false }
-async-channel = { version = "1.8.0", default-features = false }  # TODO: no-std-ize; this is has been done and is just waiting for a release: https://github.com/smol-rs/event-listener/pull/34
 async-lock = { version = "2.7.0", default-features = false }  # TODO: no-std-ize; this is has been done and is just waiting for a release: https://github.com/smol-rs/event-listener/pull/34
 atomic-take = { version = "1.1.0" }
 base64 = { version = "0.21.2", default-features = false, features = ["alloc"] }

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -23,14 +23,14 @@ use alloc::{
     boxed::Box,
     collections::VecDeque,
     string::{String, ToString as _},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 use async_lock::Mutex;
 use core::{
     cmp, fmt, mem,
     num::{NonZeroU32, NonZeroUsize},
     ptr,
-    sync::atomic::{AtomicPtr, Ordering},
+    sync::atomic::{AtomicPtr, AtomicU32, Ordering},
     task::Poll,
 };
 use futures_channel::mpsc;
@@ -61,15 +61,6 @@ struct Inner {
     // TODO: better strategy than just integers?
     next_subscription_id: u64,
 
-    /// Number of requests that have have been received from the client but whose answer hasn't
-    /// been sent back to the client yet. Includes requests whose response is in
-    /// [`Inner::pending_serialized_responses`].
-    num_requests_in_fly: u32,
-    /// Maximum value that [`Inner::num_requests_in_fly`] is allowed to reach. Beyond this, the
-    /// [`Inner::serialized_rq_receiver`] is back-pressured in order to not receive any more
-    /// request.
-    max_requests_in_fly: NonZeroU32,
-
     /// List of all active subscriptions. Keys are subscription IDs.
     ///
     /// Given that the subscription IDs are allocated locally, there is no harm in using a
@@ -81,14 +72,32 @@ struct Inner {
     /// subscription start requests are automatically denied.
     max_active_subscriptions: u32,
 
-    /// Channel connected to the [`SerializedRequestsIo`]. The requests received are guaranteed to
-    /// be a valid request JSON, but not necessarily to use a known method.
-    serialized_rq_receiver: async_channel::Receiver<String>,
+    /// Structure shared with the [`SerializedRequestsIo`]. The requests received are guaranteed
+    /// to be a valid request JSON, but not necessarily to use a known method.
+    serialized_requests_queue: Arc<SerializedRequestsQueue>,
     /// Channel connected to the [`SerializedRequestsIo`].
     serialized_rp_sender: mpsc::Sender<String>,
 
     /// Queue where responses and subscriptions push responses/notifications.
     responses_notifications_queue: Arc<ResponsesNotificationsQueue>,
+}
+
+struct SerializedRequestsQueue {
+    /// The actual queue.
+    queue: crossbeam_queue::SegQueue<String>,
+
+    /// Event notified after an element from [`SerializedRequestsQueue::queue`] has been pushed.
+    on_pushed: event_listener::Event,
+
+    /// Number of requests that have have been received from the client but whose answer hasn't
+    /// been sent back to the client yet. Includes requests whose response is in
+    /// [`Inner::pending_serialized_responses`].
+    num_requests_in_fly: AtomicU32,
+
+    /// Maximum value that [`Inner::num_requests_in_fly`] is allowed to reach. Beyond this, the
+    /// [`Inner::serialized_rq_receiver`] is back-pressured in order to not receive any more
+    /// request.
+    max_requests_in_fly: NonZeroU32,
 }
 
 /// Queue where responses and subscriptions push responses/notifications.
@@ -137,8 +146,6 @@ pub struct Config {
 
 /// Creates a new [`ClientMainTask`] and a [`SerializedRequestsIo`] connected to it.
 pub fn client_main_task(config: Config) -> (ClientMainTask, SerializedRequestsIo) {
-    let (serialized_rq_sender, serialized_rq_receiver) =
-        async_channel::bounded(config.serialized_requests_io_channel_size_hint.get());
     let (serialized_rp_sender, serialized_rp_receiver) =
         mpsc::channel(config.serialized_requests_io_channel_size_hint.get());
 
@@ -156,8 +163,6 @@ pub fn client_main_task(config: Config) -> (ClientMainTask, SerializedRequestsIo
             )),
             pending_serialized_responses: Slab::with_capacity(cmp::min(64, buffers_capacity)),
             next_subscription_id: 1,
-            num_requests_in_fly: 0,
-            max_requests_in_fly: config.max_pending_requests,
             active_subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
                 cmp::min(
                     usize::try_from(config.max_active_subscriptions).unwrap_or(usize::max_value()),
@@ -166,7 +171,12 @@ pub fn client_main_task(config: Config) -> (ClientMainTask, SerializedRequestsIo
                 Default::default(),
             ),
             max_active_subscriptions: config.max_active_subscriptions,
-            serialized_rq_receiver,
+            serialized_requests_queue: Arc::new(SerializedRequestsQueue {
+                queue: crossbeam_queue::SegQueue::new(),
+                on_pushed: event_listener::Event::new(),
+                num_requests_in_fly: AtomicU32::new(0),
+                max_requests_in_fly: config.max_pending_requests,
+            }),
             serialized_rp_sender,
             responses_notifications_queue: Arc::new(ResponsesNotificationsQueue {
                 queue: crossbeam_queue::SegQueue::new(),
@@ -178,7 +188,7 @@ pub fn client_main_task(config: Config) -> (ClientMainTask, SerializedRequestsIo
     };
 
     let serialized_requests_io = SerializedRequestsIo {
-        requests_sender: serialized_rq_sender,
+        serialized_requests_queue: Arc::downgrade(&task.inner.serialized_requests_queue),
         responses_receiver: Mutex::new(serialized_rp_receiver),
     };
 
@@ -204,12 +214,19 @@ impl ClientMainTask {
                     }
                 });
 
-                let next_serialized_request =
-                    if self.inner.num_requests_in_fly < self.inner.max_requests_in_fly.get() {
-                        either::Left(self.inner.serialized_rq_receiver.next())
-                    } else {
-                        either::Right(future::pending())
-                    };
+                let next_serialized_request = async {
+                    let mut wait = None;
+                    loop {
+                        if let Some(elem) = self.inner.serialized_requests_queue.queue.pop() {
+                            break elem;
+                        }
+                        if let Some(wait) = wait.take() {
+                            wait.await
+                        } else {
+                            wait = Some(self.inner.serialized_requests_queue.on_pushed.listen());
+                        }
+                    }
+                };
 
                 let response_notif = async {
                     let mut wait = None;
@@ -227,7 +244,7 @@ impl ClientMainTask {
                 };
 
                 match future::select(
-                    future::select(when_ready_to_send, next_serialized_request),
+                    future::select(when_ready_to_send, core::pin::pin!(next_serialized_request)),
                     core::pin::pin!(response_notif),
                 )
                 .await
@@ -238,11 +255,8 @@ impl ClientMainTask {
                     future::Either::Left((future::Either::Left((Err(_), _)), _)) => {
                         return Event::SerializedRequestsIoClosed
                     }
-                    future::Either::Left((future::Either::Right((Some(request), _)), _)) => {
+                    future::Either::Left((future::Either::Right((request, _)), _)) => {
                         WhatHappened::NewRequest(request)
-                    }
-                    future::Either::Left((future::Either::Right((None, _)), _)) => {
-                        return Event::SerializedRequestsIoClosed
                     }
                     future::Either::Right((message, _)) => WhatHappened::Message(message),
                 }
@@ -270,8 +284,12 @@ impl ClientMainTask {
                         .start_send(response_or_notif);
 
                     if is_response {
-                        debug_assert!(self.inner.num_requests_in_fly >= 1);
-                        self.inner.num_requests_in_fly -= 1;
+                        let _prev_val = self
+                            .inner
+                            .serialized_requests_queue
+                            .num_requests_in_fly
+                            .fetch_sub(1, Ordering::Release);
+                        debug_assert_ne!(_prev_val, u32::max_value()); // Check underflows.
                     }
 
                     // Shrink containers if necessary in order to reduce memory usage after a
@@ -299,13 +317,7 @@ impl ClientMainTask {
 
                     continue;
                 }
-                WhatHappened::NewRequest(request) => {
-                    self.inner.num_requests_in_fly += 1;
-                    debug_assert!(
-                        self.inner.num_requests_in_fly <= self.inner.max_requests_in_fly.get()
-                    );
-                    request
-                }
+                WhatHappened::NewRequest(request) => request,
                 WhatHappened::Message(ToMainTask::RequestResponse(response)) => {
                     let pos = self
                         .inner
@@ -729,8 +741,8 @@ pub enum Event {
 /// Object connected to the [`ClientMainTask`] that allows sending requests to the task and
 /// receiving responses.
 pub struct SerializedRequestsIo {
-    // TODO: instead of using channels we could do things manually, which would lead to less waker registrations
-    requests_sender: async_channel::Sender<String>,
+    serialized_requests_queue: Weak<SerializedRequestsQueue>,
+    // TODO: instead of using a channel we could do things manually, which would lead to less waker registrations
     responses_receiver: Mutex<mpsc::Receiver<String>>,
 }
 
@@ -768,17 +780,37 @@ impl SerializedRequestsIo {
             });
         }
 
-        match self.requests_sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(async_channel::TrySendError::Full(request)) => Err(TrySendRequestError {
+        let Some(queue) = self.serialized_requests_queue.upgrade()
+            else {
+                return Err(TrySendRequestError {
+                    request,
+                    cause: TrySendRequestErrorCause::ClientMainTaskDestroyed,
+                });
+            };
+
+        // Try to increment `num_requests_in_fly`. Returns an error if it is past the maximum.
+        if queue
+            .num_requests_in_fly
+            .fetch_update(Ordering::SeqCst, Ordering::Relaxed, |old_value| {
+                if old_value < queue.max_requests_in_fly.get() {
+                    // Considering that `old_value < max`, and `max` fits in a `u32` by
+                    // definition, then `old_value + 1` also always fits in a `u32`. QED.
+                    // There's no risk of overflow.
+                    Some(old_value + 1)
+                } else {
+                    None
+                }
+            })
+            .is_err()
+        {
+            return Err(TrySendRequestError {
                 request,
-                cause: TrySendRequestErrorCause::QueueFull,
-            }),
-            Err(async_channel::TrySendError::Closed(request)) => Err(TrySendRequestError {
-                request,
-                cause: TrySendRequestErrorCause::ClientMainTaskDestroyed,
-            }),
+                cause: TrySendRequestErrorCause::TooManyRequestInFly,
+            });
         }
+
+        queue.queue.push(request);
+        Ok(())
     }
 }
 
@@ -811,8 +843,10 @@ pub enum TrySendRequestErrorCause {
     /// Data is not JSON, or JSON is missing or has invalid fields.
     #[display(fmt = "{_0}")]
     MalformedJson(ParseError),
-    /// Queue of JSON-RPC requests to the [`ClientMainTask`] is full.
-    QueueFull,
+    /// Limit to the maximum number of pending requests that was passed as
+    /// [`Config::max_pending_requests`] has been reached. No more requests can be sent before
+    /// some responses have been pulled.
+    TooManyRequestInFly,
     /// The attached [`ClientMainTask`] has been destroyed.
     ClientMainTaskDestroyed,
 }

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -182,9 +182,9 @@ impl Frontend {
         {
             Ok(()) => Ok(()),
             Err(service::TrySendRequestError {
-                cause: service::TrySendRequestErrorCause::QueueFull,
+                cause: service::TrySendRequestErrorCause::TooManyRequestInFly,
                 request,
-            }) => Err(HandleRpcError::Overloaded {
+            }) => Err(HandleRpcError::TooManyPendingRequests {
                 json_rpc_request: request,
             }),
             Err(service::TrySendRequestError {
@@ -318,11 +318,12 @@ impl ServicePrototype {
 /// Error potentially returned when queuing a JSON-RPC request.
 #[derive(Debug, derive_more::Display)]
 pub enum HandleRpcError {
-    /// The JSON-RPC service cannot process this request, as it is already too busy.
+    /// The JSON-RPC service cannot process this request, as too many requests are already being
+    /// processed.
     #[display(
-        fmt = "The JSON-RPC service cannot process this request, as it is already too busy."
+        fmt = "The JSON-RPC service cannot process this request, as too many requests are already being processed."
     )]
-    Overloaded {
+    TooManyPendingRequests {
         /// Request that was being queued.
         json_rpc_request: String,
     },
@@ -338,7 +339,7 @@ impl HandleRpcError {
     /// notification.
     pub fn into_json_rpc_error(self) -> Option<String> {
         let json_rpc_request = match self {
-            HandleRpcError::Overloaded { json_rpc_request } => json_rpc_request,
+            HandleRpcError::TooManyPendingRequests { json_rpc_request } => json_rpc_request,
             HandleRpcError::MalformedJsonRpc(_) => return None,
         };
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -147,6 +147,8 @@ pub enum AddChainConfigJsonRpc {
         ///
         /// This parameter is necessary in order to prevent JSON-RPC clients from using up too
         /// much memory within the client.
+        /// If the JSON-RPC client is entirely trusted, then passing `u32::max_value()` is
+        /// completely reasonable.
         ///
         /// A typical value is 128.
         max_pending_requests: NonZeroU32,
@@ -158,6 +160,8 @@ pub enum AddChainConfigJsonRpc {
         ///
         /// This parameter is necessary in order to prevent JSON-RPC clients from using up too
         /// much memory within the client.
+        /// If the JSON-RPC client is entirely trusted, then passing `u32::max_value()` is
+        /// completely reasonable.
         ///
         /// While a typical reasonable value would be for example 64, existing UIs tend to start
         /// a lot of subscriptions, and a value such as 1024 is recommended.
@@ -962,9 +966,15 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
     /// Since most JSON-RPC requests can only be answered asynchronously, the request is only
     /// queued and will be decoded and processed later.
     ///
-    /// Returns an error if the node is overloaded and is capable of processing more JSON-RPC
-    /// requests before some time has passed or the [`AddChainSuccess::json_rpc_responses`]
-    /// stream is emptied.
+    /// Returns an error if the number of requests that have been sent but whose answer hasn't been
+    /// pulled with [`JsonRpcResponses::next`] is superior or equal to the value that was passed
+    /// through [`AddChainConfigJsonRpc::Enabled::max_pending_requests`]. In that situation, the
+    /// API user is encouraged to stop sending requests and start pulling answers with
+    /// [`JsonRpcResponses::next`].
+    ///
+    /// Passing `u32::max_value()` to [`AddChainConfigJsonRpc::Enabled::max_pending_requests`] is
+    /// a good way to avoid errors here, but this should only be done if the JSON-RPC client is
+    /// trusted.
     ///
     /// Also returns an error if the request could not be parsed as a valid JSON-RPC request, as
     /// in that situation smoldot is unable to send back a corresponding JSON-RPC error message.

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -407,8 +407,7 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 /// This function returns:
 /// - 0 on success.
 /// - 1 if the request couldn't be parsed as a valid JSON-RPC request.
-/// - 2 if the chain is currently overloaded with JSON-RPC requests and refuses to queue another
-/// one.
+/// - 2 if the chain has too many pending JSON-RPC requests and refuses to queue another one.
 ///
 #[no_mangle]
 pub extern "C" fn json_rpc_send(text_buffer_index: u32, chain_id: u32) -> u32 {

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -246,7 +246,7 @@ fn json_rpc_send(json_rpc_request: Vec<u8>, chain_id: u32) -> u32 {
     {
         Ok(()) => 0,
         Err(HandleRpcError::MalformedJsonRpc(_)) => 1,
-        Err(HandleRpcError::Overloaded { .. }) => 2,
+        Err(HandleRpcError::TooManyPendingRequests { .. }) => 2,
     }
 }
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/804

This fixes a change in behavior that was accidentally introduced in https://github.com/smol-dot/smoldot/pull/793, and clarifies everywhere that "queue full" means "maximum number of pending requests reached".

---

cc @lexnv and maybe @skunert 

This PR changes nothing compared to the previously released version (it fixes a bug in a PR made yesterday), but clarifies that the "queue full" error potentially returned by `json_rpc_request` simply means that `Config::max_pending_requests` has been reached.

For your specific use case, passing `max_pending_requests: u32::max_value()` (and same for the max subscriptions option) is the most appropriate.
