### PR TITLE
Slim down `futures_util` usage in `lib`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,7 @@ database-sqlite = [
 ]
 std = [
     "futures-executor/thread-pool",
-    "futures-util/io",
+    "futures-util",
     "dep:pin-project",
     "schnorrkel/getrandom", # TODO: necessary for signing; clarify in docs and in source code
     "dep:smol",
@@ -51,7 +51,6 @@ event-listener = { version = "2.5.3" }  # TODO: no-std-ize
 fnv = { version = "1.0.7", default-features = false }
 futures-lite = { version = "1.13.0", default-features = false, features = ["alloc"] }
 futures-channel = { version = "0.3.27", features = ["std", "sink"] }   # TODO: no-std-ize and remove "sink"
-futures-util = { version = "0.3.27", default-features = false, features = ["std", "async-await-macro", "sink"] }  # TODO: slim down these features
 hashbrown = { version = "0.14.0", default-features = false, features = ["serde"] }   # TODO: remove serde feature
 hex = { version = "0.4.3", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
@@ -87,6 +86,7 @@ rusqlite = { version = "0.29.0", optional = true, default-features = false, feat
 
 # `std` feature
 # Add here the crates that cannot function without the help of the operating system or environment.
+futures-util = { version = "0.3.27", optional = true, default-features = false, features = ["std",  "io", "async-await-macro", "sink"] }  # TODO: slim down these features
 parking_lot = { version = "0.12.1", optional = true }
 pin-project = { version = "1.1.1", optional = true }
 smol = { version = "1.3.0", optional = true }

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -29,8 +29,7 @@ use core::{
     slice,
     task::{Context, Poll, Waker},
 };
-use futures_lite::FutureExt as _;
-use futures_util::task;
+use futures_util::{task, FutureExt as _};
 // TODO: we use std::sync::Mutex rather than parking_lot::Mutex due to issues with Cargo features, see <https://github.com/paritytech/smoldot/issues/2732>
 use std::sync::Mutex;
 

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -29,7 +29,8 @@ use core::{
     slice,
     task::{Context, Poll, Waker},
 };
-use futures_util::{task, FutureExt as _};
+use futures_lite::FutureExt as _;
+use futures_util::task;
 // TODO: we use std::sync::Mutex rather than parking_lot::Mutex due to issues with Cargo features, see <https://github.com/paritytech/smoldot/issues/2732>
 use std::sync::Mutex;
 


### PR DESCRIPTION
No longer use it in `client_main_task`, meaning that we can make it optional.