### PR TITLE
Remove unused `UnexpectedPayload` error

### DIFF
--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -1270,8 +1270,6 @@ pub enum HandshakeError {
     PayloadDecode(PayloadDecodeError),
     /// Key passed as part of the payload failed to decode into a libp2p public key.
     InvalidKey,
-    /// Received a payload as part of a handshake message when none was expected.
-    UnexpectedPayload,
     /// Signature of the noise public key by the libp2p key failed.
     #[display(fmt = "Signature of the noise public key by the libp2p key failed.")]
     SignatureVerificationFailed(SignatureVerifyFailed),


### PR DESCRIPTION
This situation is now handled as a `PayloadDecode` error.