### PR TITLE
Refactor `ReadWrite` to give ownership of write buffers

### DIFF
--- a/fuzz/fuzz_targets/network-connection-encrypted.rs
+++ b/fuzz/fuzz_targets/network-connection-encrypted.rs
@@ -88,7 +88,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
                         &mut [],
                     )),
                     read_bytes: 0,
-                    written_bytes: 0,
+                    write_bytes_queued: 0,
                     wake_up_after: None,
                 };
 
@@ -117,7 +117,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
                         &mut [],
                     )),
                     read_bytes: 0,
-                    written_bytes: 0,
+                    write_bytes_queued: 0,
                     wake_up_after: None,
                 };
 
@@ -183,7 +183,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             incoming_buffer: Some(&remote_to_local_buffer),
             outgoing_buffer: Some((&mut local_to_remote_buffer, &mut [])),
             read_bytes: 0,
-            written_bytes: 0,
+            write_bytes_queued: 0,
             wake_up_after: None,
         };
 

--- a/fuzz/fuzz_targets/network-connection-encrypted.rs
+++ b/fuzz/fuzz_targets/network-connection-encrypted.rs
@@ -25,7 +25,7 @@ use smoldot::libp2p::{
     read_write::ReadWrite,
 };
 
-use core::{cmp, time::Duration};
+use core::{iter, time::Duration};
 
 // This fuzzing target simulates an incoming or outgoing connection whose handshake has succeeded.
 // The remote endpoint of that connection sends the fuzzing data to smoldot after it has been
@@ -61,8 +61,8 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
 
     // Store the data that the local has emitted but the remote hasn't received yet, and vice
     // versa.
-    let mut local_to_remote_buffer = Vec::with_capacity(8192);
-    let mut remote_to_local_buffer = Vec::with_capacity(8192);
+    let mut local_to_remote_buffer = Vec::<Vec<u8>>::new();
+    let mut remote_to_local_buffer = Vec::<Vec<u8>>::new();
 
     // Perform handshake.
     while !matches!(
@@ -75,58 +75,68 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
         match local {
             single_stream_handshake::Handshake::Success { .. } => {}
             single_stream_handshake::Handshake::Healthy(nego) => {
-                let local_to_remote_buffer_len = local_to_remote_buffer.len();
-                if local_to_remote_buffer_len < local_to_remote_buffer.capacity() {
-                    let cap = local_to_remote_buffer.capacity();
-                    local_to_remote_buffer.resize(cap, 0);
-                }
                 let mut read_write = ReadWrite {
                     now: Duration::new(0, 0),
-                    incoming_buffer: Some(&remote_to_local_buffer),
-                    outgoing_buffer: Some((
-                        &mut local_to_remote_buffer[local_to_remote_buffer_len..],
-                        &mut [],
-                    )),
+                    incoming_buffer: Some(
+                        remote_to_local_buffer
+                            .first()
+                            .map(|b| &b[..])
+                            .unwrap_or(&[]),
+                    ),
                     read_bytes: 0,
+                    write_buffers: Vec::new(),
                     write_bytes_queued: 0,
+                    write_bytes_queueable: Some(
+                        8162 - local_to_remote_buffer.iter().fold(0, |c, b| c + b.len()),
+                    ),
                     wake_up_after: None,
                 };
 
                 local = nego.read_write(&mut read_write).unwrap();
-                let (read_bytes, written_bytes) = (read_write.read_bytes, read_write.written_bytes);
-                for _ in 0..read_bytes {
+                local_to_remote_buffer.extend(read_write.write_buffers.drain(..));
+                for _ in 0..read_write.read_bytes {
+                    remote_to_local_buffer.first_mut().unwrap().remove(0);
+                }
+                if remote_to_local_buffer
+                    .first()
+                    .map_or(false, |b| b.is_empty())
+                {
                     remote_to_local_buffer.remove(0);
                 }
-                local_to_remote_buffer.truncate(local_to_remote_buffer_len + written_bytes);
             }
         }
 
         match remote {
             single_stream_handshake::Handshake::Success { .. } => {}
             single_stream_handshake::Handshake::Healthy(nego) => {
-                let remote_to_local_buffer_len = remote_to_local_buffer.len();
-                if remote_to_local_buffer_len < remote_to_local_buffer.capacity() {
-                    let cap = remote_to_local_buffer.capacity();
-                    remote_to_local_buffer.resize(cap, 0);
-                }
                 let mut read_write = ReadWrite {
                     now: Duration::new(0, 0),
-                    incoming_buffer: Some(&local_to_remote_buffer),
-                    outgoing_buffer: Some((
-                        &mut remote_to_local_buffer[remote_to_local_buffer_len..],
-                        &mut [],
-                    )),
+                    incoming_buffer: Some(
+                        local_to_remote_buffer
+                            .first()
+                            .map(|b| &b[..])
+                            .unwrap_or(&[]),
+                    ),
                     read_bytes: 0,
+                    write_buffers: Vec::new(),
                     write_bytes_queued: 0,
+                    write_bytes_queueable: Some(
+                        8162 - remote_to_local_buffer.iter().fold(0, |c, b| c + b.len()),
+                    ),
                     wake_up_after: None,
                 };
 
                 remote = nego.read_write(&mut read_write).unwrap();
-                let (read_bytes, written_bytes) = (read_write.read_bytes, read_write.written_bytes);
-                for _ in 0..read_bytes {
+                remote_to_local_buffer.extend(read_write.write_buffers.drain(..));
+                for _ in 0..read_write.read_bytes {
+                    local_to_remote_buffer.first_mut().unwrap().remove(0);
+                }
+                if local_to_remote_buffer
+                    .first()
+                    .map_or(false, |b| b.is_empty())
+                {
                     local_to_remote_buffer.remove(0);
                 }
-                remote_to_local_buffer.truncate(remote_to_local_buffer_len + written_bytes);
             }
         }
     }
@@ -155,35 +165,27 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     };
 
     // From this point on we will just discard the data sent by `local`.
-    // Reset the buffer and fill it with zeroes.
-    local_to_remote_buffer = vec![0; 8192];
 
     // We now encrypt the fuzzing data and add it to the buffer to send to the remote. This is
     // done all in one go.
-    {
-        let mut encrypted = vec![0; 65536];
-        let mut encrypt = remote.encrypt((&mut encrypted, &mut [])).unwrap();
-        let mut num_written = 0;
-        for buffer in encrypt.unencrypted_write_buffers() {
-            let to_copy = cmp::min(data.len(), buffer.len());
-            if to_copy == 0 {
-                break;
-            }
-            buffer[..to_copy].copy_from_slice(&data[..to_copy]);
-            num_written += to_copy;
-        }
-        let written = encrypt.encrypt(num_written);
-        remote_to_local_buffer.extend_from_slice(&encrypted[..written]);
+    for buffer in remote.encrypt(iter::once(data.to_vec())) {
+        remote_to_local_buffer.push(buffer);
     }
 
     // Now send the data to the connection.
     loop {
         let mut local_read_write = ReadWrite {
             now: Duration::new(0, 0),
-            incoming_buffer: Some(&remote_to_local_buffer),
-            outgoing_buffer: Some((&mut local_to_remote_buffer, &mut [])),
+            incoming_buffer: Some(
+                remote_to_local_buffer
+                    .first()
+                    .map(|b| &b[..])
+                    .unwrap_or(&[]),
+            ),
             read_bytes: 0,
+            write_buffers: Vec::new(),
             write_bytes_queued: 0,
+            write_bytes_queueable: Some(8192),
             wake_up_after: None,
         };
 
@@ -195,10 +197,18 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             Err(_) => return, // Invalid data. Counts as fuzzing success.
         };
 
-        let (local_read_bytes, local_written_bytes) =
-            (local_read_write.read_bytes, local_read_write.written_bytes);
+        let (local_read_bytes, local_written_bytes) = (
+            local_read_write.read_bytes,
+            local_read_write.write_bytes_queued,
+        );
 
-        for _ in 0..local_read_bytes {
+        for _ in 0..local_read_write.read_bytes {
+            remote_to_local_buffer.first_mut().unwrap().remove(0);
+        }
+        if remote_to_local_buffer
+            .first()
+            .map_or(false, |b| b.is_empty())
+        {
             remote_to_local_buffer.remove(0);
         }
 

--- a/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/fuzz/fuzz_targets/network-connection-raw.rs
@@ -62,21 +62,20 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
         (),
     );
 
-    let mut out_buffer = vec![0; 4096];
-
     loop {
         let mut read_write = smoldot::libp2p::read_write::ReadWrite {
             now: Duration::new(0, 0),
             incoming_buffer: Some(data),
-            outgoing_buffer: Some((&mut out_buffer, &mut [])),
             read_bytes: 0,
+            write_buffers: Vec::new(),
             write_bytes_queued: 0,
+            write_bytes_queueable: Some(4096),
             wake_up_after: None,
         };
         task.read_write(&mut read_write);
 
         let read_bytes = read_write.read_bytes;
-        let written_bytes = read_write.written_bytes;
+        let written_bytes = read_write.write_bytes_queued;
         data = &data[read_bytes..];
 
         // We need to call `pull_message_to_coordinator()`, as the connection state machine might

--- a/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/fuzz/fuzz_targets/network-connection-raw.rs
@@ -70,7 +70,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             incoming_buffer: Some(data),
             outgoing_buffer: Some((&mut out_buffer, &mut [])),
             read_bytes: 0,
-            written_bytes: 0,
+            write_bytes_queued: 0,
             wake_up_after: None,
         };
         task.read_write(&mut read_write);

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::util::{self, protobuf};
+use crate::util::{leb128, protobuf};
 
 use super::{
     super::{
@@ -27,7 +27,7 @@ use super::{
     SubstreamFate, SubstreamId,
 };
 
-use alloc::{collections::VecDeque, string::ToString as _, sync::Arc, vec, vec::Vec};
+use alloc::{collections::VecDeque, string::ToString as _, sync::Arc, vec::Vec};
 use core::{
     cmp,
     hash::Hash,
@@ -855,7 +855,7 @@ where
         // In WebRTC, the reading and writing sides are never closed.
         // Note that the `established::MultiStream` state machine also performs this check, but
         // we do it here again because we're not necessarily in the ̀`established` state.
-        assert!(read_write.incoming_buffer.is_some() && read_write.outgoing_buffer.is_some());
+        assert!(read_write.incoming_buffer.is_some() && read_write.write_bytes_queueable.is_some());
 
         match &mut self.connection {
             MultiStreamConnectionTaskInner::Handshake {
@@ -923,23 +923,20 @@ where
                     }
                 };
 
-                // We allocate a buffer where the Noise state machine will temporarily write out
-                // its data. The size of the buffer is capped in order to prevent the substream
-                // from generating data that wouldn't fit in a single protobuf frame.
-                let mut intermediary_write_buffer =
-                    vec![
-                        0;
-                        cmp::min(read_write.outgoing_buffer_available(), 16384).saturating_sub(10)
-                    ]; // TODO: this -10 calculation is hacky because we need to account for the variable length prefixes everywhere
-
                 let mut sub_read_write = ReadWrite {
                     now: read_write.now.clone(),
                     incoming_buffer: Some(
                         &message_within_frame[*handshake_read_buffer_partial_read..],
                     ),
-                    outgoing_buffer: Some((&mut intermediary_write_buffer, &mut [])),
                     read_bytes: 0,
-                    written_bytes: 0,
+                    write_buffers: Vec::new(),
+                    write_bytes_queued: read_write.write_bytes_queued,
+                    // Don't write out more than one frame.
+                    // TODO: this `10` is here for the length and protobuf frame size and is a bit hacky
+                    write_bytes_queueable: Some(
+                        cmp::min(read_write.write_bytes_queueable.unwrap(), 16384)
+                            .saturating_sub(10),
+                    ),
                     wake_up_after: None,
                 };
 
@@ -951,33 +948,25 @@ where
 
                 // Send out the message that the Noise handshake has written
                 // into `intermediary_write_buffer`.
-                if sub_read_write.written_bytes != 0 {
-                    let written_bytes = sub_read_write.written_bytes;
+                if sub_read_write.write_bytes_queued != read_write.write_bytes_queued {
+                    let written_bytes =
+                        sub_read_write.write_bytes_queued - read_write.write_bytes_queued;
                     drop(sub_read_write);
 
-                    debug_assert!(written_bytes <= intermediary_write_buffer.len());
-
-                    let protobuf_frame =
-                        protobuf::bytes_tag_encode(2, &intermediary_write_buffer[..written_bytes]);
-                    let protobuf_frame_len = protobuf_frame.clone().fold(0, |mut l, b| {
-                        l += AsRef::<[u8]>::as_ref(&b).len();
-                        l
-                    });
+                    // TODO: don't do the encoding manually but use the protobuf module?
+                    let tag = protobuf::tag_encode(2, 2).collect::<Vec<_>>();
+                    let data_len = leb128::encode_usize(written_bytes).collect::<Vec<_>>();
+                    let libp2p_prefix =
+                        leb128::encode_usize(tag.len() + data_len.len()).collect::<Vec<_>>();
 
                     // The spec mentions that a frame plus its length prefix shouldn't exceed
                     // 16kiB. This is normally ensured by forbidding the substream from writing
                     // more data than would fit in 16kiB.
-                    debug_assert!(protobuf_frame_len <= 16384);
-                    debug_assert!(
-                        util::leb128::encode_usize(protobuf_frame_len).count() + protobuf_frame_len
-                            <= 16384
-                    );
-                    for byte in util::leb128::encode_usize(protobuf_frame_len) {
-                        read_write.write_out(&[byte]);
-                    }
-                    for buffer in protobuf_frame {
-                        read_write.write_out(AsRef::<[u8]>::as_ref(&buffer));
-                    }
+                    debug_assert!(libp2p_prefix.len() + tag.len() + data_len.len() <= 16384);
+
+                    read_write.write_out(libp2p_prefix);
+                    read_write.write_out(tag);
+                    read_write.write_out(data_len);
                 }
 
                 if protobuf_frame_size != 0

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -839,7 +839,7 @@ where
     /// writing side of the substream was still open, then the user should reset that substream.
     ///
     /// In the case of a WebRTC connection, the [`ReadWrite::incoming_buffer`] and
-    /// [`ReadWrite::outgoing_buffer`] must always be `Some`.
+    /// [`ReadWrite::write_bytes_queueable`] must always be `Some`.
     ///
     /// # Panic
     ///

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -794,7 +794,7 @@ where
 
                 loop {
                     let (read_before, written_before) =
-                        (read_write.read_bytes, read_write.written_bytes);
+                        (read_write.read_bytes, read_write.write_bytes_queued);
 
                     let result = match handshake.read_write(read_write) {
                         Ok(rw) => rw,
@@ -816,7 +816,7 @@ where
                     match result {
                         single_stream_handshake::Handshake::Healthy(updated_handshake)
                             if (read_before, written_before)
-                                == (read_write.read_bytes, read_write.written_bytes) =>
+                                == (read_write.read_bytes, read_write.write_bytes_queued) =>
                         {
                             self.connection = SingleStreamConnectionTaskInner::Handshake {
                                 handshake: updated_handshake,

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -275,7 +275,7 @@ where
     /// [`MultiStream::pull_event`] to empty the queue of events between calls to this method.
     ///
     /// In the case of a WebRTC connection, the [`ReadWrite::incoming_buffer`] and
-    /// [`ReadWrite::outgoing_buffer`] must always be `Some`.
+    /// [`ReadWrite::write_bytes_queueable`] must always be `Some`.
     ///
     /// # Panic
     ///

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -928,7 +928,7 @@ where
                 // The ping protocol consists in sending 32 bytes of data, which the remote has
                 // to send back. The `payload` field contains these 32 bytes being received.
                 while read_write.incoming_buffer_available() != 0
-                    && read_write.outgoing_buffer_available() != 0
+                    && read_write.write_bytes_queueable.unwrap_or(0) != 0
                 {
                     let available = payload_in.remaining_capacity();
                     payload_in.extend(read_write.incoming_bytes_iter().take(available));

--- a/lib/src/libp2p/read_write.rs
+++ b/lib/src/libp2p/read_write.rs
@@ -127,7 +127,10 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
 
         let to_copy1 = cmp::min(slice1.len(), self.write_bytes_queueable.unwrap_or(0));
         let to_copy2 = if to_copy1 == slice1.len() {
-            cmp::min(slice2.len(), self.write_bytes_queueable.unwrap_or(0) - to_copy1)
+            cmp::min(
+                slice2.len(),
+                self.write_bytes_queueable.unwrap_or(0) - to_copy1,
+            )
         } else {
             0
         };

--- a/lib/src/libp2p/read_write.rs
+++ b/lib/src/libp2p/read_write.rs
@@ -119,9 +119,9 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
         out
     }
 
-    /// Copies as much as possible from the content of `data` to [`ReadWrite::outgoing_buffer`]
-    /// and increases [`ReadWrite::written_bytes`]. The bytes that have been written are removed
-    /// from `data`.
+    /// Copies as much as possible from the content of `data` to [`ReadWrite::write_buffers`]
+    /// and updates [`ReadWrite::write_bytes_queued`] and [`ReadWrite::write_bytes_queueable`].
+    /// The bytes that have been written are removed from `data`.
     pub fn write_from_vec_deque(&mut self, data: &mut VecDeque<u8>) {
         let (slice1, slice2) = data.as_slices();
 

--- a/lib/src/libp2p/read_write.rs
+++ b/lib/src/libp2p/read_write.rs
@@ -15,8 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use alloc::collections::VecDeque;
-use core::{cmp, mem};
+use core::cmp;
+
+use alloc::{collections::VecDeque, vec::Vec};
 
 // TODO: documentation
 
@@ -29,21 +30,22 @@ pub struct ReadWrite<'a, TNow> {
     /// Contains `None` if the remote has closed their writing side of the socket.
     pub incoming_buffer: Option<&'a [u8]>,
 
-    /// Pointer to two consecutive buffers of uninitialized data. Can be written to in order to
-    /// write data out towards the socket.
-    ///
-    /// Contains `None` if the writing side of the socket has been closed or must be closed.
-    pub outgoing_buffer: Option<(&'a mut [u8], &'a mut [u8])>,
-
     /// Total number of bytes that have been read from [`ReadWrite::incoming_buffer`].
     ///
     /// [`ReadWrite::incoming_buffer`] must have been advanced after these bytes.
     pub read_bytes: usize,
 
-    /// Total number of bytes that have been written to [`ReadWrite::outgoing_buffer`].
-    ///
-    /// [`ReadWrite::outgoing_buffer`] must have been advanced after these bytes.
-    pub written_bytes: usize,
+    /// List of buffers containing data to the written out. The consumer of the [`ReadWrite`] is
+    /// expected to add buffers.
+    // TODO: consider changing the inner `Vec` to `Box<dyn AsRef<[u8]>>`
+    pub write_buffers: Vec<Vec<u8>>,
+
+    /// Amount of data already queued, both outside and including [`ReadWrite::write_buffers`].
+    pub write_bytes_queued: usize,
+
+    /// Number of additional bytes that are allowed to be pushed to [`ReadWrite::write_buffers`].
+    /// `None` if the writing side of the stream is closed.
+    pub write_bytes_queueable: Option<usize>,
 
     /// If `Some`, the socket must be waken up after the given `TNow` is reached.
     pub wake_up_after: Option<TNow>,
@@ -51,9 +53,9 @@ pub struct ReadWrite<'a, TNow> {
 
 impl<'a, TNow> ReadWrite<'a, TNow> {
     /// Returns true if the connection should be considered dead. That is, both
-    /// [`ReadWrite::incoming_buffer`] and [`ReadWrite::outgoing_buffer`] are `None`.
+    /// [`ReadWrite::incoming_buffer`] is `None` and [`ReadWrite::write_bytes_queueable`] is `None`.
     pub fn is_dead(&self) -> bool {
-        self.incoming_buffer.is_none() && self.outgoing_buffer.is_none()
+        self.incoming_buffer.is_none() && self.write_bytes_queueable.is_none()
     }
 
     /// Discards the first `num` bytes of [`ReadWrite::incoming_buffer`] and adds them to
@@ -72,33 +74,11 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
         }
     }
 
-    /// Discards the first `num` bytes of [`ReadWrite::outgoing_buffer`] and adds them to
-    /// [`ReadWrite::written_bytes`].
-    ///
-    /// # Panic
-    ///
-    /// Panics if `num` is superior to the size of the available buffer.
-    ///
-    pub fn advance_write(&mut self, num: usize) {
-        if let Some(ref mut outgoing_buffer) = self.outgoing_buffer {
-            self.written_bytes += num;
-
-            let out_buf_0_len = outgoing_buffer.0.len();
-            advance_buf(&mut outgoing_buffer.0, cmp::min(num, out_buf_0_len));
-            advance_buf(&mut outgoing_buffer.1, num.saturating_sub(out_buf_0_len));
-            if outgoing_buffer.0.is_empty() && !outgoing_buffer.1.is_empty() {
-                mem::swap::<&mut [u8]>(&mut outgoing_buffer.0, &mut outgoing_buffer.1);
-            }
-        } else {
-            assert_eq!(num, 0);
-        }
-    }
-
     /// Sets the writing side of the connection to closed.
     ///
-    /// This is simply a shortcut for setting [`ReadWrite::outgoing_buffer`] to `None`.
+    /// This is simply a shortcut for setting [`ReadWrite::write_bytes_queueable`] to `None`.
     pub fn close_write(&mut self) {
-        self.outgoing_buffer = None;
+        self.write_bytes_queueable = None;
     }
 
     /// Returns the size of the data available in the incoming buffer.
@@ -139,61 +119,53 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
         out
     }
 
-    /// Returns the size of the available outgoing buffer.
-    pub fn outgoing_buffer_available(&self) -> usize {
-        self.outgoing_buffer
-            .as_ref()
-            .map_or(0, |(a, b)| a.len() + b.len())
-    }
-
-    /// Copies the content of `data` to [`ReadWrite::outgoing_buffer`] and increases
-    /// [`ReadWrite::written_bytes`].
-    ///
-    /// # Panic
-    ///
-    /// Panics if `data.len() > self.outgoing_buffer_available()`.
-    ///
-    pub fn write_out(&mut self, data: &[u8]) {
-        let outgoing_buffer = match &mut self.outgoing_buffer {
-            Some(b) => b,
-            None => {
-                assert!(data.is_empty());
-                return;
-            }
-        };
-
-        assert!(data.len() <= outgoing_buffer.0.len() + outgoing_buffer.1.len());
-
-        let to_copy_buf1 = cmp::min(outgoing_buffer.0.len(), data.len());
-        let to_copy_buf2 = data.len() - to_copy_buf1;
-        debug_assert_eq!(to_copy_buf1 + to_copy_buf2, data.len());
-
-        outgoing_buffer.0[..to_copy_buf1].copy_from_slice(&data[..to_copy_buf1]);
-        outgoing_buffer.1[..to_copy_buf2].copy_from_slice(&data[to_copy_buf1..][..to_copy_buf2]);
-
-        self.advance_write(data.len());
-    }
-
     /// Copies as much as possible from the content of `data` to [`ReadWrite::outgoing_buffer`]
     /// and increases [`ReadWrite::written_bytes`]. The bytes that have been written are removed
     /// from `data`.
     pub fn write_from_vec_deque(&mut self, data: &mut VecDeque<u8>) {
         let (slice1, slice2) = data.as_slices();
 
-        let outgoing_available = self.outgoing_buffer_available();
-        let to_copy1 = cmp::min(slice1.len(), outgoing_available);
+        let to_copy1 = cmp::min(slice1.len(), self.write_bytes_queueable.unwrap_or(0));
         let to_copy2 = if to_copy1 == slice1.len() {
-            cmp::min(slice2.len(), outgoing_available - to_copy1)
+            cmp::min(slice2.len(), self.write_bytes_queueable.unwrap_or(0) - to_copy1)
         } else {
             0
         };
 
-        self.write_out(&slice1[..to_copy1]);
-        self.write_out(&slice2[..to_copy2]);
+        let total_tocopy = to_copy1 + to_copy2;
 
-        for _ in 0..(to_copy1 + to_copy2) {
+        if total_tocopy == 0 {
+            return;
+        }
+
+        self.write_buffers.push(slice1[..to_copy1].to_vec());
+        self.write_buffers.push(slice2[..to_copy2].to_vec());
+
+        self.write_bytes_queued += total_tocopy;
+        *self.write_bytes_queueable.as_mut().unwrap() -= total_tocopy;
+
+        for _ in 0..total_tocopy {
             data.pop_front();
         }
+    }
+
+    /// Adds the `data` to [`ReadWrite::write_buffers`], increases
+    /// [`ReadWrite::write_bytes_queued`], and decreases [`ReadWrite::write_bytes_queueable`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if `data.len() > write_bytes_queueable`.
+    /// Panics if the writing side is closed and `data` isn't empty.
+    ///
+    // TODO: is this function necessary? it seems dangerous due to the panic regarding queuable bytes
+    pub fn write_out(&mut self, data: Vec<u8>) {
+        if data.is_empty() {
+            return;
+        }
+        assert!(data.len() <= self.write_bytes_queueable.unwrap_or(0));
+        self.write_bytes_queued += data.len();
+        *self.write_bytes_queueable.as_mut().unwrap() -= data.len();
+        self.write_buffers.push(data);
     }
 
     /// Sets [`ReadWrite::wake_up_after`] to `min(wake_up_after, after)`.
@@ -207,11 +179,6 @@ impl<'a, TNow> ReadWrite<'a, TNow> {
             ref mut t @ None => *t = Some(after.clone()),
         }
     }
-}
-
-fn advance_buf(buf: &mut &mut [u8], n: usize) {
-    let tmp = mem::take(buf);
-    *buf = &mut tmp[n..];
 }
 
 /// See [`ReadWrite::incoming_bytes_iter`].
@@ -257,9 +224,10 @@ mod tests {
         let mut rw = ReadWrite {
             now: 0,
             incoming_buffer: Some(&[1, 2, 3]),
-            outgoing_buffer: None,
             read_bytes: 2,
-            written_bytes: 0,
+            write_buffers: Vec::new(),
+            write_bytes_queued: 0,
+            write_bytes_queueable: None,
             wake_up_after: None,
         };
 
@@ -290,9 +258,10 @@ mod tests {
         let mut rw = ReadWrite {
             now: 0,
             incoming_buffer: Some(&buf),
-            outgoing_buffer: None,
             read_bytes: 5,
-            written_bytes: 0,
+            write_buffers: Vec::new(),
+            write_bytes_queued: 0,
+            write_bytes_queueable: None,
             wake_up_after: None,
         };
 
@@ -306,94 +275,60 @@ mod tests {
     }
 
     #[test]
-    fn advance_write() {
-        let mut buf1 = [1, 2, 3];
-        let mut buf2 = [4, 5];
-
+    fn write_out() {
         let mut rw = ReadWrite {
             now: 0,
             incoming_buffer: None,
-            outgoing_buffer: Some((&mut buf1, &mut buf2)),
             read_bytes: 0,
-            written_bytes: 5,
+            write_buffers: Vec::new(),
+            write_bytes_queued: 11,
+            write_bytes_queueable: Some(10),
             wake_up_after: None,
         };
 
-        rw.advance_write(1);
-        assert_eq!(rw.outgoing_buffer.as_ref().unwrap().0, &[2, 3]);
-        assert_eq!(rw.outgoing_buffer.as_ref().unwrap().1, &[4, 5]);
-        assert_eq!(rw.written_bytes, 6);
-
-        rw.advance_write(2);
-        assert_eq!(rw.outgoing_buffer.as_ref().unwrap().0, &[4, 5]);
-        assert!(rw.outgoing_buffer.as_ref().unwrap().1.is_empty());
-        assert_eq!(rw.written_bytes, 8);
-
-        rw.advance_write(2);
-        assert!(rw.outgoing_buffer.as_ref().unwrap().0.is_empty());
-        assert!(rw.outgoing_buffer.as_ref().unwrap().1.is_empty());
-        assert_eq!(rw.written_bytes, 10);
-
-        let mut rw = ReadWrite {
-            now: 0,
-            incoming_buffer: None,
-            outgoing_buffer: Some((&mut buf1, &mut buf2)),
-            read_bytes: 0,
-            written_bytes: 5,
-            wake_up_after: None,
-        };
-
-        rw.advance_write(4);
-        assert_eq!(rw.outgoing_buffer.as_ref().unwrap().0, &[5]);
-        assert!(rw.outgoing_buffer.as_ref().unwrap().1.is_empty());
-        assert_eq!(rw.written_bytes, 9);
+        rw.write_out(b"hello".to_vec());
+        assert_eq!(rw.write_buffers.len(), 1);
+        assert_eq!(rw.write_bytes_queued, 16);
+        assert_eq!(rw.write_bytes_queueable, Some(5));
     }
 
     #[test]
     fn write_from_vec_deque_smaller() {
-        let mut buf1 = [0, 0, 0];
-        let mut buf2 = [0, 0];
         let mut input = [1, 2, 3, 4].iter().cloned().collect();
 
         let mut rw = ReadWrite {
             now: 0,
             incoming_buffer: None,
-            outgoing_buffer: Some((&mut buf1, &mut buf2)),
             read_bytes: 0,
-            written_bytes: 5,
+            write_buffers: Vec::new(),
+            write_bytes_queueable: Some(5),
+            write_bytes_queued: 5,
             wake_up_after: None,
         };
 
         rw.write_from_vec_deque(&mut input);
         assert!(input.is_empty());
-        assert_eq!(rw.outgoing_buffer.as_ref().unwrap().0, &[0]);
-        assert!(rw.outgoing_buffer.as_ref().unwrap().1.is_empty());
-        assert_eq!(rw.written_bytes, 9);
-        assert_eq!(&buf1, &[1, 2, 3]);
-        assert_eq!(&buf2, &[4, 0]);
+        assert_eq!(rw.write_bytes_queued, 9);
+        assert_eq!(rw.write_bytes_queueable, Some(1));
     }
 
     #[test]
     fn write_from_vec_deque_larger() {
-        let mut buf1 = [0, 0, 0];
-        let mut buf2 = [0, 0];
         let mut input = [1, 2, 3, 4, 5, 6].iter().cloned().collect();
 
         let mut rw = ReadWrite {
             now: 0,
             incoming_buffer: None,
-            outgoing_buffer: Some((&mut buf1, &mut buf2)),
             read_bytes: 0,
-            written_bytes: 5,
+            write_buffers: Vec::new(),
+            write_bytes_queueable: Some(5),
+            write_bytes_queued: 5,
             wake_up_after: None,
         };
 
         rw.write_from_vec_deque(&mut input);
         assert_eq!(input.into_iter().collect::<Vec<_>>(), &[6]);
-        assert!(rw.outgoing_buffer.as_ref().unwrap().0.is_empty());
-        assert!(rw.outgoing_buffer.as_ref().unwrap().1.is_empty());
-        assert_eq!(rw.written_bytes, 10);
-        assert_eq!(&buf1, &[1, 2, 3]);
-        assert_eq!(&buf2, &[4, 5]);
+        assert_eq!(rw.write_bytes_queued, 10);
+        assert_eq!(rw.write_bytes_queueable, Some(0));
     }
 }

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -21,8 +21,8 @@ use crate::platform::{
     SubstreamDirection,
 };
 
-use alloc::{vec, vec::Vec};
-use core::{cmp, iter, pin};
+use alloc::vec::Vec;
+use core::{iter, mem, pin};
 use futures_lite::FutureExt as _;
 use futures_util::{future, FutureExt as _, StreamExt as _};
 use smoldot::{
@@ -199,12 +199,8 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
     // We need to use `peek()` on this future later down this function.
     let mut coordinator_to_connection = coordinator_to_connection.peekable();
 
-    // In order to write data on a stream, we simply pass a slice, and the platform will copy
-    // from this slice the data to send. Consequently, the write buffer is held locally. This is
-    // suboptimal compared to writing to a write buffer provided by the platform, but it is easier
-    // to implement it this way.
-    // Switched to `None` after the connection closes its writing side.
-    let mut write_buffer = Some(vec![0; 4096]);
+    // `false` as long as the writing side of the connection is open.
+    let mut write_closed = false;
 
     // The main loop is as follows:
     // - Update the state machine.
@@ -223,11 +219,7 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
         let now = platform.now();
 
         let (read_bytes, written_bytes, wake_up_after) = if !connection_task.is_reset_called() {
-            let write_side_was_open = write_buffer.is_some();
-            let writable_bytes = cmp::min(
-                platform.writable_bytes(&mut connection),
-                write_buffer.as_ref().map_or(0, |b| b.len()),
-            );
+            let write_bytes_queueable = platform.writable_bytes(&mut connection);
 
             let incoming_buffer = match platform.read_buffer(&mut connection) {
                 ReadBuffer::Reset => {
@@ -242,11 +234,11 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
             let mut read_write = ReadWrite {
                 now: now.clone(),
                 incoming_buffer,
-                outgoing_buffer: write_buffer
-                    .as_mut()
-                    .map(|b| (&mut b[..writable_bytes], &mut [][..])),
                 read_bytes: 0,
-                written_bytes: 0,
+                write_buffers: Vec::new(),
+                write_closed,
+                write_bytes_queued: 0,
+                write_bytes_queueable,
                 wake_up_after: None,
             };
             connection_task.read_write(&mut read_write);
@@ -256,29 +248,25 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
             // information from it.
             let read_bytes = read_write.read_bytes;
             debug_assert!(read_bytes <= incoming_buffer.as_ref().map_or(0, |b| b.len()));
-            let write_size_closed = write_side_was_open && read_write.outgoing_buffer.is_none();
-            let written_bytes = read_write.written_bytes;
-            debug_assert!(written_bytes <= writable_bytes);
+            let write_size_closed = !write_closed && read_write.write_closed;
+            let write_bytes_queued = read_write.write_bytes_queued;
+            let write_buffers = mem::take(&mut read_write.write_buffers);
+            debug_assert!(write_bytes_queued <= write_bytes_queueable);
             let wake_up_after = read_write.wake_up_after.clone();
             drop(read_write);
 
             // Now update the connection.
-            if written_bytes != 0 {
-                // `written_bytes`non-zero when the writing side has been closed before
-                // doesn't make sense and would indicate a bug in the networking code
-                platform.send(
-                    &mut connection,
-                    &write_buffer.as_mut().unwrap()[..written_bytes],
-                );
+            for buffer in write_buffers {
+                platform.send(&mut connection, &buffer);
             }
             if write_size_closed {
                 platform.close_send(&mut connection);
-                debug_assert!(write_buffer.is_some());
-                write_buffer = None;
+                debug_assert!(!write_closed);
+                write_closed = true;
             }
             platform.advance_read_cursor(&mut connection, read_bytes);
 
-            (read_bytes, written_bytes, wake_up_after)
+            (read_bytes, write_bytes_queued, wake_up_after)
         } else {
             (0, 0, None)
         };
@@ -405,14 +393,6 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     // For each stream, a boolean indicates whether the local writing side is closed.
     let mut open_substreams = slab::Slab::<(TPlat::Stream, bool)>::with_capacity(16);
 
-    // In order to write data on a stream, we simply pass a slice, and the platform will copy
-    // from this slice the data to send. Consequently, the write buffer is held locally. This is
-    // suboptimal compared to writing to a write buffer provided by the platform, but it is easier
-    // to implement it this way.
-    // The write buffer is limited to 16kiB, as this is the maximum amount of data a single
-    // WebRTC frame can have.
-    let mut write_buffer = vec![0; 16384];
-
     loop {
         // Start opening new outbound substreams, if needed.
         for _ in 0..connection_task
@@ -458,8 +438,7 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
             loop {
                 let (substream, write_side_was_open) = &mut open_substreams[substream_id];
 
-                let writable_bytes =
-                    cmp::min(platform.writable_bytes(substream), write_buffer.len());
+                let write_bytes_queueable = platform.writable_bytes(substream);
 
                 let incoming_buffer = match platform.read_buffer(substream) {
                     ReadBuffer::Open(buf) => buf,
@@ -475,17 +454,15 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
                 let mut read_write = ReadWrite {
                     now: now.clone(),
                     incoming_buffer: Some(incoming_buffer),
-                    outgoing_buffer: if *write_side_was_open {
-                        Some((&mut write_buffer[..writable_bytes], &mut []))
-                    } else {
-                        None
-                    },
                     read_bytes: 0,
-                    written_bytes: 0,
+                    write_buffers: Vec::new(),
+                    write_bytes_queued: 0,
+                    write_closed: *write_side_was_open,
+                    write_bytes_queueable,
                     wake_up_after,
                 };
 
-                debug_assert!(read_write.outgoing_buffer.is_some());
+                debug_assert!(!read_write.write_closed);
 
                 let substream_fate =
                     connection_task.substream_read_write(&substream_id, &mut read_write);
@@ -495,15 +472,15 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
                 // information from it.
                 let read_bytes = read_write.read_bytes;
                 debug_assert!(read_bytes <= incoming_buffer.len());
-                let written_bytes = read_write.written_bytes;
-                let must_close_writing_side =
-                    *write_side_was_open && read_write.outgoing_buffer.is_none();
+                let written_bytes = read_write.write_bytes_queued;
+                let write_buffers = mem::take(&mut read_write.write_buffers);
+                let must_close_writing_side = *write_side_was_open && read_write.write_closed;
                 wake_up_after = read_write.wake_up_after.take();
                 drop(read_write);
 
                 // Now update the connection.
-                if written_bytes != 0 {
-                    platform.send(substream, &write_buffer[..written_bytes]);
+                for buffer in write_buffers {
+                    platform.send(substream, &buffer);
                 }
                 if must_close_writing_side {
                     platform.close_send(substream);


### PR DESCRIPTION
First step of https://github.com/smol-dot/smoldot/issues/918
This PR refactors the writing side of the `ReadWrite` struct.

In a traditional events loop, you call `writev`, which takes a pointer to your buffers. If all the buffers can't immediately be written, you get back ownership of the buffers that you want to write. In other words, while the write operation is in progress, you can at any time interrupt it and modify the buffers of data.
In io_uring, however, you have to give ownership of the buffers to the kernel, and you only get it back once the operation succeeds. While the write operation is in progress, you can't write to the same buffers. If you want to queue more data for writing, you have to use different buffers.

This PR embraces this and makes it so that the writer gives back `Vec`s rather than write to buffers.

The other main motivation for this PR is to make it easier to use the `ReadWrite` struct. Right now these mutable borrows of mutable borrows can be a bit of a nightmare. The Rust borrow check has many issues when it comes to mutable borrows.
