### PR TITLE
Throw an `AddChainError` if the database isn't a string

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Blocks are now reported to `chain_subscribeAllHeads` and `chain_subscribeNewHeads` subscribers only after they have been put in the cache, preventing race conditions where JSON-RPC clients suffer from a cache miss if they ask information about these blocks too quickly. ([#854](https://github.com/smol-dot/smoldot/pull/854))
 - Runtime updates are now always reported to `state_subscribeRuntimeVersion` subscribers immediately after the `chain_subscribeNewHeads` notification corresponding to the block containing the runtime update. They were previously reported in a pseudo-random order. ([#854](https://github.com/smol-dot/smoldot/pull/854))
 - All the storage subscriptions made using `state_subscribeStorage` are now queried together into a single networking request per block, instead of sending one networking query per storage key and per subscription. ([#854](https://github.com/smol-dot/smoldot/pull/854))
-- An `AddChainError` is now thrown if the `databaseContent` parameter is not of type `string`. The database was previously silently ignored.
+- An `AddChainError` is now thrown if the `databaseContent` parameter is not of type `string`. The database was previously silently ignored. ([#861](https://github.com/smol-dot/smoldot/pull/861))
 
 ## 1.0.11 - 2023-06-25
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Blocks are now reported to `chain_subscribeAllHeads` and `chain_subscribeNewHeads` subscribers only after they have been put in the cache, preventing race conditions where JSON-RPC clients suffer from a cache miss if they ask information about these blocks too quickly. ([#854](https://github.com/smol-dot/smoldot/pull/854))
 - Runtime updates are now always reported to `state_subscribeRuntimeVersion` subscribers immediately after the `chain_subscribeNewHeads` notification corresponding to the block containing the runtime update. They were previously reported in a pseudo-random order. ([#854](https://github.com/smol-dot/smoldot/pull/854))
 - All the storage subscriptions made using `state_subscribeStorage` are now queried together into a single networking request per block, instead of sending one networking query per storage key and per subscription. ([#854](https://github.com/smol-dot/smoldot/pull/854))
+- An `AddChainError` is now thrown if the `databaseContent` parameter is not of type `string`. The database was previously silently ignored.
 
 ## 1.0.11 - 2023-06-25
 

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -500,14 +500,14 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
             }
 
             // Sanitize `databaseContent`.
-            if (typeof options.databaseContent !== 'string')
+            if (options.databaseContent !== undefined && typeof options.databaseContent !== 'string')
                 throw new AddChainError("`databaseContent` is not a string");
 
             const promise = new Promise<{ success: true, chainId: number } | { success: false, error: string }>((resolve) => state.addChainResults.push(resolve));
 
             state.instance.instance.addChain(
                 options.chainSpec,
-                options.databaseContent,
+                options.databaseContent || "",
                 potentialRelayChainsIds,
                 !!options.disableJsonRpc,
                 jsonRpcMaxPendingRequests,

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -499,11 +499,15 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                 jsonRpcMaxSubscriptions = 0xffffffff
             }
 
+            // Sanitize `databaseContent`.
+            if (typeof options.databaseContent !== 'string')
+                throw new AddChainError("`databaseContent` is not a string");
+
             const promise = new Promise<{ success: true, chainId: number } | { success: false, error: string }>((resolve) => state.addChainResults.push(resolve));
 
             state.instance.instance.addChain(
                 options.chainSpec,
-                typeof options.databaseContent === 'string' ? options.databaseContent : "",
+                options.databaseContent,
                 potentialRelayChainsIds,
                 !!options.disableJsonRpc,
                 jsonRpcMaxPendingRequests,


### PR DESCRIPTION
When not using TypeScript, it is easy to accidentally pass an `ArrayBuffer` or similar.