### PR TITLE
Remove `PlatformRef::yield_after_cpu_intensive`

### DIFF
--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -28,7 +28,6 @@ pub mod default;
 /// then create a connection on one clone, then access this connection on the other clone.
 pub trait PlatformRef: Clone + Send + Sync + 'static {
     type Delay: Future<Output = ()> + Unpin + Send + 'static;
-    type Yield: Future<Output = ()> + Unpin + Send + 'static;
     type Instant: Clone
         + ops::Add<Duration, Output = Self::Instant>
         + ops::Sub<Self::Instant, Output = Duration>
@@ -100,11 +99,6 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// Value returned when a JSON-RPC client requests the version of the client, or when a peer
     /// performs an identification request. Reasonable value is `env!("CARGO_PKG_VERSION")`.
     fn client_version(&self) -> Cow<str>;
-
-    /// Should be called after a CPU-intensive operation in order to yield back control.
-    ///
-    /// This function can be implemented as no-op on platforms where this is irrelevant.
-    fn yield_after_cpu_intensive(&self) -> Self::Yield;
 
     /// Starts a connection attempt to the given multiaddress.
     ///

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -51,7 +51,6 @@ impl DefaultPlatform {
 
 impl PlatformRef for Arc<DefaultPlatform> {
     type Delay = future::BoxFuture<'static, ()>;
-    type Yield = future::Ready<()>;
     type Instant = std::time::Instant;
     type MultiStream = std::convert::Infallible;
     type Stream = Stream;
@@ -95,11 +94,6 @@ impl PlatformRef for Arc<DefaultPlatform> {
 
     fn client_version(&self) -> Cow<str> {
         Cow::Borrowed(&self.client_version)
-    }
-
-    fn yield_after_cpu_intensive(&self) -> Self::Yield {
-        // No-op.
-        future::ready(())
     }
 
     fn connect(&self, multiaddr: &str) -> Self::ConnectFuture {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -107,9 +107,6 @@ pub struct PinnedRuntimeId(Arc<Runtime>);
 
 /// See [the module-level documentation](..).
 pub struct RuntimeService<TPlat: PlatformRef> {
-    /// See [`Config::platform`].
-    platform: TPlat,
-
     /// See [`Config::sync_service`].
     sync_service: Arc<sync_service::SyncService<TPlat>>,
 
@@ -177,7 +174,6 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
         });
 
         RuntimeService {
-            platform: config.platform,
             sync_service: config.sync_service,
             guarded,
             background_task_abort,

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -531,12 +531,8 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
             existing_runtime
         } else {
             // No identical runtime was found. Try compiling the new runtime.
-            let runtime = SuccessfulRuntime::from_storage::<TPlat>(
-                &self.platform,
-                &storage_code,
-                &storage_heap_pages,
-            )
-            .await;
+            let runtime =
+                SuccessfulRuntime::from_storage::<TPlat>(&storage_code, &storage_heap_pages).await;
             let runtime = Arc::new(Runtime {
                 heap_pages: storage_heap_pages,
                 runtime_code: storage_code,
@@ -1616,12 +1612,8 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let runtime = if let Some(existing_runtime) = existing_runtime {
             existing_runtime
         } else {
-            let runtime = SuccessfulRuntime::from_storage::<TPlat>(
-                &self.platform,
-                &storage_code,
-                &storage_heap_pages,
-            )
-            .await;
+            let runtime =
+                SuccessfulRuntime::from_storage::<TPlat>(&storage_code, &storage_heap_pages).await;
             match &runtime {
                 Ok(runtime) => {
                     log::info!(
@@ -2124,12 +2116,11 @@ struct SuccessfulRuntime {
 
 impl SuccessfulRuntime {
     async fn from_storage<TPlat: PlatformRef>(
-        platform: &TPlat,
         code: &Option<Vec<u8>>,
         heap_pages: &Option<Vec<u8>>,
     ) -> Result<Self, RuntimeError> {
         // Since compiling the runtime is a CPU-intensive operation, we yield once before.
-        platform.yield_after_cpu_intensive().await;
+        futures_lite::future::yield_now().await;
 
         // Parameters for `HostVmPrototype::new`.
         let module = code.as_ref().ok_or(RuntimeError::CodeNotFound)?;

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -138,9 +138,8 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
             if has_done_verif {
                 queue_empty = false;
 
-                // As explained in the documentation of `yield_after_cpu_intensive`, we should
-                // yield after a CPU-intensive operation. This helps provide a better granularity.
-                task.platform.yield_after_cpu_intensive().await;
+                // Yield after a CPU-intensive operation. This helps provide a better granularity.
+                futures_lite::future::yield_now().await;
             }
 
             queue_empty


### PR DESCRIPTION
This function was initially added because the wasm-node was doing some black magic when it comes to executing tasks.

The light client now simply does a yield, which the executor can detect (and does detect for the wasm-node) if needed.
