### PR TITLE
Remove weird `Config::show_informant` option of full node

### DIFF
--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -401,7 +401,6 @@ async fn run(cli_options: cli::CliOptionsRun) {
         },
         log_callback: log_callback.clone(),
         jaeger_agent: cli_options.jaeger,
-        show_informant: matches!(cli_output, cli::Output::Informant),
     })
     .await;
 

--- a/full-node/tests/author.rs
+++ b/full-node/tests/author.rs
@@ -39,7 +39,6 @@ fn basic_block_generated() {
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
             log_callback: Arc::new(move |_, _| {}),
             jaeger_agent: None,
-            show_informant: false,
         })
         .await;
 


### PR DESCRIPTION
This field was left because I didn't know what to do here.
However I think that the database isn't supposed to take a long time to open, it's just an issue somewhere.