### PR TITLE
Clean up many usages of `futures_util::future::select`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "event-listener",
  "fnv",
  "futures-channel",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.0",
  "hex",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -24,6 +24,7 @@ either = { version = "1.8.1", default-features = false }
 event-listener = "2.5.3"
 fnv = { version = "1.0.7", default-features = false }
 futures-channel = "0.3.27"
+futures-lite = { version = "1.13.0", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -306,7 +306,7 @@ pub struct JsonRpcResponses {
     ///
     /// As long as this object is alive, the JSON-RPC service will continue running. In order
     /// to prevent that from happening, we destroy it as soon as the
-    /// [`JsonRpcResponses::public_api_chain_destroyed_rx`] is notified of the destruction of
+    /// [`JsonRpcResponses::public_api_chain_destroyed`] is notified of the destruction of
     /// the sender.
     inner: Option<json_rpc_service::Frontend>,
 

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -26,6 +26,7 @@ pub mod default;
 /// Implementations of this trait are expected to be cheaply-clonable "handles". All clones of the
 /// same platform share the same objects. For instance, it is legal to create clone a platform,
 /// then create a connection on one clone, then access this connection on the other clone.
+// TODO: remove `Unpin` trait bounds
 pub trait PlatformRef: Clone + Send + Sync + 'static {
     type Delay: Future<Output = ()> + Unpin + Send + 'static;
     type Instant: Clone


### PR DESCRIPTION
I'm progressively trying to get rid of all calls to `futures_util::select`, both the macro and the function, for #133.

This is another step.
