### PR TITLE
Full node: adjust path to database and make sure directory exists

### DIFF
--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -252,14 +252,14 @@ async fn run(cli_options: cli::CliOptionsRun) {
             let parsed_relay_spec = smoldot::chain_spec::ChainSpec::from_json_bytes(&spec_json)
                 .expect("Failed to decode relay chain chain specs");
 
+            // Make sure we're not accidentally opening the same chain twice, otherwise weird
+            // interactions will happen.
+            assert_ne!(parsed_relay_spec.id(), parsed_chain_spec.id());
+
             // Create the directory if necessary.
             if let Some(base_storage_directory) = base_storage_directory.as_ref() {
                 fs::create_dir_all(base_storage_directory.join(parsed_relay_spec.id())).unwrap();
             }
-
-            // Make sure we're not accidentally opening the same chain twice, otherwise weird
-            // interactions will happen.
-            assert_ne!(parsed_relay_spec.id(), parsed_chain_spec.id());
 
             let cfg = smoldot_full_node::ChainConfig {
                 chain_spec: spec_json,

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -219,12 +219,14 @@ async fn run(cli_options: cli::CliOptionsRun) {
         None
     };
 
+    // Create the directory if necessary.
+    if let Some(base_storage_directory) = base_storage_directory.as_ref() {
+        fs::create_dir_all(base_storage_directory.join(parsed_chain_spec.id())).unwrap();
+    }
     // Directory supposed to contain the database.
-    let sqlite_database_path = base_storage_directory.as_ref().map(|d| {
-        d.join(parsed_chain_spec.id())
-            .join("database")
-            .join("database.sqlite")
-    });
+    let sqlite_database_path = base_storage_directory
+        .as_ref()
+        .map(|d| d.join(parsed_chain_spec.id()).join("database"));
     // Directory supposed to contain the keystore.
     let keystore_path = base_storage_directory
         .as_ref()
@@ -249,6 +251,11 @@ async fn run(cli_options: cli::CliOptionsRun) {
 
             let parsed_relay_spec = smoldot::chain_spec::ChainSpec::from_json_bytes(&spec_json)
                 .expect("Failed to decode relay chain chain specs");
+
+            // Create the directory if necessary.
+            if let Some(base_storage_directory) = base_storage_directory.as_ref() {
+                fs::create_dir_all(base_storage_directory.join(parsed_relay_spec.id())).unwrap();
+            }
 
             // Make sure we're not accidentally opening the same chain twice, otherwise weird
             // interactions will happen.


### PR DESCRIPTION
After the latest refactoring, creating the database fails if its directory doesn't exist.
This PR fixes that, and moves the database up one level.