### PR TITLE
Clean up and make the full node transactions pool work

### DIFF
--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -451,7 +451,7 @@ impl<TTx> Pool<TTx> {
     }
 
     /// Adds a block to the chain tracked by the transactions pool.
-    pub fn append_empty_block(mut self) {
+    pub fn append_empty_block(&mut self) {
         self.best_block_height = self.best_block_height.checked_add(1).unwrap();
 
         // Un-validate the transactions whose validation longevity has expired.

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -69,6 +69,10 @@
 //! Use [`Pool::remove_included`] when a block has been finalized to remove from the pool the
 //! transactions that are present in the finalized block and below.
 //!
+//! When authoring a block, use [`Pool::append_block`] and [`AppendBlock::includable_transactions`]
+//! to determine which transaction to include next. Use [`AppendBlock::add_transaction_by_id`] when
+//! the transaction has been included.
+//!
 //! # Out of scope
 //!
 //! The following are examples of things that are related transactions pool to but out of scope of
@@ -773,7 +777,7 @@ impl<TTx> AppendBlock<TTx> {
     ///
     /// The transaction is compared against the list of non-included transactions that are already
     /// in the pool. If a non-included transaction with the same bytes is found, it is switched to
-    /// the "included" state and  [`AppendBlockTransaction::NonIncludedUpdated`] is returned.
+    /// the "included" state and [`AppendBlockTransaction::NonIncludedUpdated`] is returned.
     /// Otherwise, [`AppendBlockTransaction::Unknown`] is returned and the transaction can be
     /// inserted in the pool.
     ///

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -619,6 +619,15 @@ impl<TTx> AppendBlock<TTx> {
     pub fn finish(self) -> Pool<TTx> {
         self.inner
     }
+
+    /// Aborts the block insertion process and reverts all the changes that were made.
+    ///
+    /// > **Note**: Not everything is reverted to the exact state where it was before. Some
+    /// >           transactions might have to be revalidated.
+    pub fn revert_block_insertion(mut self) -> Pool<TTx> {
+        let _ = self.inner.retract_blocks(1);
+        self.inner
+    }
 }
 
 impl<TTx: fmt::Debug> fmt::Debug for AppendBlock<TTx> {

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -84,14 +84,14 @@
 //! - Sending transactions to other peers.
 //!
 
-// TODO: this code is completely untested
-
 use alloc::{
     collections::{btree_set, BTreeSet},
     vec::Vec,
 };
 use core::{fmt, iter, mem, ops};
 use hashbrown::HashSet;
+
+mod tests;
 
 pub use super::validate::ValidTransaction;
 
@@ -908,5 +908,3 @@ impl<'a, 'b, TTx: fmt::Debug> fmt::Debug for Vacant<'a, 'b, TTx> {
 fn blake2_hash(bytes: &[u8]) -> [u8; 32] {
     <[u8; 32]>::try_from(blake2_rfc::blake2b::blake2b(32, &[], bytes).as_bytes()).unwrap()
 }
-
-// TODO: needs tests

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -49,11 +49,11 @@
 //! properties:
 //!
 //! - Whether or not it has been validated, and if yes, the block against which it has been
-//! validated and the characteristics of the transaction (as provided by the runtime): the tags it
-//! provides and requires, its longevity, and its priority. See [the `validate` module](../validate)
-//! for more information.
+//! validated and the characteristics of the transaction (as provided by the runtime). These
+//! characterstics are: the tags it provides and requires, its longevity, and its priority.
+//! See [the `validate` module](../validate) for more information.
 //! - The height of the block, if any, in which the transaction has been included.
-//! - A so-called user data, an opaque field controller by the API user.
+//! - A so-called user data, an opaque field controlled by the API user.
 //!
 //! Use [`Pool::add_unvalidated`] to add to the pool a transaction that should be included in a
 //! block at a later point in time.
@@ -82,8 +82,11 @@
 
 use super::validate::{TransactionValidityError, ValidTransaction};
 
-use alloc::{collections::BTreeSet, vec::Vec};
-use core::fmt;
+use alloc::{
+    collections::{btree_set, BTreeSet},
+    vec::Vec,
+};
+use core::{fmt, iter, mem};
 use hashbrown::HashSet;
 
 /// Identifier of a transaction stored within the [`Pool`].
@@ -108,8 +111,8 @@ pub struct Config {
     /// Height of the finalized block at initialization.
     ///
     /// The [`Pool`] doesn't track which block is finalized. This value is only used to initialize
-    /// the best block number. The field could also have been called `best_block_height`, but it
-    /// might have created confusion.
+    /// the best block number. The field could also have been called `best_block_height`, but doing
+    /// so might created confusion.
     ///
     /// Non-finalized blocks should be added to the pool after initialization using
     /// [`Pool::append_block`].
@@ -159,12 +162,12 @@ impl<TTx> Pool<TTx> {
         self.transactions.len()
     }
 
-    /// Inserts a new unverified transaction in the pool.
+    /// Inserts a new non-validated transaction in the pool.
     pub fn add_unvalidated(&mut self, scale_encoded: Vec<u8>, user_data: TTx) -> TransactionId {
         self.add_unvalidated_inner(scale_encoded, None, user_data)
     }
 
-    /// Inserts a new unverified transaction in the pool.
+    /// Inserts a new non-validated transaction in the pool.
     fn add_unvalidated_inner(
         &mut self,
         scale_encoded: impl AsRef<[u8]> + Into<Vec<u8>>,

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -359,8 +359,14 @@ impl<TTx> Pool<TTx> {
         Some(&self.transactions.get(id.0)?.scale_encoded)
     }
 
-    /// Tries to find a transaction in the pool whose bytes are `scale_encoded`.
-    pub fn find(&'_ self, scale_encoded: &[u8]) -> impl Iterator<Item = TransactionId> + '_ {
+    /// Finds the transactions in the pool whose bytes are `scale_encoded`.
+    ///
+    /// This operation has a complexity of `O(log n)` where `n` is the number of entries in the
+    /// pool.
+    pub fn transactions_by_scale_encoding(
+        &'_ self,
+        scale_encoded: &[u8],
+    ) -> impl Iterator<Item = TransactionId> + '_ {
         let hash = blake2_hash(scale_encoded);
         self.by_hash
             .range(

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -86,7 +86,7 @@ use alloc::{
     collections::{btree_set, BTreeSet},
     vec::Vec,
 };
-use core::{fmt, iter, mem};
+use core::{fmt, iter, mem, ops};
 use hashbrown::HashSet;
 
 /// Identifier of a transaction stored within the [`Pool`].
@@ -341,20 +341,6 @@ impl<TTx> Pool<TTx> {
             .map(|(id, tx)| (TransactionId(id), &mut tx.user_data))
     }
 
-    /// Returns the user data associated with a given transaction.
-    ///
-    /// Returns `None` if the identifier is invalid.
-    pub fn user_data(&self, id: TransactionId) -> Option<&TTx> {
-        Some(&self.transactions.get(id.0)?.user_data)
-    }
-
-    /// Returns the user data associated with a given transaction.
-    ///
-    /// Returns `None` if the identifier is invalid.
-    pub fn user_data_mut(&mut self, id: TransactionId) -> Option<&mut TTx> {
-        Some(&mut self.transactions.get_mut(id.0)?.user_data)
-    }
-
     /// Returns the block height at which the given transaction has been included.
     ///
     /// A transaction has been included if it has been added to the pool with
@@ -518,6 +504,20 @@ impl<TTx> Pool<TTx> {
         }
 
         tx.validation = Some((block_number_validated_against, result));
+    }
+}
+
+impl<TTx> ops::Index<TransactionId> for Pool<TTx> {
+    type Output = TTx;
+
+    fn index(&self, index: TransactionId) -> &Self::Output {
+        &self.transactions[index.0].user_data
+    }
+}
+
+impl<TTx> ops::IndexMut<TransactionId> for Pool<TTx> {
+    fn index_mut(&mut self, index: TransactionId) -> &mut Self::Output {
+        &mut self.transactions[index.0].user_data
     }
 }
 

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -851,7 +851,7 @@ impl<TTx: fmt::Debug> fmt::Debug for Pool<TTx> {
     }
 }
 
-/// See [`AppendBlock::block_transaction`].
+/// See [`AppendBlock::best_block_add_transaction_by_scale_encoding`].
 #[derive(Debug)]
 pub enum AppendBlockTransaction<'a, 'b, TTx> {
     /// Transaction to add isn't in the list of non-included transactions. It can be added to the

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -868,7 +868,7 @@ impl<TTx: fmt::Debug> fmt::Debug for Pool<TTx> {
     }
 }
 
-/// See [`AppendBlock::best_block_add_transaction_by_scale_encoding`].
+/// See [`Pool::best_block_add_transaction_by_scale_encoding`].
 #[derive(Debug)]
 pub enum AppendBlockTransaction<'a, 'b, TTx> {
     /// Transaction to add isn't in the list of non-included transactions. It can be added to the

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -163,6 +163,23 @@ pub struct Pool<TTx> {
     best_block_height: u64,
 }
 
+/// Entry in [`Pool::transactions`].
+struct Transaction<TTx> {
+    /// Bytes corresponding to the SCALE-encoded transaction.
+    scale_encoded: Vec<u8>,
+
+    /// If `Some`, contains the outcome of the validation of this transaction and the block height
+    /// it was validated against.
+    validation: Option<(u64, ValidTransaction)>,
+
+    /// If `Some`, the height of the block at which the transaction has been included.
+    included_block_height: Option<u64>,
+
+    /// User data chosen by the user.
+    user_data: TTx,
+}
+
+/// Entry in [`Pool::tags`].
 struct TagInfo {
     /// List of validated transactions that have the tag in their `provides` tags list.
     // TODO: shrink_to_fit from time to time?
@@ -885,22 +902,6 @@ impl<'a, 'b, TTx: fmt::Debug> fmt::Debug for Vacant<'a, 'b, TTx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.inner, f)
     }
-}
-
-/// Entry in [`Pool::transactions`].
-struct Transaction<TTx> {
-    /// Bytes corresponding to the SCALE-encoded transaction.
-    scale_encoded: Vec<u8>,
-
-    /// If `Some`, contains the outcome of the validation of this transaction and the block height
-    /// it was validated against.
-    validation: Option<(u64, ValidTransaction)>,
-
-    /// If `Some`, the height of the block at which the transaction has been included.
-    included_block_height: Option<u64>,
-
-    /// User data chosen by the user.
-    user_data: TTx,
 }
 
 /// Utility. Calculates the BLAKE2 hash of the given bytes.

--- a/lib/src/transactions/pool/tests.rs
+++ b/lib/src/transactions/pool/tests.rs
@@ -1,0 +1,59 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use core::num::NonZeroU64;
+
+use super::{Config, Pool, ValidTransaction};
+
+#[test]
+fn basic_includable() {
+    let mut pool = Pool::new(Config {
+        capacity: 16,
+        finalized_block_height: 0,
+        randomness_seed: [0; 16],
+    });
+
+    let tx_id = pool.add_unvalidated(vec![], ());
+
+    pool.append_empty_block();
+    assert!(pool.best_block_includable_transactions().next().is_none());
+
+    pool.set_validation_result(
+        tx_id,
+        1,
+        ValidTransaction {
+            longevity: NonZeroU64::new(16).unwrap(),
+            priority: 0,
+            propagate: true,
+            provides: Vec::new(),
+            requires: Vec::new(),
+        },
+    );
+
+    pool.append_empty_block();
+    assert_eq!(
+        pool.best_block_includable_transactions().next(),
+        Some((tx_id, &()))
+    );
+
+    pool.best_block_add_transaction_by_id(tx_id);
+    assert!(pool.best_block_includable_transactions().next().is_none());
+}
+
+// TODO: more tests


### PR DESCRIPTION
This PR cleans up and more or less finishes the full node transactions pool implementation.
This is still completely untested, but at least now the usage and behavior have been clarified.
