### PR TITLE
Refactor the light client network_service

### DIFF
--- a/lib/src/network/protocol/storage_call_proof.rs
+++ b/lib/src/network/protocol/storage_call_proof.rs
@@ -17,7 +17,7 @@
 
 use crate::util::protobuf;
 
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 
 /// Description of a storage proof request that can be sent to a peer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,7 +54,7 @@ pub struct CallProofRequestConfig<'a, I> {
     /// Hash of the block to request the storage of.
     pub block_hash: [u8; 32],
     /// Name of the runtime function to call.
-    pub method: &'a str,
+    pub method: Cow<'a, str>,
     /// Iterator to buffers of bytes to be concatenated then passed as input to the call. The
     /// semantics of these bytes depend on which method is being called.
     pub parameter_vectored: I,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1078,7 +1078,7 @@ async fn background_task<TPlat: PlatformRef>(
                     "".into(),
                     tasks::single_stream_connection_task::<TPlat>(
                         connection,
-                        shared.clone(),
+                        shared.platform.clone(),
                         connection_id,
                         connection_task,
                         coordinator_to_connection_rx,
@@ -1118,7 +1118,7 @@ async fn background_task<TPlat: PlatformRef>(
                     "".into(),
                     tasks::webrtc_multi_stream_connection_task::<TPlat>(
                         connection,
-                        shared.clone(),
+                        shared.platform.clone(),
                         connection_id,
                         connection_task,
                         coordinator_to_connection_rx,
@@ -1789,7 +1789,7 @@ async fn background_task<TPlat: PlatformRef>(
                 // Perform the connection process in a separate task.
                 let task = tasks::connection_task(
                     start_connect,
-                    shared.clone(),
+                    shared.platform.clone(),
                     shared.messages_tx.clone(),
                     is_important,
                 );

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1722,11 +1722,6 @@ async fn update_round<TPlat: PlatformRef>(
 
         // Dispatch the event to the various senders.
 
-        // Because the tasks processing the receivers might be waiting to acquire the lock, we
-        // need to unlock the lock before sending. This guarantees that the sending finishes at
-        // some point in the future.
-        drop(guarded);
-
         // This little `if` avoids having to do `event.clone()` if we don't have to.
         if event_senders.len() == 1 {
             let _ = event_senders[0].send(event).await;
@@ -1738,9 +1733,6 @@ async fn update_round<TPlat: PlatformRef>(
                 let _ = sender.send(event.clone()).await;
             }
         }
-
-        // Re-acquire lock to continue the function.
-        guarded = shared.guarded.lock().await;
     }
 
     // TODO: doc

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1298,6 +1298,9 @@ async fn update_round<TPlat: PlatformRef>(
         };
     }
 
+    // TODO: this is hacky; instead, should be cleaned up as a response to an event from the service; no such event exists yet
+    guarded.active_connections.retain(|_, tx| !tx.is_closed());
+
     // Process the events that the coordinator has generated.
     'events_loop: loop {
         let event = loop {

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -36,7 +36,7 @@ use smoldot::{
 pub(super) async fn connection_task<TPlat: PlatformRef>(
     start_connect: service::StartConnect<TPlat::Instant>,
     shared: Arc<Shared<TPlat>>,
-    connection_to_coordinator_tx: mpsc::Sender<ToBackground>,
+    connection_to_coordinator_tx: mpsc::Sender<ToBackground<TPlat>>,
     is_important: bool,
 ) {
     log::debug!(
@@ -234,7 +234,7 @@ async fn single_stream_connection_task<TPlat: PlatformRef>(
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<TPlat::Instant>,
     coordinator_to_connection: mpsc::Receiver<service::CoordinatorToConnection<TPlat::Instant>>,
-    mut connection_to_coordinator: mpsc::Sender<ToBackground>,
+    mut connection_to_coordinator: mpsc::Sender<ToBackground<TPlat>>,
 ) {
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();
@@ -442,7 +442,7 @@ async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     connection_id: service::ConnectionId,
     mut connection_task: service::MultiStreamConnectionTask<TPlat::Instant, usize>,
     coordinator_to_connection: mpsc::Receiver<service::CoordinatorToConnection<TPlat::Instant>>,
-    mut connection_to_coordinator: mpsc::Sender<ToBackground>,
+    mut connection_to_coordinator: mpsc::Sender<ToBackground<TPlat>>,
 ) {
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -23,9 +23,8 @@ use crate::platform::{
 
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{cmp, iter, pin};
-use futures_channel::mpsc;
 use futures_lite::FutureExt as _;
-use futures_util::{future, FutureExt as _, SinkExt as _, StreamExt as _};
+use futures_util::{future, FutureExt as _, StreamExt as _};
 use smoldot::{
     libp2p::{collection::SubstreamFate, read_write::ReadWrite},
     network::service,
@@ -36,7 +35,7 @@ use smoldot::{
 pub(super) async fn connection_task<TPlat: PlatformRef>(
     start_connect: service::StartConnect<TPlat::Instant>,
     shared: Arc<Shared<TPlat>>,
-    mut connection_to_coordinator_tx: mpsc::Sender<ToBackground<TPlat>>,
+    connection_to_coordinator_tx: async_channel::Sender<ToBackground<TPlat>>,
     is_important: bool,
 ) {
     log::debug!(
@@ -198,8 +197,10 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
     shared: Arc<Shared<TPlat>>,
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<TPlat::Instant>,
-    coordinator_to_connection: mpsc::Receiver<service::CoordinatorToConnection<TPlat::Instant>>,
-    mut connection_to_coordinator: mpsc::Sender<ToBackground<TPlat>>,
+    coordinator_to_connection: async_channel::Receiver<
+        service::CoordinatorToConnection<TPlat::Instant>,
+    >,
+    connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();
@@ -394,8 +395,10 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     shared: Arc<Shared<TPlat>>,
     connection_id: service::ConnectionId,
     mut connection_task: service::MultiStreamConnectionTask<TPlat::Instant, usize>,
-    coordinator_to_connection: mpsc::Receiver<service::CoordinatorToConnection<TPlat::Instant>>,
-    mut connection_to_coordinator: mpsc::Sender<ToBackground<TPlat>>,
+    coordinator_to_connection: async_channel::Receiver<
+        service::CoordinatorToConnection<TPlat::Instant>,
+    >,
+    connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -333,18 +333,6 @@ async fn single_stream_connection_task<TPlat: PlatformRef>(
         // this function.
         let (mut task_update, message) = connection_task.pull_message_to_coordinator();
 
-        // If `task_update` is `None`, the connection task is going to die as soon as the
-        // message reaches the coordinator. Before returning, we need to do a bit of clean up
-        // by removing the task from the list of active connections.
-        // This is done before the message is sent to the coordinator, in order to be sure
-        // that the connection id is still attributed to the current task, and not to a new
-        // connection that the coordinator has assigned after receiving the message.
-        if task_update.is_none() {
-            let mut guarded = shared.guarded.lock().await;
-            let _was_in = guarded.active_connections.remove(&connection_id);
-            debug_assert!(_was_in.is_some());
-        }
-
         let has_message = message.is_some();
         if let Some(message) = message {
             // Sending this message might take a long time (in case the coordinator is busy),
@@ -589,18 +577,6 @@ async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
             // connection must be abruptly closed, which is what happens when we return from
             // this function.
             let (mut task_update, message) = connection_task.pull_message_to_coordinator();
-
-            // If `task_update` is `None`, the connection task is going to die as soon as the
-            // message reaches the coordinator. Before returning, we need to do a bit of clean up
-            // by removing the task from the list of active connections.
-            // This is done before the message is sent to the coordinator, in order to be sure
-            // that the connection id is still attributed to the current task, and not to a new
-            // connection that the coordinator has assigned after receiving the message.
-            if task_update.is_none() {
-                let mut guarded = shared.guarded.lock().await;
-                let _was_in = guarded.active_connections.remove(&connection_id);
-                debug_assert!(_was_in.is_some());
-            }
 
             let has_message = message.is_some();
             if let Some(message) = message {

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -132,10 +132,6 @@ pub(super) async fn connection_task<TPlat: PlatformRef>(
                     .await
                     .unwrap();
 
-                // We wake up the background task so that the slot can potentially be
-                // assigned to a different peer.
-                shared.wake_up_main_background_task.notify(1);
-
                 // Stop the task.
                 return;
             }
@@ -330,8 +326,6 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
             if send_out.or(process_in).await.is_err() {
                 return;
             }
-
-            shared.wake_up_main_background_task.notify(1);
         }
 
         if let Some(task_update) = task_update {
@@ -577,8 +571,6 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
                 if send_out.or(process_in).await.is_err() {
                     return;
                 }
-
-                shared.wake_up_main_background_task.notify(1);
             }
 
             if let Some(task_update) = task_update {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -812,7 +812,7 @@ impl<TPlat: PlatformRef> RuntimeAccess<TPlat> {
                 self.block_number,
                 protocol::CallProofRequestConfig {
                     block_hash: self.hash,
-                    method,
+                    method: method.into(),
                     parameter_vectored: parameter_vectored.clone(),
                 },
                 total_attempts,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -564,7 +564,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         peer_id,
                         network::protocol::CallProofRequestConfig {
                             block_hash,
-                            method: &function_name,
+                            method: function_name,
                             parameter_vectored: iter::once(parameter_vectored),
                         },
                         Duration::from_secs(16),


### PR DESCRIPTION
This PR aims (and in my opinion, succeeds) at simplifying the `network_service` of the light client.

Previously, multiple different tasks all shared a `Mutex` that they can lock whenever they want.
While this is rather efficient, it also leads to a lot of complexity. Some tasks have to be careful to unlock the `Mutex` in order to avoid deadlocks, some tasks have to wake up others, and so on.

This PR gets rid of this `Mutex` altogether, and does everything through messages.
There's now a single background task that handles messages coming in and sends back messages.

Can be reviewed commit by commit. Each commit was very straight forward.
