### PR TITLE
Change back close_write_if_empty to close_write

### DIFF
--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -1020,7 +1020,7 @@ where
                         // that the substream is dead. If the reading side is still open, we
                         // indicate that it's not dead and store it in the state machine while
                         // waiting for it to be closed by the remote.
-                        read_write.close_write_if_empty();
+                        read_write.close_write();
                         let handshake_substream_still_open = read_write.incoming_buffer.is_some();
 
                         let mut established = established.take().unwrap();
@@ -1067,7 +1067,7 @@ where
                 // substream is dead. If the reading side is still open, we indicate that it's not
                 // dead and simply wait for the remote to close it.
                 // TODO: kill the connection if the remote sends more data?
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 if read_write.incoming_buffer.is_none() {
                     *handshake_substream = None;
                     SubstreamFate::Reset

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -882,7 +882,7 @@ where
 
                 // This might have been done already during the shutdown process, but we do it
                 // again just in case.
-                read_write.close_write_if_empty();
+                read_write.close_write();
             }
 
             SingleStreamConnectionTaskInner::ShutdownWaitingAck {

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -209,7 +209,7 @@ where
                 && self.inner.yamux.goaway_sent()
                 && self.inner.yamux.received_goaway().is_some()
             {
-                read_write.close_write_if_empty();
+                read_write.close_write();
             }
 
             // Any meaningful activity within this loop can set this value to `true`. If this

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -424,7 +424,7 @@ where
                 // have been eagerly sending data (assuming that the negotiation would
                 // succeed), which should be silently discarded.
                 read_write.discard_all_incoming();
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 if read_write.is_dead() {
                     (None, None)
                 } else {
@@ -436,7 +436,7 @@ where
                 // Substream has failed to negotiate a protocol. The substream is expected to
                 // close soon.
                 read_write.discard_all_incoming();
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 (
                     if read_write.is_dead() {
                         None
@@ -603,7 +603,7 @@ where
             }
             SubstreamInner::NotificationsOutClosed => {
                 read_write.discard_all_incoming();
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 (
                     if read_write.is_dead() {
                         None
@@ -625,7 +625,7 @@ where
                 // `read_write` the response arrived after the timeout. It is the responsibility
                 // of the user to call `read_write` in an appropriate way for this to not happen.
                 if timeout < read_write.now {
-                    read_write.close_write_if_empty();
+                    read_write.close_write();
                     return (
                         None,
                         Some(Event::Response {
@@ -669,7 +669,7 @@ where
                     .map_or(true, |n| n.can_write_protocol_data())
                 {
                     if request.is_empty() {
-                        read_write.close_write_if_empty();
+                        read_write.close_write();
                     } else {
                         read_write.write_from_vec_deque(&mut request);
                     }
@@ -679,7 +679,7 @@ where
                     let incoming_buffer = match read_write.incoming_buffer {
                         Some(buf) => buf,
                         None => {
-                            read_write.close_write_if_empty();
+                            read_write.close_write();
                             return (
                                 None,
                                 Some(Event::Response {
@@ -692,7 +692,7 @@ where
                     match response.update(incoming_buffer) {
                         Ok((num_read, leb128::Framed::Finished(response))) => {
                             read_write.advance_read(num_read);
-                            read_write.close_write_if_empty();
+                            read_write.close_write();
                             (
                                 None,
                                 Some(Event::Response {
@@ -776,7 +776,7 @@ where
             SubstreamInner::RequestInApiWait => (Some(SubstreamInner::RequestInApiWait), None),
             SubstreamInner::RequestInRespond { mut response } => {
                 if response.is_empty() {
-                    read_write.close_write_if_empty();
+                    read_write.close_write();
                     (None, None)
                 } else {
                     read_write.write_from_vec_deque(&mut response);
@@ -788,7 +788,7 @@ where
                 let incoming_buffer = match read_write.incoming_buffer {
                     Some(buf) => buf,
                     None => {
-                        read_write.close_write_if_empty();
+                        read_write.close_write();
                         return (
                             None,
                             Some(Event::InboundError {
@@ -836,7 +836,7 @@ where
             }
             SubstreamInner::NotificationsInRefused => {
                 read_write.discard_all_incoming();
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 (
                     if read_write.is_dead() {
                         None
@@ -855,13 +855,13 @@ where
                 read_write.write_from_vec_deque(&mut handshake);
 
                 if close_desired && handshake.is_empty() {
-                    read_write.close_write_if_empty();
+                    read_write.close_write();
                 }
 
                 let incoming_buffer = match read_write.incoming_buffer {
                     Some(buf) => buf,
                     None => {
-                        read_write.close_write_if_empty();
+                        read_write.close_write();
                         return (
                             Some(SubstreamInner::NotificationsInClosed),
                             Some(Event::NotificationsInClose { outcome: Ok(()) }),
@@ -909,7 +909,7 @@ where
             }
             SubstreamInner::NotificationsInClosed => {
                 read_write.discard_all_incoming();
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 (
                     if read_write.is_dead() {
                         None
@@ -949,7 +949,7 @@ where
             }
 
             SubstreamInner::PingOutFailed { mut queued_pings } => {
-                read_write.close_write_if_empty();
+                read_write.close_write();
                 if !queued_pings.is_empty() {
                     queued_pings.remove(0);
                     (

--- a/lib/src/libp2p/read_write.rs
+++ b/lib/src/libp2p/read_write.rs
@@ -96,12 +96,9 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
 
     /// Sets the writing side of the connection to closed.
     ///
-    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None` if
-    /// [`ReadWrite::written_bytes`] is equal to 0.
-    pub fn close_write_if_empty(&mut self) {
-        if self.written_bytes == 0 {
-            self.outgoing_buffer = None;
-        }
+    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None`.
+    pub fn close_write(&mut self) {
+        self.outgoing_buffer = None;
     }
 
     /// Returns the size of the data available in the incoming buffer.


### PR DESCRIPTION
In https://github.com/smol-dot/smoldot/commit/bffd3ad502fbb816a4fa20e0aaf0c90ddf9fa12e, I changed `close_write` to `close_write_if_empty`.

This turned out to be wrong. Setting the outgoing buffer to `None` doesn't clear the existing data, as the caller of the `read_write` function still has the outgoing buffer available and has access to the `ReadWrite::written_bytes`.

This confusion came from a bug that is now fixed in https://github.com/smol-dot/smoldot/pull/866
