### PR TITLE
Add a basic JSON-RPC server draft to the full node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,6 +2408,7 @@ dependencies = [
 name = "smoldot-full-node"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "blake2-rfc",
  "clap",
  "ctrlc",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -14,6 +14,7 @@ name = "full-node"
 path = "bin/main.rs"
 
 [dependencies]
+async-channel = { version = "1.8.0", default-features = false }
 blake2-rfc = { version = "0.2.18", default-features = false }
 clap = { version = "4.3.9", default-features = false, features = ["color", "derive", "help", "std", "suggestions", "usage"] }  # Note: enabling/disabling some features modifies the internal behavior of clap, be careful
 ctrlc = "3.4.0"

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -391,6 +391,17 @@ async fn run(cli_options: cli::CliOptionsRun) {
     })
     .await;
 
+    if let Some(addr) = client.json_rpc_server_addr() {
+        log_callback.log(
+            smoldot_full_node::LogLevel::Info,
+            format!(
+                "JSON-RPC server listening on {addr}. Visit \
+                <https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=ws%3A%2F%2F{addr}> in order to \
+                interact with the node."
+            ),
+        );
+    }
+
     // Starting from here, a SIGINT (or equivalent) handler is set up. If the user does Ctrl+C,
     // an event will be triggered on `ctrlc_detected`.
     // This should be performed after all the expensive initialization is done, as otherwise these

--- a/full-node/src/json_rpc_service/requests_handler.rs
+++ b/full-node/src/json_rpc_service/requests_handler.rs
@@ -1,0 +1,65 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use smol::stream::StreamExt as _;
+use smoldot::json_rpc::{methods, service};
+
+pub struct Config {
+    pub receiver: async_channel::Receiver<Message>,
+}
+
+pub enum Message {
+    Request(service::RequestProcess),
+    SubscriptionStart(service::SubscriptionStartProcess),
+}
+
+pub fn spawn_requests_handler(mut config: Config) {
+    smol::spawn(async move {
+        loop {
+            match config.receiver.next().await {
+                Some(Message::Request(request)) => match request.request() {
+                    methods::MethodCall::rpc_methods {} => {
+                        request.respond(methods::Response::rpc_methods(methods::RpcMethods {
+                            methods: methods::MethodCall::method_names()
+                                .map(|n| n.into())
+                                .collect(),
+                        }));
+                    }
+                    methods::MethodCall::system_name {} => {
+                        request.respond(methods::Response::system_version(
+                            env!("CARGO_PKG_NAME").into(),
+                        ));
+                    }
+                    methods::MethodCall::system_version {} => {
+                        request.respond(methods::Response::system_version(
+                            env!("CARGO_PKG_VERSION").into(),
+                        ));
+                    }
+                    _ => request.fail(service::ErrorResponse::ServerError(
+                        -32000,
+                        "Not implemented in smoldot yet",
+                    )),
+                },
+                Some(Message::SubscriptionStart(request)) => request.fail(
+                    service::ErrorResponse::ServerError(-32000, "Not implemented in smoldot yet"),
+                ),
+                None => return,
+            }
+        }
+    })
+    .detach();
+}

--- a/full-node/src/util.rs
+++ b/full-node/src/util.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::fmt::{self, Write as _};
+
 /// Implementation of the `BuildHasher` trait for the sip hasher.
 ///
 /// Contrary to the one in the standard library, a seed is explicitly passed here, making the
@@ -33,4 +35,33 @@ impl core::hash::BuildHasher for SipHasherBuild {
     fn build_hasher(&self) -> Self::Hasher {
         siphasher::sip::SipHasher13::new_with_key(&self.0)
     }
+}
+
+/// Returns an opaque object implementing the `fmt::Display` trait. Truncates the given `char`
+/// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
+/// the end.
+pub fn truncated_str<'a>(
+    input: impl Iterator<Item = char> + Clone + 'a,
+    limit: usize,
+) -> impl fmt::Display + 'a {
+    struct Iter<I>(I, usize);
+
+    impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut counter = 0;
+            for c in self.0.clone() {
+                f.write_char(c)?;
+
+                counter += 1;
+                if counter >= self.1 {
+                    f.write_char('…')?;
+                    break;
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    Iter(input, limit)
 }


### PR DESCRIPTION
This PR designs a basic architecture that can be used to add JSON-RPC function implementations.