### PR TITLE
Implement the full node JSON-RPC server more properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1048,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1662,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nix"
@@ -2429,6 +2466,7 @@ dependencies = [
  "siphasher",
  "smol",
  "smoldot",
+ "soketto",
  "terminal_size",
  "zeroize",
 ]
@@ -2516,6 +2554,7 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.1",
  "bytes",
+ "flate2",
  "futures",
  "httparse",
  "log",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.8.5"
 serde = { version = "1.0.163", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = ["std"] }
 siphasher = { version = "0.3.10", default-features = false }
+soketto = { version = "0.7.1", features = ["deflate"] }
 smol = "1.3.0"
 smoldot = { version = "0.8.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.2.6"

--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -85,6 +85,9 @@ pub struct CliOptionsRun {
     /// Bind point of the JSON-RPC server ("none" or `<ip>:<port>`).
     #[arg(long, default_value = "127.0.0.1:9944", value_parser = parse_json_rpc_address)]
     pub json_rpc_address: JsonRpcAddress,
+    /// Maximum number of JSON-RPC clients that can be connected simultaneously. Ignored if no server.
+    #[arg(long, default_value = "64")]
+    pub json_rpc_max_clients: u32,
     /// List of secret phrases to insert in the keystore of the node. Used to author blocks.
     #[arg(long, value_parser = decode_sr25519_private_key)]
     // TODO: also automatically add the same keys through ed25519?

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -380,7 +380,14 @@ async fn run(cli_options: cli::CliOptionsRun) {
         relay_chain,
         libp2p_key,
         listen_addresses: cli_options.listen_addr,
-        json_rpc_address: cli_options.json_rpc_address.0,
+        json_rpc: if let Some(address) = cli_options.json_rpc_address.0 {
+            Some(smoldot_full_node::JsonRpcConfig {
+                address,
+                max_json_rpc_clients: cli_options.json_rpc_max_clients,
+            })
+        } else {
+            None
+        },
         tasks_executor: {
             let executor = executor.clone();
             Arc::new(move |task| executor.spawn(task).detach())

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -135,7 +135,7 @@ pub struct Client {
 impl Client {
     /// Returns the address the JSON-RPC server is listening on.
     ///
-    /// Returns `None` if and only if [`Config::json_rpc_address`] was `None`.
+    /// Returns `None` if and only if [`Config::json_rpc`] was `None`.
     pub fn json_rpc_server_addr(&self) -> Option<SocketAddr> {
         self.json_rpc_service.as_ref().map(|j| j.listen_addr())
     }

--- a/full-node/tests/author.rs
+++ b/full-node/tests/author.rs
@@ -35,7 +35,7 @@ fn basic_block_generated() {
             relay_chain: None,
             libp2p_key: Box::new([0; 32]),
             listen_addresses: Vec::new(),
-            json_rpc_address: None,
+            json_rpc: None,
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
             log_callback: Arc::new(move |_, _| {}),
             jaeger_agent: None,

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -97,6 +97,9 @@ struct SerializedRequestsQueue {
     /// Event notified after an element from [`SerializedRequestsQueue::queue`] has been pushed.
     on_pushed: event_listener::Event,
 
+    /// Event notified after an element from [`SerializedRequestsQueue::queue`] has been pulled.
+    on_pulled: event_listener::Event,
+
     /// Number of requests that have have been received from the client but whose answer hasn't
     /// been sent back to the client yet. Includes requests whose response is still in
     /// [`Inner::pending_serialized_responses`].
@@ -183,6 +186,7 @@ pub fn client_main_task(config: Config) -> (ClientMainTask, SerializedRequestsIo
             serialized_requests_queue: Arc::new(SerializedRequestsQueue {
                 queue: crossbeam_queue::SegQueue::new(),
                 on_pushed: event_listener::Event::new(),
+                on_pulled: event_listener::Event::new(),
                 num_requests_in_fly: AtomicU32::new(0),
                 max_requests_in_fly: config.max_pending_requests,
             }),
@@ -227,6 +231,10 @@ impl ClientMainTask {
                     let mut wait = None;
                     loop {
                         if let Some(elem) = self.inner.serialized_requests_queue.queue.pop() {
+                            self.inner
+                                .serialized_requests_queue
+                                .on_pulled
+                                .notify(usize::max_value());
                             break elem;
                         }
                         if let Some(wait) = wait.take() {
@@ -773,7 +781,62 @@ impl SerializedRequestsIo {
             .ok_or(WaitNextResponseError::ClientMainTaskDestroyed)
     }
 
-    // TODO: add functions for when you want to block the sending
+    /// Adds a JSON-RPC request to the queue of requests of the [`ClientMainTask`]. Waits if the
+    /// queue is full.
+    ///
+    /// This might cause a call to [`ClientMainTask::run_until_event`] to return
+    /// [`Event::HandleRequest`] or [`Event::HandleSubscriptionStart`].
+    pub async fn send_request(&self, request: String) -> Result<(), SendRequestError> {
+        // Try parse the request here. This guarantees that the [`ClientMainTask`] can't receive
+        // requests that can't be parsed.
+        if let Err(methods::ParseCallError::JsonRpcParse(err)) = methods::parse_json_call(&request)
+        {
+            return Err(SendRequestError {
+                request,
+                cause: SendRequestErrorCause::MalformedJson(err),
+            });
+        }
+
+        let Some(queue) = self.serialized_requests_queue.upgrade()
+            else {
+                return Err(SendRequestError {
+                    request,
+                    cause: SendRequestErrorCause::ClientMainTaskDestroyed,
+                });
+            };
+
+        // Wait until it is possible to increment `num_requests_in_fly`.
+        let mut wait = None;
+        loop {
+            if queue
+                .num_requests_in_fly
+                .fetch_update(Ordering::SeqCst, Ordering::Relaxed, |old_value| {
+                    if old_value < queue.max_requests_in_fly.get() {
+                        // Considering that `old_value < max`, and `max` fits in a `u32` by
+                        // definition, then `old_value + 1` also always fits in a `u32`. QED.
+                        // There's no risk of overflow.
+                        Some(old_value + 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+            {
+                break;
+            }
+
+            if let Some(wait) = wait.take() {
+                wait.await;
+            } else {
+                wait = Some(queue.on_pulled.listen());
+            }
+        }
+
+        // Everything successful.
+        queue.queue.push(request);
+        queue.on_pushed.notify(usize::max_value());
+        Ok(())
+    }
 
     /// Tries to add a JSON-RPC request to the queue of requests of the [`ClientMainTask`].
     ///
@@ -835,6 +898,26 @@ impl fmt::Debug for SerializedRequestsIo {
 /// See [`SerializedRequestsIo::wait_next_response`].
 #[derive(Debug, Clone, derive_more::Display)]
 pub enum WaitNextResponseError {
+    /// The attached [`ClientMainTask`] has been destroyed.
+    ClientMainTaskDestroyed,
+}
+
+/// Error returned by [`SerializedRequestsIo::send_request`].
+#[derive(Debug, derive_more::Display)]
+#[display(fmt = "{cause}")]
+pub struct SendRequestError {
+    /// The JSON-RPC request that was passed as parameter.
+    pub request: String,
+    /// Reason for the error.
+    pub cause: SendRequestErrorCause,
+}
+
+/// See [`SendRequestError::cause`].
+#[derive(Debug, derive_more::Display)]
+pub enum SendRequestErrorCause {
+    /// Data is not JSON, or JSON is missing or has invalid fields.
+    #[display(fmt = "{_0}")]
+    MalformedJson(ParseError),
     /// The attached [`ClientMainTask`] has been destroyed.
     ClientMainTaskDestroyed,
 }

--- a/lib/src/json_rpc/websocket_server.rs
+++ b/lib/src/json_rpc/websocket_server.rs
@@ -113,6 +113,8 @@
 #![cfg(feature = "std")]
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
+// TODO: consider removing this module altogether
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
Instead of using the `websocket_server` struct found in `/lib`, we now directly use `soketto`.
This fixes the awkwardness caused by the fact that `websocket_server` does everything in a single task.
Everything should be robust now.

Unfortunately, enabling the `deflate` extension leads to errors in `soketto`. It's not clear whether it's a bug or a misuse of the API.
