### PR TITLE
Properly implement PlatformRef::supports_connection_type in wasm-node

### DIFF
--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -100,7 +100,12 @@ impl PlatformRef for Arc<DefaultPlatform> {
         // TODO: support WebSocket secure
         matches!(
             connection_type,
-            ConnectionType::Tcp | ConnectionType::WebSocket { secure: false, .. }
+            ConnectionType::TcpIpv4
+                | ConnectionType::TcpIpv6
+                | ConnectionType::TcpDns
+                | ConnectionType::WebSocketIpv4 { .. }
+                | ConnectionType::WebSocketIpv6 { .. }
+                | ConnectionType::WebSocketDns { secure: false, .. }
         )
     }
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Fix regression introduced in version 1.0.12 where only WebSocket secure and WebRTC connections were ever opened, regardless of the `forbid*` configuration flags.
+- Fix regression introduced in version 1.0.12 where only WebSocket secure and WebRTC connections were ever opened, regardless of the `forbid*` configuration flags. ([#923](https://github.com/smol-dot/smoldot/pull/923))
 
 ## 1.0.12 - 2023-07-10
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - The smoldot binary now longer has SIMD enabled, in order to make it work on a greater range of hardware. It was previously assumed that SIMD instructions were emulated on hardware that doesn't natively support them, but this doesn't seem to be the case for some browser engines. ([#903](https://github.com/smol-dot/smoldot/pull/903))
 
+### Fixed
+
+- Fix regression introduced in version 1.0.12 where only WebSocket secure and WebRTC connections were ever opened, regardless of the `forbid*` configuration flags.
+
 ## 1.0.12 - 2023-07-10
 
 ### Changed

--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -234,10 +234,10 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
                 case 4:
                 case 5:
                 case 6: {
-                    return config.forbidWs ? 0 : 1
+                    return config.forbidNonLocalWs ? 0 : 1
                 }
                 case 7: {
-                    return config.forbidNonLocalWs ? 0 : 1
+                    return config.forbidWs ? 0 : 1
                 }
                 case 14: {
                     return config.forbidWss ? 0 : 1


### PR DESCRIPTION
This was meant to be properly implemented before merging https://github.com/smol-dot/smoldot/pull/876, but I forgot.