### PR TITLE
Improve the memory zeroing story of keystore.rs and seed_phrase.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "wasmi",
  "wasmtime",
  "wat",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "smol",
  "smoldot",
  "terminal_size",
+ "zeroize",
 ]
 
 [[package]]

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -35,3 +35,4 @@ siphasher = { version = "0.3.10", default-features = false }
 smol = "1.3.0"
 smoldot = { version = "0.8.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.2.6"
+zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }

--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -75,7 +75,7 @@ pub struct CliOptionsRun {
     pub color: ColorChoice,
     /// Ed25519 private key of network identity (as a seed phrase).
     #[arg(long, value_parser = decode_ed25519_private_key)]
-    pub libp2p_key: Option<[u8; 32]>,
+    pub libp2p_key: Option<Box<[u8; 32]>>,
     /// `Multiaddr` to listen on.
     #[arg(long, value_parser = decode_multiaddr)]
     pub listen_addr: Vec<Multiaddr>,
@@ -88,7 +88,7 @@ pub struct CliOptionsRun {
     /// List of secret phrases to insert in the keystore of the node. Used to author blocks.
     #[arg(long, value_parser = decode_sr25519_private_key)]
     // TODO: also automatically add the same keys through ed25519?
-    pub keystore_memory: Vec<[u8; 64]>,
+    pub keystore_memory: Vec<Box<[u8; 64]>>,
     /// Address of a Jaeger agent to send traces to (hint: port is typically 6831).
     #[arg(long)]
     pub jaeger: Option<SocketAddr>,
@@ -293,10 +293,10 @@ fn parse_max_bytes(string: &str) -> Result<MaxBytes, String> {
 
 // `clap` requires error types to implement the `std::error::Error` trait.
 // For this reason, we locally define some wrappers.
-fn decode_ed25519_private_key(phrase: &str) -> Result<[u8; 32], String> {
+fn decode_ed25519_private_key(phrase: &str) -> Result<Box<[u8; 32]>, String> {
     seed_phrase::decode_ed25519_private_key(phrase).map_err(|err| err.to_string())
 }
-fn decode_sr25519_private_key(phrase: &str) -> Result<[u8; 64], String> {
+fn decode_sr25519_private_key(phrase: &str) -> Result<Box<[u8; 64]>, String> {
     seed_phrase::decode_sr25519_private_key(phrase).map_err(|err| err.to_string())
 }
 fn decode_multiaddr(addr: &str) -> Result<Multiaddr, String> {

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -277,20 +277,25 @@ async fn run(cli_options: cli::CliOptionsRun) {
     // Determine which networking key to use.
     //
     // This is either passed as a CLI option, loaded from disk, or generated randomly.
-    let libp2p_key = if let Some(node_key) = &cli_options.libp2p_key {
-        *node_key
+    let libp2p_key = if let Some(node_key) = cli_options.libp2p_key {
+        node_key
     } else if let Some(dir) = base_storage_directory.as_ref() {
         let path = dir.join("libp2p_ed25519_secret_key.secret");
         let libp2p_key = if path.exists() {
-            let file_content =
-                fs::read_to_string(&path).expect("failed to read libp2p secret key file content");
-            let hex_decoded =
-                hex::decode(file_content).expect("invalid libp2p secret key file content");
-            <[u8; 32]>::try_from(hex_decoded).expect("invalid libp2p secret key file content")
+            let file_content = zeroize::Zeroizing::new(
+                fs::read_to_string(&path).expect("failed to read libp2p secret key file content"),
+            );
+            let mut hex_decoded = Box::new([0u8; 32]);
+            hex::decode_to_slice(file_content, &mut *hex_decoded)
+                .expect("invalid libp2p secret key file content");
+            hex_decoded
         } else {
-            let actual_key: [u8; 32] = rand::random();
-            fs::write(&path, hex::encode(actual_key))
-                .expect("failed to write libp2p secret key file");
+            let mut actual_key = Box::new([0u8; 32]);
+            rand::Fill::try_fill(&mut *actual_key, &mut rand::thread_rng()).unwrap();
+            let mut hex_encoded = Box::new([0; 64]);
+            hex::encode_to_slice(&*actual_key, &mut *hex_encoded).unwrap();
+            fs::write(&path, &*hex_encoded).expect("failed to write libp2p secret key file");
+            zeroize::Zeroize::zeroize(&mut *hex_encoded);
             actual_key
         };
         // On Unix platforms, set the permission as 0o400 (only reading and by owner is permitted).
@@ -299,7 +304,9 @@ async fn run(cli_options: cli::CliOptionsRun) {
         let _ = fs::set_permissions(&path, std::os::unix::fs::PermissionsExt::from_mode(0o400));
         libp2p_key
     } else {
-        rand::random()
+        let mut key = Box::new([0u8; 32]);
+        rand::Fill::try_fill(&mut *key, &mut rand::thread_rng()).unwrap();
+        key
     };
 
     // Create an executor where tasks are going to be spawned onto.

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -277,6 +277,7 @@ async fn run(cli_options: cli::CliOptionsRun) {
     // Determine which networking key to use.
     //
     // This is either passed as a CLI option, loaded from disk, or generated randomly.
+    // TODO: move this code to `/lib/src/identity`?
     let libp2p_key = if let Some(node_key) = cli_options.libp2p_key {
         node_key
     } else if let Some(dir) = base_storage_directory.as_ref() {

--- a/full-node/tests/author.rs
+++ b/full-node/tests/author.rs
@@ -33,7 +33,7 @@ fn basic_block_generated() {
                 keystore_path: None,
             },
             relay_chain: None,
-            libp2p_key: [0; 32],
+            libp2p_key: Box::new([0; 32]),
             listen_addresses: Vec::new(),
             json_rpc_address: None,
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -78,6 +78,7 @@ snow = { version = "0.9.2", default-features = false, features = ["default-resol
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 twox-hash = { version = "1.6.3", default-features = false }
 wasmi = { version = "0.30.0", default-features = false }
+zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # `database-sqlite` feature
 rusqlite = { version = "0.29.0", optional = true, default-features = false, features = ["bundled"] }

--- a/lib/src/identity/seed_phrase.rs
+++ b/lib/src/identity/seed_phrase.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use zeroize::Zeroize as _;
 
 // TODO: unclear what purpose soft derivations serve

--- a/lib/src/identity/seed_phrase.rs
+++ b/lib/src/identity/seed_phrase.rs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use alloc::{string::String, vec::Vec};
+use zeroize::Zeroize as _;
 
 // TODO: unclear what purpose soft derivations serve
 
@@ -27,12 +28,16 @@ pub const DEFAULT_SEED_PHRASE: &str =
     "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
 
 /// Decodes a human-readable private key (a.k.a. a seed phrase) using the Sr25519 curve.
-pub fn decode_sr25519_private_key(phrase: &str) -> Result<[u8; 64], ParsePrivateKeyError> {
+///
+/// > **Note**: The key is returned within a `Box` in order to guarantee that no trace of the
+/// >           secret key is accidentally left in memory due to automatic copies of stack data.
+pub fn decode_sr25519_private_key(phrase: &str) -> Result<Box<[u8; 64]>, ParsePrivateKeyError> {
     let parsed = parse_private_key(phrase)?;
 
     // Note: `from_bytes` can only panic if the slice is of the wrong length, which we know can
     // never happen.
-    let mini_key = schnorrkel::MiniSecretKey::from_bytes(&parsed.seed).unwrap();
+    let mini_key =
+        zeroize::Zeroizing::new(schnorrkel::MiniSecretKey::from_bytes(&*parsed.seed).unwrap());
 
     let mut secret_key = mini_key
         .expand_to_keypair(schnorrkel::ExpansionMode::Ed25519)
@@ -49,11 +54,18 @@ pub fn decode_sr25519_private_key(phrase: &str) -> Result<[u8; 64], ParsePrivate
         };
     }
 
-    Ok(secret_key.to_bytes())
+    // TODO: unclear if the zeroizing works, we probably need some tweaks in the schnorrkel library
+    let bytes = zeroize::Zeroizing::new(secret_key.to_bytes());
+    let mut out = Box::new([0; 64]);
+    out.copy_from_slice(bytes.as_ref());
+    Ok(out)
 }
 
 /// Decodes a human-readable private key (a.k.a. a seed phrase) using the Ed25519 curve.
-pub fn decode_ed25519_private_key(phrase: &str) -> Result<[u8; 32], ParsePrivateKeyError> {
+///
+/// > **Note**: The key is returned within a `Box` in order to guarantee that no trace of the
+/// >           secret key is accidentally left in memory due to automatic copies of stack data.
+pub fn decode_ed25519_private_key(phrase: &str) -> Result<Box<[u8; 32]>, ParsePrivateKeyError> {
     let parsed = parse_private_key(phrase)?;
 
     let mut secret_key = parsed.seed;
@@ -64,9 +76,13 @@ pub fn decode_ed25519_private_key(phrase: &str) -> Result<[u8; 32], ParsePrivate
                 let mut hash = blake2_rfc::blake2b::Blake2b::new(32);
                 hash.update(crate::util::encode_scale_compact_usize(11).as_ref()); // Length of `"Ed25519HDKD"`
                 hash.update(b"Ed25519HDKD");
-                hash.update(&secret_key);
+                hash.update(&*secret_key);
                 hash.update(&cc);
-                <[u8; 32]>::try_from(hash.finalize().as_bytes()).unwrap()
+
+                let mut out = Box::new([0; 32]);
+                out.copy_from_slice(hash.finalize().as_ref());
+                // TODO: `hash` should be zero'ed on drop :-/
+                out
             }
         };
     }
@@ -87,7 +103,11 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                             nom::bytes::complete::tag("0x"),
                             nom::character::complete::hex_digit0,
                         ),
-                        |hex| <[u8; 32]>::try_from(hex::decode(hex).ok()?).ok(),
+                        |hex| {
+                            let mut out = Box::new([0; 32]);
+                            hex::decode_to_slice(hex, &mut *out).ok()?;
+                            Some(out)
+                        },
                     ),
                     either::Left,
                 ),
@@ -148,7 +168,11 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
 pub struct ParsedPrivateKey {
     /// Base seed phrase. Must be derived through [`ParsedPrivateKey::path`] to obtain the final
     /// result.
-    pub seed: [u8; 32],
+    ///
+    /// > **Note**: The key is embedded within a `Box` in order to guarantee that no trace of the
+    /// >           secret key is accidentally left in memory due to automatic copies of stack
+    /// >           data.
+    pub seed: Box<[u8; 32]>,
 
     /// Derivation path found in the secret phrase.
     pub path: Vec<DeriveJunction>,
@@ -201,8 +225,10 @@ impl DeriveJunction {
 }
 
 /// Turns a BIP39 seed phrase into a 32 bytes cryptographic seed.
-// TODO: zeroize the return value?
-pub fn bip39_to_seed(phrase: &str, password: &str) -> Result<[u8; 32], Bip39ToSeedError> {
+///
+/// > **Note**: The key is returned within a `Box` in order to guarantee that no trace of the
+/// >           secret key is accidentally left in memory due to automatic copies of stack data.
+pub fn bip39_to_seed(phrase: &str, password: &str) -> Result<Box<[u8; 32]>, Bip39ToSeedError> {
     let parsed = bip39::Mnemonic::parse_in_normalized(bip39::Language::English, phrase)
         .map_err(|err| Bip39ToSeedError::WrongMnemonic(Bip39DecodeError(err)))?;
 
@@ -219,25 +245,27 @@ pub fn bip39_to_seed(phrase: &str, password: &str) -> Result<[u8; 32], Bip39ToSe
         return Err(Bip39ToSeedError::BadWordsCount);
     }
 
-    let mut salt = String::with_capacity(8 + password.len());
+    let mut salt = zeroize::Zeroizing::new(String::with_capacity(8 + password.len()));
     salt.push_str("mnemonic");
     salt.push_str(password);
 
     // This function returns an error only in case of wrong buffer length, making it safe to
     // unwrap.
-    let mut seed = [0u8; 64];
+    let mut seed_too_long = Box::new([0u8; 64]);
     pbkdf2::pbkdf2::<hmac::Hmac<sha2::Sha512>>(
         &entropy[..entropy_len],
         salt.as_bytes(),
         2048,
-        &mut seed,
+        &mut *seed_too_long,
     )
     .unwrap();
 
-    // TODO: salt.zeroize();
-
     // The seed is truncated to 32 bytes.
-    Ok(<[u8; 32]>::try_from(&seed[..32]).unwrap())
+    let mut seed = Box::new([0u8; 32]);
+    seed.copy_from_slice(&seed_too_long[..32]);
+    seed_too_long.zeroize();
+
+    Ok(seed)
 }
 
 /// Failed to decode BIP39 mnemonic phrase.
@@ -258,7 +286,7 @@ mod tests {
     #[test]
     fn empty_matches_sr25519() {
         assert_eq!(
-            super::decode_sr25519_private_key("").unwrap(),
+            *super::decode_sr25519_private_key("").unwrap(),
             [
                 5, 214, 85, 132, 99, 13, 22, 205, 74, 246, 208, 190, 193, 15, 52, 187, 80, 74, 93,
                 203, 98, 219, 162, 18, 45, 73, 245, 166, 99, 118, 61, 10, 253, 25, 12, 206, 116,
@@ -271,7 +299,7 @@ mod tests {
     #[test]
     fn empty_matches_ed25519() {
         assert_eq!(
-            super::decode_ed25519_private_key("").unwrap(),
+            *super::decode_ed25519_private_key("").unwrap(),
             [
                 250, 199, 149, 157, 191, 231, 47, 5, 46, 90, 12, 60, 141, 101, 48, 242, 2, 176, 47,
                 216, 249, 245, 202, 53, 128, 236, 141, 235, 119, 151, 71, 158
@@ -320,7 +348,7 @@ mod tests {
     #[test]
     fn alice_matches_sr25519() {
         assert_eq!(
-            super::decode_sr25519_private_key("//Alice").unwrap(),
+            *super::decode_sr25519_private_key("//Alice").unwrap(),
             [
                 51, 166, 243, 9, 63, 21, 138, 113, 9, 246, 121, 65, 11, 239, 26, 12, 84, 22, 129,
                 69, 224, 206, 203, 77, 240, 6, 193, 194, 255, 251, 31, 9, 146, 90, 34, 93, 151,
@@ -333,7 +361,7 @@ mod tests {
     #[test]
     fn alice_matches_ed25519() {
         assert_eq!(
-            super::decode_ed25519_private_key("//Alice").unwrap(),
+            *super::decode_ed25519_private_key("//Alice").unwrap(),
             [
                 171, 248, 229, 189, 190, 48, 198, 86, 86, 192, 163, 203, 209, 129, 255, 138, 86,
                 41, 74, 105, 223, 237, 210, 121, 130, 170, 206, 74, 118, 144, 145, 21
@@ -344,7 +372,7 @@ mod tests {
     #[test]
     fn hex_seed_matches_sr25519() {
         assert_eq!(
-            super::decode_sr25519_private_key(
+            *super::decode_sr25519_private_key(
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
             )
             .unwrap(),
@@ -360,7 +388,7 @@ mod tests {
     #[test]
     fn hex_seed_matches_ed25519() {
         assert_eq!(
-            super::decode_ed25519_private_key(
+            *super::decode_ed25519_private_key(
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
             )
             .unwrap(),
@@ -374,7 +402,7 @@ mod tests {
     #[test]
     fn multi_derivation_and_password_sr25519() {
         assert_eq!(
-            super::decode_sr25519_private_key("strong isolate job basic auto frozen want garlic autumn height riot desert//foo//2//baz///my_password").unwrap(),
+            *super::decode_sr25519_private_key("strong isolate job basic auto frozen want garlic autumn height riot desert//foo//2//baz///my_password").unwrap(),
             [144, 209, 243, 24, 75, 220, 185, 255, 47, 39, 160, 1, 179, 74, 230, 178, 26, 1, 64, 139, 194, 14, 123, 204, 213, 105, 88, 17, 142, 68, 198, 10, 101, 57, 5, 124, 59, 208, 57, 242, 223, 43, 140, 191, 21, 56, 88, 79, 192, 241, 237, 195, 169, 103, 244, 249, 36, 90, 106, 10, 109, 40, 29, 73]
         );
     }
@@ -382,7 +410,7 @@ mod tests {
     #[test]
     fn multi_derivation_and_password_ed25519() {
         assert_eq!(
-            super::decode_ed25519_private_key("strong isolate job basic auto frozen want garlic autumn height riot desert//foo//2//baz///my_password").unwrap(),
+            *super::decode_ed25519_private_key("strong isolate job basic auto frozen want garlic autumn height riot desert//foo//2//baz///my_password").unwrap(),
             [95, 205, 122, 218, 56, 195, 127, 158, 30, 205, 82, 84, 159, 120, 105, 63, 210, 155, 217, 74, 40, 142, 70, 179, 11, 75, 82, 143, 219, 208, 86, 245]
         );
     }


### PR DESCRIPTION
This PR reviews the secret keys manipulation code of `keystore.rs` and `seed_phrase.rs` and zeroes said secret keys where possible.

I've added TODO remarks in places that seem still insecure to me.
