### PR TITLE
Add support for keccak256 trie host functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2351,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.7",
+ "sha3",
  "siphasher",
  "slab",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,6 @@ dependencies = [
  "smallvec",
  "soketto",
  "tempfile",
- "tiny-keccak",
  "twox-hash",
  "wasmi",
  "wasmtime",
@@ -2640,15 +2639,6 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -701,6 +701,7 @@ async fn open_database(
                             partial_key,
                             storage_value,
                         },
+                        trie::HashFunction::Blake2,
                         is_root_node,
                     )
                     .unwrap();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -71,10 +71,11 @@ schnorrkel = { version = "0.10.2", default-features = false, features = ["preaud
 serde = { version = "1.0.167", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.102", default-features = false, features = ["alloc", "raw_value"] }
 sha2 = { version = "0.10.7", default-features = false }
+sha3 = { version = "0.10.8", default-features = false }
 siphasher = { version = "0.3.10", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
-tiny-keccak = { version = "2.0", features = ["keccak"] }
+tiny-keccak = { version = "2.0", features = ["keccak"] } # TODO: redundant with `sha3` crate
 twox-hash = { version = "1.6.3", default-features = false }
 wasmi = { version = "0.30.0", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -75,7 +75,6 @@ sha3 = { version = "0.10.8", default-features = false }
 siphasher = { version = "0.3.10", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
-tiny-keccak = { version = "2.0", features = ["keccak"] } # TODO: redundant with `sha3` crate
 twox-hash = { version = "1.6.3", default-features = false }
 wasmi = { version = "0.30.0", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -585,7 +585,7 @@ impl ChainInformationBuild {
                         parent_hash: &[0; 32],
                         number: 0,
                         state_root: &state_trie_root_hash,
-                        extrinsics_root: &trie::EMPTY_TRIE_MERKLE_VALUE,
+                        extrinsics_root: &trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty(),
                     }
                     .scale_encoding_vec(inner.block_number_bytes);

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -126,7 +126,8 @@ impl ChainSpec {
                     match self.genesis_storage() {
                         GenesisStorage::TrieRootHash(hash) => *hash,
                         GenesisStorage::Items(genesis_storage) => {
-                            let mut calculation = trie::calculate_root::root_merkle_value();
+                            let mut calculation =
+                                trie::calculate_root::root_merkle_value(trie::HashFunction::Blake2);
 
                             loop {
                                 match calculation {

--- a/lib/src/database/full_sqlite/tests.rs
+++ b/lib/src/database/full_sqlite/tests.rs
@@ -106,6 +106,7 @@ fn empty_database_fill_then_query() {
                     partial_key,
                     storage_value,
                 },
+                trie::HashFunction::Blake2,
                 is_root_node,
             )
             .unwrap();
@@ -118,7 +119,7 @@ fn empty_database_fill_then_query() {
             let state_root = &trie
                 .root_user_data()
                 .map(|n| *<&[u8; 32]>::try_from(n.1.as_ref().unwrap().as_ref()).unwrap())
-                .unwrap_or(trie::EMPTY_TRIE_MERKLE_VALUE);
+                .unwrap_or(trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE);
 
             let trie_entries_linear =
                 trie.iter_unordered()

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -202,7 +202,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{fmt, hash::Hasher as _, iter, str};
-use sha2::Digest as _;
 
 pub mod runtime_version;
 
@@ -1619,13 +1618,9 @@ impl ReadyToRun {
                     .alloc_write_and_return_pointer(host_fn.name(), iter::once(&hash))
             }
             HostFunction::ext_hashing_sha2_256_version_1 => {
-                let mut hasher = sha2::Sha256::new();
-                hasher.update(expect_pointer_size!(0));
-
-                self.inner.alloc_write_and_return_pointer(
-                    host_fn.name(),
-                    iter::once(hasher.finalize().as_slice()),
-                )
+                let hash = <sha2::Sha256 as sha2::Digest>::digest(expect_pointer_size!(0).as_ref());
+                self.inner
+                    .alloc_write_and_return_pointer(host_fn.name(), iter::once(&hash))
             }
             HostFunction::ext_hashing_blake2_128_version_1 => {
                 let out = {

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -203,7 +203,6 @@ use alloc::{
 };
 use core::{fmt, hash::Hasher as _, iter, str};
 use sha2::Digest as _;
-use tiny_keccak::Hasher as _;
 
 pub mod runtime_version;
 
@@ -1608,22 +1607,16 @@ impl ReadyToRun {
                 })
             }
             HostFunction::ext_hashing_keccak_256_version_1 => {
-                let mut keccak = tiny_keccak::Keccak::v256();
-                keccak.update(expect_pointer_size!(0).as_ref());
-                let mut out = [0u8; 32];
-                keccak.finalize(&mut out);
-
+                let hash =
+                    <sha3::Keccak256 as sha3::Digest>::digest(expect_pointer_size!(0).as_ref());
                 self.inner
-                    .alloc_write_and_return_pointer(host_fn.name(), iter::once(&out))
+                    .alloc_write_and_return_pointer(host_fn.name(), iter::once(&hash))
             }
             HostFunction::ext_hashing_keccak_512_version_1 => {
-                let mut keccak = tiny_keccak::Keccak::v512();
-                keccak.update(expect_pointer_size!(0).as_ref());
-                let mut out = [0u8; 64];
-                keccak.finalize(&mut out);
-
+                let hash =
+                    <sha3::Keccak512 as sha3::Digest>::digest(expect_pointer_size!(0).as_ref());
                 self.inner
-                    .alloc_write_and_return_pointer(host_fn.name(), iter::once(&out))
+                    .alloc_write_and_return_pointer(host_fn.name(), iter::once(&hash))
             }
             HostFunction::ext_hashing_sha2_256_version_1 => {
                 let mut hasher = sha2::Sha256::new();

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -1815,13 +1815,18 @@ impl ReadyToRun {
                 host_fn_not_implemented!()
             }
             HostFunction::ext_trie_blake2_256_root_version_1
-            | HostFunction::ext_trie_blake2_256_root_version_2 => {
-                let state_version =
-                    if matches!(host_fn, HostFunction::ext_trie_blake2_256_root_version_2) {
-                        expect_state_version!(1)
-                    } else {
-                        TrieEntryVersion::V0
-                    };
+            | HostFunction::ext_trie_blake2_256_root_version_2
+            | HostFunction::ext_trie_keccak_256_root_version_1
+            | HostFunction::ext_trie_keccak_256_root_version_2 => {
+                let state_version = if matches!(
+                    host_fn,
+                    HostFunction::ext_trie_blake2_256_root_version_2
+                        | HostFunction::ext_trie_keccak_256_root_version_2
+                ) {
+                    expect_state_version!(1)
+                } else {
+                    TrieEntryVersion::V0
+                };
 
                 let result = {
                     let input = expect_pointer_size!(0);
@@ -1848,7 +1853,19 @@ impl ReadyToRun {
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
-                        Ok(elements) => Ok(trie::trie_root(state_version, &elements[..])),
+                        Ok(elements) => Ok(trie::trie_root(
+                            state_version,
+                            if matches!(
+                                host_fn,
+                                HostFunction::ext_trie_blake2_256_root_version_1
+                                    | HostFunction::ext_trie_blake2_256_root_version_2
+                            ) {
+                                trie::HashFunction::Blake2
+                            } else {
+                                trie::HashFunction::Keccak256
+                            },
+                            &elements[..],
+                        )),
                         Err(_) => Err(()),
                     }
                 };
@@ -1864,10 +1881,13 @@ impl ReadyToRun {
                 }
             }
             HostFunction::ext_trie_blake2_256_ordered_root_version_1
-            | HostFunction::ext_trie_blake2_256_ordered_root_version_2 => {
+            | HostFunction::ext_trie_blake2_256_ordered_root_version_2
+            | HostFunction::ext_trie_keccak_256_ordered_root_version_1
+            | HostFunction::ext_trie_keccak_256_ordered_root_version_2 => {
                 let state_version = if matches!(
                     host_fn,
                     HostFunction::ext_trie_blake2_256_ordered_root_version_2
+                        | HostFunction::ext_trie_keccak_256_ordered_root_version_2
                 ) {
                     expect_state_version!(1)
                 } else {
@@ -1893,7 +1913,19 @@ impl ReadyToRun {
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
-                        Ok(elements) => Ok(trie::ordered_root(state_version, &elements[..])),
+                        Ok(elements) => Ok(trie::ordered_root(
+                            state_version,
+                            if matches!(
+                                host_fn,
+                                HostFunction::ext_trie_blake2_256_ordered_root_version_1
+                                    | HostFunction::ext_trie_blake2_256_ordered_root_version_2
+                            ) {
+                                trie::HashFunction::Blake2
+                            } else {
+                                trie::HashFunction::Keccak256
+                            },
+                            &elements[..],
+                        )),
                         Err(_) => Err(()),
                     }
                 };
@@ -1908,10 +1940,6 @@ impl ReadyToRun {
                     },
                 }
             }
-            HostFunction::ext_trie_keccak_256_root_version_1 => host_fn_not_implemented!(),
-            HostFunction::ext_trie_keccak_256_root_version_2 => host_fn_not_implemented!(),
-            HostFunction::ext_trie_keccak_256_ordered_root_version_1 => host_fn_not_implemented!(),
-            HostFunction::ext_trie_keccak_256_ordered_root_version_2 => host_fn_not_implemented!(),
             HostFunction::ext_trie_blake2_256_verify_proof_version_1 => host_fn_not_implemented!(),
             HostFunction::ext_trie_blake2_256_verify_proof_version_2 => host_fn_not_implemented!(),
             HostFunction::ext_trie_keccak_256_verify_proof_version_1 => host_fn_not_implemented!(),

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -1361,7 +1361,7 @@ impl Inner {
                         main_trie_key.extend_from_slice(DEFAULT_CHILD_STORAGE_SPECIAL_PREFIX);
                         main_trie_key.extend_from_slice(child_trie);
 
-                        if trie_root_hash != trie::EMPTY_TRIE_MERKLE_VALUE {
+                        if trie_root_hash != trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE {
                             self.pending_storage_changes
                                 .trie_diffs
                                 .entry(None)

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -200,7 +200,7 @@ impl ClosestDescendant {
                     } else {
                         // If the element doesn't have a parent, then the trie is completely empty.
                         InProgress::Finished {
-                            trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
+                            trie_root_hash: trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                         }
                     };
                 }
@@ -339,7 +339,7 @@ impl StorageValue {
                 // This case is handled separately in order to not generate
                 // a `TrieNodeInsertUpdateEvent` for a node that doesn't actually exist.
                 InProgress::Finished {
-                    trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
+                    trie_root_hash: trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                 }
             }
 
@@ -373,6 +373,7 @@ impl StorageValue {
                             (None, _) => trie::trie_node::StorageValue::None,
                         },
                     },
+                    trie::HashFunction::Blake2,
                     parent_node.is_none(),
                 )
                 .unwrap_or_else(|_| panic!());
@@ -582,7 +583,7 @@ impl TrieNodeRemoveEvent {
                     self.inner.next()
                 } else {
                     InProgress::Finished {
-                        trie_root_hash: trie::EMPTY_TRIE_MERKLE_VALUE,
+                        trie_root_hash: trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                     }
                 }
             }

--- a/lib/src/executor/trie_root_calculator/tests.rs
+++ b/lib/src/executor/trie_root_calculator/tests.rs
@@ -34,7 +34,7 @@ fn empty_trie_works() {
     loop {
         match calculation {
             InProgress::Finished { trie_root_hash } => {
-                assert_eq!(trie_root_hash, trie::EMPTY_TRIE_MERKLE_VALUE);
+                assert_eq!(trie_root_hash, trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE);
                 return;
             }
             InProgress::ClosestDescendant(req) => {
@@ -72,6 +72,7 @@ fn one_inserted_node_in_diff() {
                         partial_key: trie::bytes_to_nibbles(vec![0xaa, 0xaa].into_iter()),
                         storage_value: trie::trie_node::StorageValue::Unhashed(b"foo"),
                     },
+                    trie::HashFunction::Blake2,
                     true,
                 )
                 .unwrap();
@@ -263,6 +264,7 @@ fn fuzzing() {
                         partial_key,
                         storage_value,
                     },
+                    trie::HashFunction::Blake2,
                     is_root_node,
                 )
                 .unwrap();
@@ -410,7 +412,7 @@ fn fuzzing() {
         let expected_hash = trie_after_diff
             .root_user_data()
             .map(|n| *<&[u8; 32]>::try_from(n.1.as_ref().unwrap().as_ref()).unwrap())
-            .unwrap_or(trie::EMPTY_TRIE_MERKLE_VALUE);
+            .unwrap_or(trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE);
         if obtained_hash != expected_hash {
             panic!(
                 "\nexpected = {:?}\ncalculated = {:?}\ntrie_before = {:?}\ndiff = {:?}",

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -119,7 +119,11 @@ pub fn hash_from_scale_encoded_header_vectored(
 /// transactions in that block.
 pub fn extrinsics_root(transactions: &[impl AsRef<[u8]>]) -> [u8; 32] {
     // The extrinsics root is always calculated with V0 of the trie.
-    trie::ordered_root(trie::TrieEntryVersion::V0, transactions)
+    trie::ordered_root(
+        trie::TrieEntryVersion::V0,
+        trie::HashFunction::Blake2,
+        transactions,
+    )
 }
 
 /// Attempt to decode the given SCALE-encoded header.

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -81,15 +81,17 @@
 use super::{
     branch_search,
     nibble::{nibbles_to_bytes_suffix_extend, Nibble},
-    trie_node, TrieEntryVersion, EMPTY_TRIE_MERKLE_VALUE,
+    trie_node, HashFunction, TrieEntryVersion, EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
+    EMPTY_KECCAK256_TRIE_MERKLE_VALUE,
 };
 
 use alloc::vec::Vec;
 use core::array;
 
 /// Start calculating the Merkle value of the root node.
-pub fn root_merkle_value() -> RootMerkleValueCalculation {
+pub fn root_merkle_value(hash_function: HashFunction) -> RootMerkleValueCalculation {
     CalcInner {
+        hash_function,
         stack: Vec::with_capacity(8),
     }
     .next()
@@ -116,6 +118,8 @@ pub enum RootMerkleValueCalculation {
 /// Calculation of the Merkle value is ready to continue.
 /// Shared by all the public-facing structs.
 struct CalcInner {
+    /// Hash function used by the trie.
+    hash_function: HashFunction,
     /// Stack of nodes whose value is currently being calculated.
     stack: Vec<Node>,
 }
@@ -174,6 +178,7 @@ impl CalcInner {
                         partial_key: calculated_elem.partial_key.iter().copied(),
                         storage_value: trie_node::StorageValue::None,
                     },
+                    self.hash_function,
                     self.stack.is_empty(),
                 )
                 .unwrap_or_else(|_| unreachable!());
@@ -269,7 +274,10 @@ impl NextKey {
                 } else {
                     // Trie is completely empty.
                     RootMerkleValueCalculation::Finished {
-                        hash: EMPTY_TRIE_MERKLE_VALUE,
+                        hash: match self.calculation.hash_function {
+                            HashFunction::Blake2 => EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
+                            HashFunction::Keccak256 => EMPTY_KECCAK256_TRIE_MERKLE_VALUE,
+                        },
                     }
                 }
             }
@@ -326,6 +334,7 @@ impl StorageValue {
                     (None, _) => trie_node::StorageValue::None,
                 },
             },
+            self.calculation.hash_function,
             self.calculation.stack.is_empty(),
         )
         .unwrap_or_else(|_| unreachable!());
@@ -345,12 +354,12 @@ impl StorageValue {
 
 #[cfg(test)]
 mod tests {
-    use crate::trie::TrieEntryVersion;
+    use crate::trie::{HashFunction, TrieEntryVersion};
     use alloc::collections::BTreeMap;
     use core::ops::Bound;
 
     fn calculate_root(version: TrieEntryVersion, trie: &BTreeMap<Vec<u8>, Vec<u8>>) -> [u8; 32] {
-        let mut calculation = super::root_merkle_value();
+        let mut calculation = super::root_merkle_value(HashFunction::Blake2);
 
         loop {
             match calculation {

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -32,14 +32,14 @@
 //!
 //! ```
 //! use std::{collections::BTreeMap, ops::Bound};
-//! use smoldot::trie::{TrieEntryVersion, calculate_root};
+//! use smoldot::trie::{HashFunction, TrieEntryVersion, calculate_root};
 //!
 //! // In this example, the storage consists in a binary tree map.
 //! let mut storage = BTreeMap::<Vec<u8>, (Vec<u8>, TrieEntryVersion)>::new();
 //! storage.insert(b"foo".to_vec(), (b"bar".to_vec(), TrieEntryVersion::V1));
 //!
 //! let trie_root = {
-//!     let mut calculation = calculate_root::root_merkle_value();
+//!     let mut calculation = calculate_root::root_merkle_value(HashFunction::Blake2);
 //!     loop {
 //!         match calculation {
 //!             calculate_root::RootMerkleValueCalculation::Finished { hash, .. } => break hash,

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -434,7 +434,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         parent_hash: [0; 32],
                         number: 0,
                         state_root: *chain_spec.genesis_storage().into_trie_root_hash().unwrap(),
-                        extrinsics_root: smoldot::trie::EMPTY_TRIE_MERKLE_VALUE,
+                        extrinsics_root: smoldot::trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty().into(),
                     };
 
@@ -477,7 +477,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         parent_hash: [0; 32],
                         number: 0,
                         state_root: *chain_spec.genesis_storage().into_trie_root_hash().unwrap(),
-                        extrinsics_root: smoldot::trie::EMPTY_TRIE_MERKLE_VALUE,
+                        extrinsics_root: smoldot::trie::EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
                         digest: header::DigestRef::empty().into(),
                     };
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add support for the `ext_trie_keccak_256_root_version_1`, `ext_trie_keccak_256_root_version_2`, `ext_trie_keccak_256_ordered_root_version_1`, and `ext_trie_keccak_256_ordered_root_version_2` host functions.
+
 ### Changed
 
 - The smoldot binary now longer has SIMD enabled, in order to make it work on a greater range of hardware. It was previously assumed that SIMD instructions were emulated on hardware that doesn't natively support them, but this doesn't seem to be the case for some browser engines. ([#903](https://github.com/smol-dot/smoldot/pull/903))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add support for the `ext_trie_keccak_256_root_version_1`, `ext_trie_keccak_256_root_version_2`, `ext_trie_keccak_256_ordered_root_version_1`, and `ext_trie_keccak_256_ordered_root_version_2` host functions.
+- Add support for the `ext_trie_keccak_256_root_version_1`, `ext_trie_keccak_256_root_version_2`, `ext_trie_keccak_256_ordered_root_version_1`, and `ext_trie_keccak_256_ordered_root_version_2` host functions. ([#906](https://github.com/smol-dot/smoldot/pull/906))
 
 ### Changed
 


### PR DESCRIPTION
The `trie` module now has a `HashFunction` enum, and can calculate either the blake2 hash or the keccak hash.

This allow adding support for the keccak256 equivalents of the blake2 host functions.