### PR TITLE
Format let-else blocks with rustfmt

### DIFF
--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -236,7 +236,7 @@ pub struct Bootnode {
 fn parse_bootnode(string: &str) -> Result<Bootnode, String> {
     let mut address = string.parse::<Multiaddr>().map_err(|err| err.to_string())?;
     let Some(ProtocolRef::P2p(peer_id)) = address.iter().last() else {
-        return Err("Bootnode address must end with /p2p/...".into())
+        return Err("Bootnode address must end with /p2p/...".into());
     };
     let peer_id = PeerId::from_bytes(peer_id.to_vec())
         .map_err(|(err, _)| format!("Failed to parse PeerId in bootnode: {err}"))?;
@@ -286,8 +286,9 @@ fn parse_max_bytes(string: &str) -> Result<MaxBytes, String> {
         (1, string)
     };
 
-    let Ok(num) = num.parse::<usize>()
-        else { return Err("Failed to parse number of bytes".into()) };
+    let Ok(num) = num.parse::<usize>() else {
+        return Err("Failed to parse number of bytes".into());
+    };
 
     // Because it's a maximum value it's ok to saturate rather than return an error.
     let real_value = num.saturating_mul(multiplier);

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -747,16 +747,18 @@ impl SyncBackground {
         // Actual block production now happening.
         let (new_block_header, new_block_body, authoring_logs) = {
             let parent_hash = self.sync.best_block_hash();
-            let parent_runtime_arc = if self.sync.best_block_number()
-                != self.sync.finalized_block_header().number
-            {
-                let NonFinalizedBlock::Verified {
-                    runtime: parent_runtime_arc,
-                } = &self.sync[(self.sync.best_block_number(), &self.sync.best_block_hash())] else { unreachable!() };
-                parent_runtime_arc.clone()
-            } else {
-                self.finalized_runtime.clone()
-            };
+            let parent_runtime_arc =
+                if self.sync.best_block_number() != self.sync.finalized_block_header().number {
+                    let NonFinalizedBlock::Verified {
+                        runtime: parent_runtime_arc,
+                    } = &self.sync[(self.sync.best_block_number(), &self.sync.best_block_hash())]
+                    else {
+                        unreachable!()
+                    };
+                    parent_runtime_arc.clone()
+                } else {
+                    self.finalized_runtime.clone()
+                };
             let parent_runtime = parent_runtime_arc.try_lock().unwrap().take().unwrap();
 
             // Start the block authoring process.
@@ -1219,9 +1221,9 @@ impl SyncBackground {
 
                 let parent_hash = *header_verification_success.parent_hash();
                 let parent_info = header_verification_success.parent_user_data().map(|b| {
-                    let NonFinalizedBlock::Verified {
-                        runtime,
-                    } = b else { unreachable!() };
+                    let NonFinalizedBlock::Verified { runtime } = b else {
+                        unreachable!()
+                    };
                     runtime.clone()
                 });
                 let parent_runtime_arc = parent_info
@@ -1596,7 +1598,10 @@ impl SyncBackground {
                         }
 
                         let finalized_block = finalized_blocks.pop().unwrap();
-                        let NonFinalizedBlock::Verified { runtime } = finalized_block.user_data else { unreachable!() };
+                        let NonFinalizedBlock::Verified { runtime } = finalized_block.user_data
+                        else {
+                            unreachable!()
+                        };
                         self.finalized_runtime = runtime;
                         let new_finalized_hash =
                             finalized_block.header.hash(self.sync.block_number_bytes());

--- a/full-node/src/jaeger_service.rs
+++ b/full-node/src/jaeger_service.rs
@@ -85,7 +85,9 @@ impl JaegerService {
                         async { Some(traces_out.next().await) },
                     )
                     .await
-                    else { break };
+                    else {
+                        break;
+                    };
 
                     // UDP sending errors happen only either if the API is misused (in which case
                     // panicking is desirable) or in case of missing priviledge, in which case a

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -171,10 +171,16 @@ impl JsonRpcBackground {
     async fn run(mut self) {
         loop {
             let Some(accept_result) = future::or(
-                async { (&mut self.on_service_dropped).await; None },
-                async { Some(self.tcp_listener.accept().await) }
-            ).await
-                else { return };
+                async {
+                    (&mut self.on_service_dropped).await;
+                    None
+                },
+                async { Some(self.tcp_listener.accept().await) },
+            )
+            .await
+            else {
+                return;
+            };
 
             let (tcp_socket, address) = match accept_result {
                 Ok(v) => v,

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -717,8 +717,9 @@ async fn open_database(
                 .collect::<Vec<_>>()
                 .into_iter()
                 .map(|node_index| {
-                    let (storage_value, Some(merkle_value)) = &trie_structure[node_index]
-                        else { unreachable!() };
+                    let (storage_value, Some(merkle_value)) = &trie_structure[node_index] else {
+                        unreachable!()
+                    };
                     // Cloning to solve borrow checker restriction. // TODO: optimize?
                     let storage_value = if let Some(storage_value) = storage_value {
                         // TODO: child tries support?

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -405,13 +405,17 @@ impl NetworkService {
                 let mut on_foreground_shutdown = foreground_shutdown.listen();
                 async move {
                     loop {
-                        let Some(accept_result) =
-                            future::or(async {
+                        let Some(accept_result) = future::or(
+                            async {
                                 (&mut on_foreground_shutdown).await;
                                 None
-                            }, async { Some(tcp_listener.accept().await) })
-                            .await
-                            else { break };
+                            },
+                            async { Some(tcp_listener.accept().await) },
+                        )
+                        .await
+                        else {
+                            break;
+                        };
 
                         let (socket, addr) = match accept_result {
                             Ok(v) => v,
@@ -1087,8 +1091,9 @@ async fn background_task(mut inner: Inner) {
                 inner.process_network_service_events = true;
 
                 // We check this before generating an event.
-                let either::Left(mut event_senders) = inner.event_senders
-                    else { unreachable!() };
+                let either::Left(mut event_senders) = inner.event_senders else {
+                    unreachable!()
+                };
 
                 inner.event_senders = either::Right(Box::pin(async move {
                     // This little `if` avoids having to do `event.clone()` if we don't have to.
@@ -1132,7 +1137,9 @@ async fn background_task(mut inner: Inner) {
                         })
                         .cloned();
 
-                    let Some(peer_to_assign) = peer_to_assign else { break };
+                    let Some(peer_to_assign) = peer_to_assign else {
+                        break;
+                    };
                     inner.log_callback.log(
                         LogLevel::Debug,
                         format!(

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -557,14 +557,18 @@ impl ChainInformationBuild {
                     } else {
                         // If the GrandPa runtime API version is too old, it is not possible to
                         // determine the current set ID.
-                        let Some(grandpa_current_set_id_call_output) = inner.grandpa_current_set_id_call_output.take()
-                            else {
-                                debug_assert_eq!(inner.runtime_grandpa_supports_currentsetid, Some(false));
-                                return ChainInformationBuild::Finished {
-                                    result: Err(Error::GrandpaApiTooOld),
-                                    virtual_machine: inner.virtual_machine.take().unwrap(),
-                                }
+                        let Some(grandpa_current_set_id_call_output) =
+                            inner.grandpa_current_set_id_call_output.take()
+                        else {
+                            debug_assert_eq!(
+                                inner.runtime_grandpa_supports_currentsetid,
+                                Some(false)
+                            );
+                            return ChainInformationBuild::Finished {
+                                result: Err(Error::GrandpaApiTooOld),
+                                virtual_machine: inner.virtual_machine.take().unwrap(),
                             };
+                        };
 
                         grandpa_current_set_id_call_output
                     },

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -735,8 +735,7 @@ impl SqliteFullDatabase {
             return Err(StorageAccessError::Pruned);
         }
 
-        let Some(value) = value
-            else { return Ok(None) };
+        let Some(value) = value else { return Ok(None) };
 
         let trie_entry_version = u8::try_from(trie_entry_version.unwrap())
             .map_err(|_| CorruptedError::InvalidTrieEntryVersion)

--- a/lib/src/database/full_sqlite/tests.rs
+++ b/lib/src/database/full_sqlite/tests.rs
@@ -33,7 +33,9 @@ fn empty_database_fill_then_query() {
             cache_size: 2 * 1024 * 1024,
             ty: ConfigTy::Memory,
         })
-        .unwrap() else { panic!() };
+        .unwrap() else {
+            panic!()
+        };
 
         fn uniform_sample(min: u8, max: u8) -> u8 {
             Uniform::new_inclusive(min, max).sample(&mut rand::thread_rng())
@@ -123,8 +125,9 @@ fn empty_database_fill_then_query() {
                     .collect::<Vec<_>>()
                     .into_iter()
                     .map(|node_index| {
-                        let (storage_value, Some(merkle_value)) = &trie[node_index]
-                            else { unreachable!() };
+                        let (storage_value, Some(merkle_value)) = &trie[node_index] else {
+                            unreachable!()
+                        };
                         let storage_value = if let Some(storage_value) = storage_value {
                             InsertTrieNodeStorageValue::Value {
                                 value: Cow::Owned(storage_value.to_vec()),

--- a/lib/src/executor/read_only_runtime_host.rs
+++ b/lib/src/executor/read_only_runtime_host.rs
@@ -163,8 +163,9 @@ impl StorageGet {
         match &self.inner.vm {
             host::HostVm::ExternalStorageGet(req) => either::Left(req.key()),
             host::HostVm::ExternalStorageRoot(req) => {
-                let Some(child_trie) = req.child_trie()
-                    else { unreachable!() };
+                let Some(child_trie) = req.child_trie() else {
+                    unreachable!()
+                };
                 // TODO: allocation here, but probably not problematic
                 const PREFIX: &[u8] = b":child_storage:default:";
                 let mut key = Vec::with_capacity(PREFIX.len() + child_trie.as_ref().len());

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -751,7 +751,9 @@ impl ClosestDescendantMerkleValue {
     pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
         let (_, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request)) =
             self.inner.root_calculation.as_ref().unwrap()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
         request.key().flat_map(util::as_ref_iter)
     }
 
@@ -759,7 +761,9 @@ impl ClosestDescendantMerkleValue {
     pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
         let (trie, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(_)) =
             self.inner.root_calculation.as_ref().unwrap()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
         trie.as_ref()
     }
 
@@ -770,7 +774,9 @@ impl ClosestDescendantMerkleValue {
     pub fn resume_unknown(mut self) -> RuntimeHostVm {
         let (trie, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request)) =
             self.inner.root_calculation.take().unwrap()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
 
         self.inner.root_calculation = Some((trie, request.resume_unknown()));
         self.inner.run()
@@ -783,7 +789,9 @@ impl ClosestDescendantMerkleValue {
     pub fn inject_merkle_value(mut self, merkle_value: Option<&[u8]>) -> RuntimeHostVm {
         let (trie, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request)) =
             self.inner.root_calculation.take().unwrap()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
 
         self.inner.root_calculation = Some((
             trie,

--- a/lib/src/executor/vm/tests.rs
+++ b/lib/src/executor/vm/tests.rs
@@ -726,7 +726,9 @@ fn wrong_type_returned_by_host_function_call() {
 
         let mut vm = prototype.prepare().start("hello", &[]).unwrap();
 
-        let Ok(super::ExecOutcome::Interrupted { id: 0, .. }) = vm.run(None) else { panic!() };
+        let Ok(super::ExecOutcome::Interrupted { id: 0, .. }) = vm.run(None) else {
+            panic!()
+        };
         assert!(matches!(
             vm.run(Some(super::WasmValue::I64(3))),
             Err(super::RunErr::BadValueTy { .. })

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -797,13 +797,12 @@ impl SerializedRequestsIo {
             });
         }
 
-        let Some(queue) = self.serialized_requests_queue.upgrade()
-            else {
-                return Err(SendRequestError {
-                    request,
-                    cause: SendRequestErrorCause::ClientMainTaskDestroyed,
-                });
-            };
+        let Some(queue) = self.serialized_requests_queue.upgrade() else {
+            return Err(SendRequestError {
+                request,
+                cause: SendRequestErrorCause::ClientMainTaskDestroyed,
+            });
+        };
 
         // Wait until it is possible to increment `num_requests_in_fly`.
         let mut wait = None;
@@ -853,13 +852,12 @@ impl SerializedRequestsIo {
             });
         }
 
-        let Some(queue) = self.serialized_requests_queue.upgrade()
-            else {
-                return Err(TrySendRequestError {
-                    request,
-                    cause: TrySendRequestErrorCause::ClientMainTaskDestroyed,
-                });
-            };
+        let Some(queue) = self.serialized_requests_queue.upgrade() else {
+            return Err(TrySendRequestError {
+                request,
+                cause: TrySendRequestErrorCause::ClientMainTaskDestroyed,
+            });
+        };
 
         // Try to increment `num_requests_in_fly`. Return an error if it is past the maximum.
         if queue

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -263,7 +263,9 @@ where
                         Some(ConnectionToCoordinatorInner::InboundAcceptedCancel { _id: id })
                     }
                     Some(established::Event::RequestIn { id, request, .. }) => {
-                        let either::Right(protocol_index) = established[id] else { panic!() };
+                        let either::Right(protocol_index) = established[id] else {
+                            panic!()
+                        };
                         Some(ConnectionToCoordinatorInner::RequestIn {
                             id,
                             protocol_index,
@@ -275,7 +277,9 @@ where
                         user_data,
                         ..
                     }) => {
-                        let either::Left(outer_substream_id) = user_data else { panic!() };
+                        let either::Left(outer_substream_id) = user_data else {
+                            panic!()
+                        };
                         outbound_substreams_map.remove(&outer_substream_id).unwrap();
                         Some(ConnectionToCoordinatorInner::Response {
                             response,
@@ -283,7 +287,9 @@ where
                         })
                     }
                     Some(established::Event::NotificationsInOpen { id, handshake, .. }) => {
-                        let either::Right(protocol_index) = established[id] else { panic!() };
+                        let either::Right(protocol_index) = established[id] else {
+                            panic!()
+                        };
                         Some(ConnectionToCoordinatorInner::NotificationsInOpen {
                             id,
                             protocol_index,
@@ -303,11 +309,15 @@ where
                     Some(established::Event::NotificationsOutResult { id, result }) => {
                         let (outer_substream_id, result) = match result {
                             Ok(r) => {
-                                let either::Left(outer_substream_id) = established[id] else { panic!() };
+                                let either::Left(outer_substream_id) = established[id] else {
+                                    panic!()
+                                };
                                 (outer_substream_id, Ok(r))
                             }
                             Err((err, ud)) => {
-                                let either::Left(outer_substream_id) = ud else { panic!() };
+                                let either::Left(outer_substream_id) = ud else {
+                                    panic!()
+                                };
                                 outbound_substreams_map.remove(&outer_substream_id);
                                 (outer_substream_id, Err(NotificationsOutErr::Substream(err)))
                             }
@@ -319,7 +329,9 @@ where
                         })
                     }
                     Some(established::Event::NotificationsOutCloseDemanded { id }) => {
-                        let either::Left(outer_substream_id) = established[id] else { panic!() };
+                        let either::Left(outer_substream_id) = established[id] else {
+                            panic!()
+                        };
                         Some(
                             ConnectionToCoordinatorInner::NotificationsOutCloseDemanded {
                                 id: outer_substream_id,
@@ -327,7 +339,9 @@ where
                         )
                     }
                     Some(established::Event::NotificationsOutReset { user_data, .. }) => {
-                        let either::Left(outer_substream_id) = user_data else { panic!() };
+                        let either::Left(outer_substream_id) = user_data else {
+                            panic!()
+                        };
                         outbound_substreams_map.remove(&outer_substream_id);
                         Some(ConnectionToCoordinatorInner::NotificationsOutReset {
                             id: outer_substream_id,

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -624,7 +624,9 @@ where
                             );
                         }
                         Some(established::Event::RequestIn { id, request, .. }) => {
-                            let either::Right(protocol_index) = connection[id] else { panic!() };
+                            let either::Right(protocol_index) = connection[id] else {
+                                panic!()
+                            };
                             self.pending_messages.push_back(
                                 ConnectionToCoordinatorInner::RequestIn {
                                     id,
@@ -638,7 +640,9 @@ where
                             user_data,
                             ..
                         }) => {
-                            let either::Left(outer_substream_id) = user_data else { panic!() };
+                            let either::Left(outer_substream_id) = user_data else {
+                                panic!()
+                            };
                             outbound_substreams_map.remove(&outer_substream_id).unwrap();
                             self.pending_messages.push_back(
                                 ConnectionToCoordinatorInner::Response {
@@ -648,7 +652,9 @@ where
                             );
                         }
                         Some(established::Event::NotificationsInOpen { id, handshake, .. }) => {
-                            let either::Right(protocol_index) = connection[id] else { panic!() };
+                            let either::Right(protocol_index) = connection[id] else {
+                                panic!()
+                            };
                             self.pending_messages.push_back(
                                 ConnectionToCoordinatorInner::NotificationsInOpen {
                                     id,
@@ -676,11 +682,15 @@ where
                         Some(established::Event::NotificationsOutResult { id, result }) => {
                             let (outer_substream_id, result) = match result {
                                 Ok(r) => {
-                                    let either::Left(outer_substream_id) = connection[id] else { panic!() };
+                                    let either::Left(outer_substream_id) = connection[id] else {
+                                        panic!()
+                                    };
                                     (outer_substream_id, Ok(r))
                                 }
                                 Err((err, ud)) => {
-                                    let either::Left(outer_substream_id) = ud else { panic!() };
+                                    let either::Left(outer_substream_id) = ud else {
+                                        panic!()
+                                    };
                                     outbound_substreams_map.remove(&outer_substream_id);
                                     (outer_substream_id, Err(NotificationsOutErr::Substream(err)))
                                 }
@@ -694,7 +704,9 @@ where
                             );
                         }
                         Some(established::Event::NotificationsOutCloseDemanded { id }) => {
-                            let either::Left(outer_substream_id) = connection[id] else { panic!() };
+                            let either::Left(outer_substream_id) = connection[id] else {
+                                panic!()
+                            };
                             self.pending_messages.push_back(
                                 ConnectionToCoordinatorInner::NotificationsOutCloseDemanded {
                                     id: outer_substream_id,
@@ -702,7 +714,9 @@ where
                             );
                         }
                         Some(established::Event::NotificationsOutReset { user_data, .. }) => {
-                            let either::Left(outer_substream_id) = user_data else { panic!() };
+                            let either::Left(outer_substream_id) = user_data else {
+                                panic!()
+                            };
                             outbound_substreams_map.remove(&outer_substream_id);
                             self.pending_messages.push_back(
                                 ConnectionToCoordinatorInner::NotificationsOutReset {

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -962,7 +962,10 @@ impl<T> Yamux<T> {
                                 ..
                             },
                         ..
-                    }) = self.inner.substreams.get_mut(&substream_id.0) else { continue; };
+                    }) = self.inner.substreams.get_mut(&substream_id.0)
+                    else {
+                        continue;
+                    };
 
                     *remote_write_closed = true;
 
@@ -1067,8 +1070,7 @@ impl<T> Yamux<T> {
 
                     // Decode the header in `incoming_header`.
                     let decoded_header = {
-                        let Ok(full_header) = <&[u8; 12]>::try_from(&incoming_header[..])
-                        else {
+                        let Ok(full_header) = <&[u8; 12]>::try_from(&incoming_header[..]) else {
                             // Not enough data to finish receiving header. Nothing more can be
                             // done.
                             debug_assert!(data.is_empty());
@@ -1199,7 +1201,9 @@ impl<T> Yamux<T> {
                             // which we have sent a RST frame earlier. Considering that we don't
                             // always keep traces of old substreams, we have no way to know whether
                             // this is the case or not.
-                            let Some(s) = self.inner.substreams.get_mut(&stream_id) else { continue };
+                            let Some(s) = self.inner.substreams.get_mut(&stream_id) else {
+                                continue;
+                            };
                             if !matches!(s.state, SubstreamState::Healthy { .. }) {
                                 continue;
                             }
@@ -1682,7 +1686,10 @@ impl<T> Yamux<T> {
                             local_write_close: local_write,
                             allowed_window,
                             ..
-                        } = &mut sub.state else { unreachable!() };
+                        } = &mut sub.state
+                        else {
+                            unreachable!()
+                        };
 
                         let has_data_to_write = (*allowed_window != 0 && !write_queue.is_empty())
                             || matches!(local_write, SubstreamStateLocalWrite::FinDesired);

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -766,8 +766,11 @@ impl<TTx> Pool<TTx> {
     ///
     fn unvalidate_transaction(&mut self, tx_id: TransactionId) {
         // No effect if wasn't validated.
-        let Some((block_height_validated_against, validation)) = self.transactions[tx_id.0].validation.take()
-            else { return; };
+        let Some((block_height_validated_against, validation)) =
+            self.transactions[tx_id.0].validation.take()
+        else {
+            return;
+        };
 
         // We don't care in this context whether the transaction was includable or not, and we
         // call `remove` in both cases.

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -144,11 +144,10 @@ where
             .collect::<hashbrown::HashSet<_, fnv::FnvBuildHasher>>();
         for (hash, (_, proof_entry_range)) in merkle_values.iter() {
             let node_value = &config.proof.as_ref()[proof_entry_range.clone()];
-            let Ok(decoded) = trie_node::decode(node_value)
-                else {
-                    maybe_trie_roots.remove(hash);
-                    continue
-                };
+            let Ok(decoded) = trie_node::decode(node_value) else {
+                maybe_trie_roots.remove(hash);
+                continue;
+            };
             for child in decoded.children.into_iter().flatten() {
                 if let Ok(child) = &<[u8; 32]>::try_from(child) {
                     maybe_trie_roots.remove(child);
@@ -917,12 +916,11 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
                         // `ancestor_key`.
                         key_before.truncate(ancestor_key.len());
                         loop {
-                            let Some(nibble) = key_before.pop()
-                                else {
-                                    // `key_before` is equal to `0xffff...` and thus can't
-                                    // have any next sibling.
-                                    return Ok(None)
-                                };
+                            let Some(nibble) = key_before.pop() else {
+                                // `key_before` is equal to `0xffff...` and thus can't
+                                // have any next sibling.
+                                return Ok(None);
+                            };
                             if let Some(new_nibble) = nibble.checked_add(1) {
                                 key_before.push(new_nibble);
                                 break;

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -391,7 +391,9 @@ impl ProofBuilder {
                     .user_data()
                     .take()
                 // Ignore nodes whose value is missing.
-                else { return either::Right(iter::empty()); };
+                else {
+                    return either::Right(iter::empty());
+                };
 
                 // Nodes of length < 32 should have been inlined within their parent or ancestor.
                 // We thus skip them, unless they're the root node.

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -792,8 +792,9 @@ impl<TUd> TrieStructure<TUd> {
                     // `iter` is strictly inferior to `start_key`, and all of its children will
                     // also be strictly inferior to `start_key`.
                     // Stop the search immediately after the current node in the parent.
-                    let Some((parent, parent_nibble)) = iter_node.parent
-                        else { return either::Right(iter::empty()); };
+                    let Some((parent, parent_nibble)) = iter_node.parent else {
+                        return either::Right(iter::empty());
+                    };
                     let next_nibble = parent_nibble.checked_add(1);
                     if iter_key_nibbles_extra == 0 {
                         return either::Right(iter::empty());
@@ -940,7 +941,9 @@ impl<TUd> TrieStructure<TUd> {
                         return None;
                     }
 
-                    let Some((parent_node_index, parent_nibble_direction)) = node.parent else { return None; };
+                    let Some((parent_node_index, parent_nibble_direction)) = node.parent else {
+                        return None;
+                    };
                     iter_key_nibbles_extra -= 2;
                     iter_key_nibbles_extra -= node.partial_key.len();
                     let next_sibling_nibble = parent_nibble_direction.checked_add(1);

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -808,8 +808,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::sudo_unstable_p2pDiscover`].
     async fn sudo_unstable_p2p_discover(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::sudo_unstable_p2pDiscover { multiaddr } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::sudo_unstable_p2pDiscover { multiaddr } = request.request() else {
+            unreachable!()
+        };
 
         match multiaddr.parse::<multiaddr::Multiaddr>() {
             Ok(mut addr) if matches!(addr.iter().last(), Some(multiaddr::ProtocolRef::P2p(_))) => {

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -52,8 +52,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_call { follow_subscription, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_call {
+            follow_subscription,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // This is implemented by sending a message to the notifications task.
         // The task dedicated to this subscription will receive the message and send a response to
@@ -88,7 +93,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         request: service::SubscriptionStartProcess,
     ) {
         let methods::MethodCall::chainHead_unstable_follow { with_runtime } = request.request()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
 
         let events = if with_runtime {
             let subscribe_all = self
@@ -303,8 +310,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_storage { follow_subscription, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_storage {
+            follow_subscription,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // This is implemented by sending a message to the notifications task.
         // The task dedicated to this subscription will receive the message and send a response to
@@ -339,7 +351,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         request: service::RequestProcess,
     ) {
         let methods::MethodCall::chainHead_unstable_storageContinue { .. } = request.request()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
         // TODO: not implemented properly
         request.respond(methods::Response::chainHead_unstable_storageContinue(()));
     }
@@ -349,8 +363,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_body { follow_subscription, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_body {
+            follow_subscription,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // This is implemented by sending a message to the notifications task.
         // The task dedicated to this subscription will receive the message and send a response to
@@ -384,8 +403,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::RequestProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_header { follow_subscription, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_header {
+            follow_subscription,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // This is implemented by sending a message to the notifications task.
         // The task dedicated to this subscription will receive the message and send a response to
@@ -412,8 +436,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::RequestProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_unpin { follow_subscription, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_unpin {
+            follow_subscription,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // This is implemented by sending a message to the notifications task.
         // The task dedicated to this subscription will receive the message and send a response to
@@ -752,8 +781,14 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
     }
 
     async fn start_chain_head_body(&mut self, request: service::SubscriptionStartProcess) {
-        let methods::MethodCall::chainHead_unstable_body { hash, network_config, .. } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_body {
+            hash,
+            network_config,
+            ..
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // Determine whether the requested block hash is valid, and if yes its number.
         let block_number = {
@@ -851,7 +886,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             network_config,
             ..
         } = request.request()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
 
         // Obtain the header of the requested block.
         let block_scale_encoded_header = {
@@ -1062,7 +1099,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                 network_config,
                 ..
             } = request.request()
-                else { unreachable!() };
+            else {
+                unreachable!()
+            };
 
             let network_config = network_config.unwrap_or(methods::NetworkConfig {
                 max_parallel: 1,

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -193,8 +193,11 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::RequestProcess,
     ) {
-        let methods::MethodCall::chainHead_unstable_finalizedDatabase { max_size_bytes } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chainHead_unstable_finalizedDatabase { max_size_bytes } =
+            request.request()
+        else {
+            unreachable!()
+        };
 
         let response = crate::database::encode_database(
             &self.network_service.0,

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -42,8 +42,9 @@ mod sub_utils;
 impl<TPlat: PlatformRef> Background<TPlat> {
     /// Handles a call to [`methods::MethodCall::system_accountNextIndex`].
     pub(super) async fn account_next_index(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::system_accountNextIndex { account } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::system_accountNextIndex { account } = request.request() else {
+            unreachable!()
+        };
 
         let block_hash = header::hash_from_scale_encoded_header(
             sub_utils::subscribe_best(&self.runtime_service).await.0,
@@ -87,8 +88,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::chain_getBlock`].
     pub(super) async fn chain_get_block(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::chain_getBlock { hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_getBlock { hash } = request.request() else {
+            unreachable!()
+        };
 
         // `hash` equal to `None` means "the current best block".
         let hash = match hash {
@@ -186,8 +188,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::chain_getBlockHash`].
     pub(super) async fn chain_get_block_hash(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::chain_getBlockHash { height } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_getBlockHash { height } = request.request() else {
+            unreachable!()
+        };
 
         // TODO: maybe store values in cache?
         match height {
@@ -214,8 +217,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::chain_getHeader`].
     pub(super) async fn chain_get_header(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::chain_getHeader { hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_getHeader { hash } = request.request() else {
+            unreachable!()
+        };
 
         // `hash` equal to `None` means "best block".
         let hash = match hash {
@@ -328,8 +332,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chain_subscribeAllHeads {  } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_subscribeAllHeads {} = request.request() else {
+            unreachable!()
+        };
 
         self.platform
             .spawn_task(format!("{}-subscribe-all-heads", self.log_target).into(), {
@@ -445,8 +450,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chain_subscribeFinalizedHeads {  }= request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_subscribeFinalizedHeads {} = request.request() else {
+            unreachable!()
+        };
 
         let mut blocks_list = {
             let (finalized_block_header, finalized_blocks_subscription) =
@@ -522,8 +528,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::chain_subscribeNewHeads {  } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::chain_subscribeNewHeads {} = request.request() else {
+            unreachable!()
+        };
 
         let mut blocks_list = {
             let (block_header, blocks_subscription) =
@@ -592,8 +599,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::payment_queryInfo`].
     pub(super) async fn payment_query_info(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::payment_queryInfo { extrinsic, hash: block_hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::payment_queryInfo {
+            extrinsic,
+            hash: block_hash,
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         let block_hash = match block_hash {
             Some(h) => h.0,
@@ -643,8 +655,14 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_call`].
     pub(super) async fn state_call(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_call { name: function_to_call, parameters: call_parameters, hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_call {
+            name: function_to_call,
+            parameters: call_parameters,
+            hash,
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         let block_hash = if let Some(hash) = hash {
             hash.0
@@ -678,8 +696,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_getKeys`].
     pub(super) async fn state_get_keys(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_getKeys { prefix, hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_getKeys { prefix, hash } = request.request() else {
+            unreachable!()
+        };
 
         // `hash` equal to `None` means "best block".
         let hash = match hash {
@@ -741,8 +760,15 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_getKeysPaged`].
     pub(super) async fn state_get_keys_paged(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_getKeysPaged { prefix, count, start_key, hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_getKeysPaged {
+            prefix,
+            count,
+            start_key,
+            hash,
+        } = request.request()
+        else {
+            unreachable!()
+        };
 
         // `hash` equal to `None` means "best block".
         let hash = match hash {
@@ -851,8 +877,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_getMetadata`].
     pub(super) async fn state_get_metadata(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_getMetadata { hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_getMetadata { hash } = request.request() else {
+            unreachable!()
+        };
 
         let block_hash = if let Some(hash) = hash {
             hash.0
@@ -906,7 +933,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         request: service::RequestProcess,
     ) {
         let methods::MethodCall::state_getRuntimeVersion { at: block_hash } = request.request()
-            else { unreachable!() };
+        else {
+            unreachable!()
+        };
 
         let block_hash = match block_hash {
             Some(h) => h.0,
@@ -951,8 +980,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_getStorage`].
     pub(super) async fn state_get_storage(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_getStorage { key, hash } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_getStorage { key, hash } = request.request() else {
+            unreachable!()
+        };
 
         let hash = hash
             .as_ref()
@@ -983,8 +1013,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::state_queryStorageAt`].
     pub(super) async fn state_query_storage_at(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::state_queryStorageAt { keys, at } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_queryStorageAt { keys, at } = request.request() else {
+            unreachable!()
+        };
 
         let best_block = header::hash_from_scale_encoded_header(
             &sub_utils::subscribe_best(&self.runtime_service).await.0,
@@ -1023,8 +1054,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::state_subscribeRuntimeVersion {  } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_subscribeRuntimeVersion {} = request.request() else {
+            unreachable!()
+        };
 
         let runtime_service = self.runtime_service.clone();
 
@@ -1115,8 +1147,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::SubscriptionStartProcess,
     ) {
-        let methods::MethodCall::state_subscribeStorage { list } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::state_subscribeStorage { list } = request.request() else {
+            unreachable!()
+        };
 
         if list.is_empty() {
             // When the list of keys is empty, that means we want to subscribe to *all*
@@ -1194,8 +1227,13 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                                     .await
                                 {
                                     Ok(mut values) => {
-                                        let Some(sync_service::StorageResultItem::Value { value, .. }) = values.pop()
-                                            else { unreachable!() };
+                                        let Some(sync_service::StorageResultItem::Value {
+                                            value,
+                                            ..
+                                        }) = values.pop()
+                                        else {
+                                            unreachable!()
+                                        };
                                         match &mut known_values[key_index] {
                                             Some(v) if *v == value => {}
                                             v => {

--- a/light-base/src/json_rpc_service/background/transactions.rs
+++ b/light-base/src/json_rpc_service/background/transactions.rs
@@ -47,8 +47,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         self: &Arc<Self>,
         request: service::RequestProcess,
     ) {
-        let methods::MethodCall::author_submitExtrinsic { transaction } = request.request()
-            else { unreachable!() };
+        let methods::MethodCall::author_submitExtrinsic { transaction } = request.request() else {
+            unreachable!()
+        };
 
         // Note that this function is misnamed. It should really be called
         // "author_submitTransaction".

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -470,12 +470,12 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                 .peers_assumed_know_blocks(block_number, block_hash)
                 .await
                 .choose(&mut rand::thread_rng())
-                    else {
-                        // No peer knows this block. Returning with a failure.
-                        return Err(StorageQueryError {
-                            errors: outcome_errors,
-                        });
-                    };
+            else {
+                // No peer knows this block. Returning with a failure.
+                return Err(StorageQueryError {
+                    errors: outcome_errors,
+                });
+            };
 
             // Build the list of keys to request.
             let keys_to_request = {

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -401,8 +401,11 @@ fn advance_execution() {
             }
             ExecutionState::NotReady => return,
             ExecutionState::Ready(_) => {
-                let ExecutionState::Ready(runnable) = mem::replace(&mut *executor_execute_guard, ExecutionState::NotReady)
-                    else { unreachable!() };
+                let ExecutionState::Ready(runnable) =
+                    mem::replace(&mut *executor_execute_guard, ExecutionState::NotReady)
+                else {
+                    unreachable!()
+                };
                 runnable
             }
         }


### PR DESCRIPTION
The latest nightly `rustfmt` is now capable of formatting `let-else` blocks.
I've manually run it on the repo.

While this new formatting isn't enforced by CI, doing it now reduces the risk of conflict between PRs I'll open later and the PR that bumps the Rust version to whichever supports this formatting.
