### PR TITLE
Add a `PlaformRef::fill_random_bytes` function and use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "no-std-net",
  "parking_lot",
  "rand",
+ "rand_chacha",
  "serde",
  "serde_json",
  "siphasher",

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -30,7 +30,8 @@ itertools = "0.11.0"
 log = { version = "0.4.18", default-features = false }
 lru = { version = "0.11.0", default-features = false }
 no-std-net = { version = "0.6.0", default-features = false }
-rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"] }  # TODO: no-std-size
+rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
+rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.167", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.100", default-features = false, features = ["alloc"] }
 siphasher = { version = "0.3.10", default-features = false }
@@ -45,7 +46,7 @@ smol = { version = "1.3.0", optional = true }
 
 [features]
 default = ["std", "wasmtime"]
-std = ["dep:parking_lot", "dep:smol", "smoldot/std"]
+std = ["dep:parking_lot", "dep:smol", "rand/std", "rand/std_rng", "smoldot/std"]
 wasmtime = ["smoldot/wasmtime"]
 
 [dev-dependencies]

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -140,7 +140,6 @@ pub(super) fn start<TPlat: PlatformRef>(
 
     let me = Arc::new(Background {
         log_target,
-        platform: config.platform,
         chain_name: config.chain_spec.name().to_owned(),
         chain_ty: config.chain_spec.chain_type().to_owned(),
         chain_is_live: config.chain_spec.has_live_network(),
@@ -155,11 +154,16 @@ pub(super) fn start<TPlat: PlatformRef>(
         to_legacy: Mutex::new(to_legacy_tx.clone()),
         state_get_keys_paged_cache: Mutex::new(lru::LruCache::with_hasher(
             NonZeroUsize::new(2).unwrap(),
-            util::SipHasherBuild::new(rand::random()),
+            util::SipHasherBuild::new({
+                let mut seed = [0; 16];
+                config.platform.fill_random_bytes(&mut seed);
+                seed
+            }),
         )),
         genesis_block_hash: config.genesis_block_hash,
         printed_legacy_json_rpc_warning: atomic::AtomicBool::new(false),
         chain_head_follow_tasks: Mutex::new(hashbrown::HashMap::with_hasher(Default::default())),
+        platform: config.platform,
     });
 
     let (tx, rx) = async_channel::bounded(

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -170,7 +170,11 @@ pub(super) fn start_task<TPlat: PlatformRef>(
             ),
             storage_subscriptions_by_key: hashbrown::HashMap::with_capacity_and_hasher(
                 16,
-                crate::util::SipHasherBuild::new(rand::random()),
+                crate::util::SipHasherBuild::new({
+                    let mut seed = [0; 16];
+                    config.platform.fill_random_bytes(&mut seed);
+                    seed
+                }),
             ),
             stale_storage_subscriptions: hashbrown::HashSet::with_capacity_and_hasher(
                 16,
@@ -479,9 +483,11 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
 
                 // Build the list of keys that must be requested by aggregating the keys requested
                 // by all stale storage subscriptions.
-                let mut keys = hashbrown::HashSet::with_hasher(crate::util::SipHasherBuild::new(
-                    rand::random(),
-                ));
+                let mut keys = hashbrown::HashSet::with_hasher(crate::util::SipHasherBuild::new({
+                    let mut seed = [0; 16];
+                    task.platform.fill_random_bytes(&mut seed);
+                    seed
+                }));
                 keys.extend(
                     task.stale_storage_subscriptions
                         .iter()

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -214,13 +214,21 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                         max_addresses_per_peer: NonZeroUsize::new(5).unwrap(),
                         noise_key: config.noise_key,
                         handshake_timeout: Duration::from_secs(8),
-                        randomness_seed: rand::random(),
+                        randomness_seed: {
+                            let mut seed = [0; 32];
+                            config.platform.fill_random_bytes(&mut seed);
+                            seed
+                        },
                     }),
                     platform: config.platform.clone(),
                     event_senders: either::Left(event_senders),
                     slots_assign_backoff: HashMap::with_capacity_and_hasher(
                         32,
-                        util::SipHasherBuild::new(rand::random()),
+                        util::SipHasherBuild::new({
+                            let mut seed = [0; 16];
+                            config.platform.fill_random_bytes(&mut seed);
+                            seed
+                        }),
                     ),
                     important_nodes: HashSet::with_capacity_and_hasher(16, Default::default()),
                     active_connections: HashMap::with_capacity_and_hasher(32, Default::default()),

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -81,6 +81,14 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     /// Returns an object that represents "now".
     fn now(&self) -> Self::Instant;
 
+    /// The given buffer must be completely filled with pseudo-random bytes.
+    ///
+    /// # Panic
+    ///
+    /// Must panic if for some reason it is not possible to fill the buffer.
+    ///
+    fn fill_random_bytes(&self, buffer: &mut [u8]);
+
     /// Creates a future that becomes ready after at least the given duration has elapsed.
     fn sleep(&self, duration: Duration) -> Self::Delay;
 

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -66,6 +66,11 @@ impl PlatformRef for Arc<DefaultPlatform> {
         std::time::Instant::now()
     }
 
+    fn fill_random_bytes(&self, buffer: &mut [u8]) {
+        use rand::RngCore as _;
+        rand::thread_rng().fill_bytes(buffer);
+    }
+
     fn sleep(&self, duration: Duration) -> Self::Delay {
         smol::Timer::after(duration).map(|_| ()).boxed()
     }

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -59,7 +59,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
 
         ParachainBackgroundTask {
             log_target,
-            platform,
             from_foreground,
             block_number_bytes,
             relay_chain_block_number_bytes,
@@ -75,7 +74,11 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
             obsolete_finalized_parahead,
             sync_sources_map: HashMap::with_capacity_and_hasher(
                 0,
-                util::SipHasherBuild::new(rand::random()),
+                util::SipHasherBuild::new({
+                    let mut seed = [0; 16];
+                    platform.fill_random_bytes(&mut seed);
+                    seed
+                }),
             ),
             subscription_state: ParachainBackgroundState::NotSubscribed {
                 all_subscriptions: Vec::new(),
@@ -95,6 +98,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                 },
             },
             relay_chain_sync,
+            platform,
         }
     };
 

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -106,7 +106,11 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
         network_chain_index,
         peers_source_id_map: HashMap::with_capacity_and_hasher(
             0,
-            util::SipHasherBuild::new(rand::random()),
+            util::SipHasherBuild::new({
+                let mut seed = [0; 16];
+                platform.fill_random_bytes(&mut seed);
+                seed
+            }),
         ),
         platform,
     };
@@ -687,7 +691,11 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 // Grandpa warp sync fragment to verify.
                 let sender_peer_id = verify.proof_sender().1 .0.clone(); // TODO: unnecessary cloning most of the time
 
-                let (sync, result) = verify.perform(rand::random());
+                let (sync, result) = verify.perform({
+                    let mut seed = [0; 32];
+                    self.platform.fill_random_bytes(&mut seed);
+                    seed
+                });
                 self.sync = sync;
 
                 if let Err(err) = result {
@@ -861,7 +869,11 @@ impl<TPlat: PlatformRef> Task<TPlat> {
 
             all::ProcessOne::VerifyFinalityProof(verify) => {
                 // Finality proof to verify.
-                match verify.perform(rand::random()) {
+                match verify.perform({
+                    let mut seed = [0; 32];
+                    self.platform.fill_random_bytes(&mut seed);
+                    seed
+                }) {
                     (
                         sync,
                         all::FinalityProofVerifyOutcome::NewFinalized {

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -83,6 +83,11 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         Instant::now()
     }
 
+    fn fill_random_bytes(&self, buffer: &mut [u8]) {
+        use rand::RngCore as _;
+        rand::thread_rng().fill_bytes(buffer);
+    }
+
     fn sleep(&self, duration: Duration) -> Self::Delay {
         Delay::new(duration)
     }


### PR DESCRIPTION
cc #133 

Rather than rely on `getrandom`, the `smoldot-light` crate now uses a new `PlatformRef::fill_random_bytes` function.

The `rand/std` feature is still enabled when the `std` feature is enabled, in order to provide the default platform implementation.
