### PR TITLE
Add an `include` field to the Cargo.tomls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krie
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 edition = "2021"
 repository = "https://github.com/smol-dot/smoldot"
+include = ["**/*.rs"]  # Only Rust files are included, as anything else might be a test fixture.
 
 [profile.dev]
 debug = 1    # Default value is `2`, which contains the full debug info. `1` is enough for stack traces.  # TODO: use the named version after Cargo v1.71

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+include.workspace = true
 publish = false
 default-run = "full-node"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+include.workspace = true
 
 [features]
 default = ["database-sqlite", "std", "wasmtime"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+include.workspace = true
 
 [[example]]
 name = "basic"

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+include.workspace = true
 publish = false
 
 [lib]


### PR DESCRIPTION
This field is now necessary because the introduction of test fixtures made the package size go over the 10 MiB limit allowed by `crates.io`.

Versions 0.8 and 0.9 published on crates.io (https://github.com/smol-dot/smoldot/pull/881) include this pull request.

While it would have been better to revert https://github.com/smol-dot/smoldot/pull/881, then submit a new PR with both the version bumps and this change, I don't think anyone will mind skipping this process.
