### PR TITLE
Turn all `nom` complete parsers into streaming parsers

### DIFF
--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -926,18 +926,18 @@ fn decode_babe_configuration_output(
     let result: nom::IResult<_, _> =
         nom::combinator::all_consuming(nom::combinator::complete(nom::combinator::map(
             nom::sequence::tuple((
-                nom::number::complete::le_u64,
-                nom::combinator::map_opt(nom::number::complete::le_u64, NonZeroU64::new),
-                nom::number::complete::le_u64,
-                nom::number::complete::le_u64,
+                nom::number::streaming::le_u64,
+                nom::combinator::map_opt(nom::number::streaming::le_u64, NonZeroU64::new),
+                nom::number::streaming::le_u64,
+                nom::number::streaming::le_u64,
                 nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
                     nom::multi::many_m_n(
                         num_elems,
                         num_elems,
                         nom::combinator::map(
                             nom::sequence::tuple((
-                                nom::bytes::complete::take(32u32),
-                                nom::number::complete::le_u64,
+                                nom::bytes::streaming::take(32u32),
+                                nom::number::streaming::le_u64,
                             )),
                             move |(public_key, weight)| header::BabeAuthority {
                                 public_key: <[u8; 32]>::try_from(public_key).unwrap(),
@@ -946,28 +946,28 @@ fn decode_babe_configuration_output(
                         ),
                     )
                 }),
-                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                     <[u8; 32]>::try_from(b).unwrap()
                 }),
                 |b| {
                     if is_babe_api_v1 {
                         nom::branch::alt((
-                            nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+                            nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                                 header::BabeAllowedSlots::PrimarySlots
                             }),
-                            nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+                            nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| {
                                 header::BabeAllowedSlots::PrimaryAndSecondaryPlainSlots
                             }),
                         ))(b)
                     } else {
                         nom::branch::alt((
-                            nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+                            nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                                 header::BabeAllowedSlots::PrimarySlots
                             }),
-                            nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+                            nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| {
                                 header::BabeAllowedSlots::PrimaryAndSecondaryPlainSlots
                             }),
-                            nom::combinator::map(nom::bytes::complete::tag(&[2]), |_| {
+                            nom::combinator::map(nom::bytes::streaming::tag(&[2]), |_| {
                                 header::BabeAllowedSlots::PrimaryAndSecondaryVrfSlots
                             }),
                         ))(b)
@@ -1005,17 +1005,17 @@ fn decode_babe_epoch_output(
 ) -> Result<chain_information::BabeEpochInformation, Error> {
     let mut combinator = nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
-            nom::number::complete::le_u64,
-            nom::number::complete::le_u64,
-            nom::number::complete::le_u64,
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
                 nom::multi::many_m_n(
                     num_elems,
                     num_elems,
                     nom::combinator::map(
                         nom::sequence::tuple((
-                            nom::bytes::complete::take(32u32),
-                            nom::number::complete::le_u64,
+                            nom::bytes::streaming::take(32u32),
+                            nom::number::streaming::le_u64,
                         )),
                         move |(public_key, weight)| header::BabeAuthority {
                             public_key: <[u8; 32]>::try_from(public_key).unwrap(),
@@ -1024,11 +1024,11 @@ fn decode_babe_epoch_output(
                     ),
                 )
             }),
-            nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+            nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                 <[u8; 32]>::try_from(b).unwrap()
             }),
-            nom::number::complete::le_u64,
-            nom::number::complete::le_u64,
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
             |b| {
                 header::BabeAllowedSlots::from_slice(b)
                     .map(|v| (&[][..], v))
@@ -1088,8 +1088,8 @@ fn decode_grandpa_authorities_output(
                 num_elems,
                 num_elems,
                 nom::sequence::tuple((
-                    nom::bytes::complete::take(32u32),
-                    nom::combinator::map_opt(nom::number::complete::le_u64, NonZeroU64::new),
+                    nom::bytes::streaming::take(32u32),
+                    nom::combinator::map_opt(nom::number::streaming::le_u64, NonZeroU64::new),
                 )),
                 move || Vec::with_capacity(num_elems),
                 |mut acc, (public_key, weight)| {

--- a/lib/src/chain_spec/light_sync_state.rs
+++ b/lib/src/chain_spec/light_sync_state.rs
@@ -97,8 +97,8 @@ fn epoch_changes<'a, E: nom::error::ParseError<&'a [u8]>>(
                     num_elems,
                     num_elems,
                     nom::sequence::tuple((
-                        nom::bytes::complete::take(32u32),
-                        nom::number::complete::le_u32,
+                        nom::bytes::streaming::take(32u32),
+                        nom::number::streaming::le_u32,
                         persisted_epoch,
                     )),
                 )
@@ -128,17 +128,17 @@ fn gap_epochs<'a, E: nom::error::ParseError<&'a [u8]>>(
     nom::combinator::map(
         nom::sequence::tuple((
             nom::sequence::tuple((
-                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                     *<&[u8; 32]>::try_from(b).unwrap()
                 }),
-                nom::number::complete::le_u32,
+                nom::number::streaming::le_u32,
                 persisted_epoch,
             )),
             crate::util::nom_option_decode(nom::sequence::tuple((
-                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                     *<&[u8; 32]>::try_from(b).unwrap()
                 }),
-                nom::number::complete::le_u32,
+                nom::number::streaming::le_u32,
                 babe_epoch,
             ))),
         )),
@@ -158,13 +158,13 @@ fn persisted_epoch_header<'a, E: nom::error::ParseError<&'a [u8]>>(
     nom::branch::alt((
         nom::combinator::map(
             nom::sequence::preceded(
-                nom::bytes::complete::tag(&[0]),
+                nom::bytes::streaming::tag(&[0]),
                 nom::sequence::tuple((epoch_header, epoch_header)),
             ),
             |(a, b)| PersistedEpochHeader::Genesis(a, b),
         ),
         nom::combinator::map(
-            nom::sequence::preceded(nom::bytes::complete::tag(&[1]), epoch_header),
+            nom::sequence::preceded(nom::bytes::streaming::tag(&[1]), epoch_header),
             PersistedEpochHeader::Regular,
         ),
     ))(bytes)
@@ -180,7 +180,7 @@ fn epoch_header<'a, E: nom::error::ParseError<&'a [u8]>>(
     bytes: &'a [u8],
 ) -> nom::IResult<&'a [u8], EpochHeader, E> {
     nom::combinator::map(
-        nom::sequence::tuple((nom::number::complete::le_u64, nom::number::complete::le_u64)),
+        nom::sequence::tuple((nom::number::streaming::le_u64, nom::number::streaming::le_u64)),
         move |(start_slot, end_slot)| EpochHeader {
             _start_slot: start_slot,
             _end_slot: end_slot,
@@ -200,13 +200,13 @@ fn persisted_epoch<'a, E: nom::error::ParseError<&'a [u8]>>(
     nom::branch::alt((
         nom::combinator::map(
             nom::sequence::preceded(
-                nom::bytes::complete::tag(&[0]),
+                nom::bytes::streaming::tag(&[0]),
                 nom::sequence::tuple((babe_epoch, babe_epoch)),
             ),
             |(a, b)| PersistedEpoch::Genesis(a, b),
         ),
         nom::combinator::map(
-            nom::sequence::preceded(nom::bytes::complete::tag(&[1]), babe_epoch),
+            nom::sequence::preceded(nom::bytes::streaming::tag(&[1]), babe_epoch),
             PersistedEpoch::Regular,
         ),
     ))(bytes)
@@ -227,13 +227,13 @@ fn babe_epoch<'a, E: nom::error::ParseError<&'a [u8]>>(
 ) -> nom::IResult<&'a [u8], BabeEpoch, E> {
     nom::combinator::map(
         nom::sequence::tuple((
-            nom::number::complete::le_u64,
-            nom::number::complete::le_u64,
-            nom::number::complete::le_u64,
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                 nom::multi::many_m_n(num_elems, num_elems, babe_authority)
             }),
-            nom::bytes::complete::take(32u32),
+            nom::bytes::streaming::take(32u32),
             |b| {
                 BabeNextConfig::from_slice(b)
                     .map(|c| (&b[17..], c)) // TODO: hacky to use a constant
@@ -269,8 +269,8 @@ fn babe_authority<'a, E: nom::error::ParseError<&'a [u8]>>(
 ) -> nom::IResult<&'a [u8], BabeAuthority, E> {
     nom::combinator::map(
         nom::sequence::tuple((
-            nom::bytes::complete::take(32u32),
-            nom::number::complete::le_u64,
+            nom::bytes::streaming::take(32u32),
+            nom::number::streaming::le_u64,
         )),
         move |(public_key, weight)| BabeAuthority {
             public_key: *<&[u8; 32]>::try_from(public_key).unwrap(),
@@ -298,7 +298,7 @@ fn authority_set<'a, E: nom::error::ParseError<&'a [u8]>>(
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                 nom::multi::many_m_n(num_elems, num_elems, grandpa_authority)
             }),
-            nom::number::complete::le_u64,
+            nom::number::streaming::le_u64,
             fork_tree(pending_change),
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                 nom::multi::many_m_n(num_elems, num_elems, pending_change)
@@ -308,8 +308,8 @@ fn authority_set<'a, E: nom::error::ParseError<&'a [u8]>>(
                     num_elems,
                     num_elems,
                     nom::sequence::tuple((
-                        nom::number::complete::le_u64,
-                        nom::number::complete::le_u32,
+                        nom::number::streaming::le_u64,
+                        nom::number::streaming::le_u32,
                     )),
                 )
             }),
@@ -347,9 +347,9 @@ fn pending_change<'a, E: nom::error::ParseError<&'a [u8]>>(
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                 nom::multi::many_m_n(num_elems, num_elems, grandpa_authority)
             }),
-            nom::number::complete::le_u32,
-            nom::number::complete::le_u32,
-            nom::bytes::complete::take(32u32),
+            nom::number::streaming::le_u32,
+            nom::number::streaming::le_u32,
+            nom::bytes::streaming::take(32u32),
             delay_kind,
         )),
         move |(next_authorities, delay, canon_height, canon_hash, delay_kind)| PendingChange {
@@ -372,11 +372,11 @@ fn delay_kind<'a, E: nom::error::ParseError<&'a [u8]>>(
     bytes: &'a [u8],
 ) -> nom::IResult<&'a [u8], DelayKind, E> {
     nom::branch::alt((
-        nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| DelayKind::Finalized),
+        nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| DelayKind::Finalized),
         nom::combinator::map(
             nom::sequence::preceded(
-                nom::bytes::complete::tag(&[1]),
-                nom::number::complete::le_u32,
+                nom::bytes::streaming::tag(&[1]),
+                nom::number::streaming::le_u32,
             ),
             |median_last_finalized| DelayKind::Best {
                 _median_last_finalized: median_last_finalized,
@@ -402,8 +402,8 @@ fn grandpa_authority<'a, E: nom::error::ParseError<&'a [u8]>>(
 ) -> nom::IResult<&'a [u8], GrandpaAuthority, E> {
     nom::combinator::map(
         nom::sequence::tuple((
-            nom::bytes::complete::take(32u32),
-            nom::number::complete::le_u64,
+            nom::bytes::streaming::take(32u32),
+            nom::number::streaming::le_u64,
         )),
         move |(public_key, weight)| GrandpaAuthority {
             public_key: *<&[u8; 32]>::try_from(public_key).unwrap(),
@@ -443,7 +443,7 @@ fn fork_tree<'a, T, E: nom::error::ParseError<&'a [u8]>>(
 
                 Ok((bytes, roots))
             },
-            crate::util::nom_option_decode(nom::number::complete::le_u32),
+            crate::util::nom_option_decode(nom::number::streaming::le_u32),
         )),
         |(roots, best_finalized_number)| ForkTree {
             _roots: roots,
@@ -465,8 +465,8 @@ fn fork_tree_node<'a, 'p, T, E: nom::error::ParseError<&'a [u8]>>(
 ) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], ForkTreeNode<T>, E> + 'p {
     nom::combinator::map(
         nom::sequence::tuple((
-            nom::bytes::complete::take(32u32),
-            nom::number::complete::le_u32,
+            nom::bytes::streaming::take(32u32),
+            nom::number::streaming::le_u32,
             // We do parsing manually due to borrow checking troubles regarding `inner`.
             move |mut bytes| {
                 let (bytes_rest, data) = match inner(bytes) {

--- a/lib/src/chain_spec/light_sync_state.rs
+++ b/lib/src/chain_spec/light_sync_state.rs
@@ -180,7 +180,10 @@ fn epoch_header<'a, E: nom::error::ParseError<&'a [u8]>>(
     bytes: &'a [u8],
 ) -> nom::IResult<&'a [u8], EpochHeader, E> {
     nom::combinator::map(
-        nom::sequence::tuple((nom::number::streaming::le_u64, nom::number::streaming::le_u64)),
+        nom::sequence::tuple((
+            nom::number::streaming::le_u64,
+            nom::number::streaming::le_u64,
+        )),
         move |(start_slot, end_slot)| EpochHeader {
             _start_slot: start_slot,
             _end_slot: end_slot,

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -1622,7 +1622,10 @@ fn decode_babe_epoch_information(
                 )
             }),
             nom::bytes::streaming::take(32u32),
-            nom::sequence::tuple((nom::number::streaming::le_u64, nom::number::streaming::le_u64)),
+            nom::sequence::tuple((
+                nom::number::streaming::le_u64,
+                nom::number::streaming::le_u64,
+            )),
             nom::branch::alt((
                 nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                     header::BabeAllowedSlots::PrimarySlots

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -1603,16 +1603,16 @@ fn decode_babe_epoch_information(
 ) -> Result<chain_information::BabeEpochInformation, AccessError> {
     let result = nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
-            nom::number::complete::le_u64,
-            util::nom_option_decode(nom::number::complete::le_u64),
+            nom::number::streaming::le_u64,
+            util::nom_option_decode(nom::number::streaming::le_u64),
             nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
                 nom::multi::many_m_n(
                     num_elems,
                     num_elems,
                     nom::combinator::map(
                         nom::sequence::tuple((
-                            nom::bytes::complete::take(32u32),
-                            nom::number::complete::le_u64,
+                            nom::bytes::streaming::take(32u32),
+                            nom::number::streaming::le_u64,
                         )),
                         move |(public_key, weight)| header::BabeAuthority {
                             public_key: TryFrom::try_from(public_key).unwrap(),
@@ -1621,16 +1621,16 @@ fn decode_babe_epoch_information(
                     ),
                 )
             }),
-            nom::bytes::complete::take(32u32),
-            nom::sequence::tuple((nom::number::complete::le_u64, nom::number::complete::le_u64)),
+            nom::bytes::streaming::take(32u32),
+            nom::sequence::tuple((nom::number::streaming::le_u64, nom::number::streaming::le_u64)),
             nom::branch::alt((
-                nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+                nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                     header::BabeAllowedSlots::PrimarySlots
                 }),
-                nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+                nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| {
                     header::BabeAllowedSlots::PrimaryAndSecondaryPlainSlots
                 }),
-                nom::combinator::map(nom::bytes::complete::tag(&[2]), |_| {
+                nom::combinator::map(nom::bytes::streaming::tag(&[2]), |_| {
                     header::BabeAllowedSlots::PrimaryAndSecondaryVrfSlots
                 }),
             )),

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -1021,7 +1021,7 @@ impl ReadyToRun {
                     let input = expect_pointer_size!(1);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
                         nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::complete::le_u32,
+                            nom::number::streaming::le_u32,
                         ))(input.as_ref())
                         .map(|(_, parse_result)| parse_result);
 
@@ -1205,7 +1205,7 @@ impl ReadyToRun {
                     let input = expect_pointer_size!(1);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
                         nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::complete::le_u32,
+                            nom::number::streaming::le_u32,
                         ))(input.as_ref())
                         .map(|(_, parse_result)| parse_result);
 
@@ -1252,7 +1252,7 @@ impl ReadyToRun {
                     let input = expect_pointer_size!(2);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
                         nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::complete::le_u32,
+                            nom::number::streaming::le_u32,
                         ))(input.as_ref())
                         .map(|(_, parse_result)| parse_result);
 
@@ -1875,11 +1875,11 @@ impl ReadyToRun {
                                     nom::sequence::tuple((
                                         nom::combinator::flat_map(
                                             crate::util::nom_scale_compact_usize,
-                                            nom::bytes::complete::take,
+                                            nom::bytes::streaming::take,
                                         ),
                                         nom::combinator::flat_map(
                                             crate::util::nom_scale_compact_usize,
-                                            nom::bytes::complete::take,
+                                            nom::bytes::streaming::take,
                                         ),
                                     )),
                                 )
@@ -1940,7 +1940,7 @@ impl ReadyToRun {
                                     num_elems,
                                     nom::combinator::flat_map(
                                         crate::util::nom_scale_compact_usize,
-                                        nom::bytes::complete::take,
+                                        nom::bytes::streaming::take,
                                     ),
                                 )
                             },

--- a/lib/src/finality/grandpa/commit/decode.rs
+++ b/lib/src/finality/grandpa/commit/decode.rs
@@ -80,8 +80,8 @@ fn commit_message<'a>(
         "commit_message",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::number::complete::le_u64,
-                nom::number::complete::le_u64,
+                nom::number::streaming::le_u64,
+                nom::number::streaming::le_u64,
                 compact_commit(block_number_bytes),
             )),
             |(round_number, set_id, message)| CommitMessageRef {
@@ -100,7 +100,7 @@ fn compact_commit<'a>(
         "compact_commit",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::bytes::complete::take(32u32),
+                nom::bytes::streaming::take(32u32),
                 crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                 nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
                     nom::multi::many_m_n(
@@ -115,8 +115,8 @@ fn compact_commit<'a>(
                         num_elems,
                         nom::combinator::map(
                             nom::sequence::tuple((
-                                nom::bytes::complete::take(64u32),
-                                nom::bytes::complete::take(32u32),
+                                nom::bytes::streaming::take(64u32),
+                                nom::bytes::streaming::take(32u32),
                             )),
                             |(sig, pubkey)| {
                                 (
@@ -145,7 +145,7 @@ fn unsigned_precommit<'a>(
         "unsigned_precommit",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::bytes::complete::take(32u32),
+                nom::bytes::streaming::take(32u32),
                 crate::util::nom_varsize_number_decode_u64(block_number_bytes),
             )),
             |(target_hash, target_number)| UnsignedPrecommitRef {

--- a/lib/src/finality/justification/decode.rs
+++ b/lib/src/finality/justification/decode.rs
@@ -314,8 +314,8 @@ fn grandpa_justification<'a>(
         "grandpa_justification",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::number::complete::le_u64,
-                nom::bytes::complete::take(32u32),
+                nom::number::streaming::le_u64,
+                nom::bytes::streaming::take(32u32),
                 crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                 precommits(block_number_bytes),
                 votes_ancestries(block_number_bytes),
@@ -364,10 +364,10 @@ fn precommit<'a>(
         "precommit",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::bytes::complete::take(32u32),
+                nom::bytes::streaming::take(32u32),
                 crate::util::nom_varsize_number_decode_u64(block_number_bytes),
-                nom::bytes::complete::take(64u32),
-                nom::bytes::complete::take(32u32),
+                nom::bytes::streaming::take(64u32),
+                nom::bytes::streaming::take(32u32),
             )),
             |(target_hash, target_number, signature, authority_public_key)| PrecommitRef {
                 target_hash: TryFrom::try_from(target_hash).unwrap(),

--- a/lib/src/header/grandpa.rs
+++ b/lib/src/header/grandpa.rs
@@ -433,14 +433,14 @@ fn grandpa_consensus_log_ref<
         nom::branch::alt((
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[1]),
+                    nom::bytes::streaming::tag(&[1]),
                     grandpa_scheduled_change_ref(block_number_bytes),
                 ),
                 GrandpaConsensusLogRef::ScheduledChange,
             ),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[2]),
+                    nom::bytes::streaming::tag(&[2]),
                     nom::sequence::tuple((
                         crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                         grandpa_scheduled_change_ref(block_number_bytes),
@@ -453,21 +453,21 @@ fn grandpa_consensus_log_ref<
             ),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[3]),
-                    nom::number::complete::le_u64,
+                    nom::bytes::streaming::tag(&[3]),
+                    nom::number::streaming::le_u64,
                 ),
                 GrandpaConsensusLogRef::OnDisabled,
             ),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[4]),
+                    nom::bytes::streaming::tag(&[4]),
                     crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                 ),
                 GrandpaConsensusLogRef::Pause,
             ),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[5]),
+                    nom::bytes::streaming::tag(&[5]),
                     crate::util::nom_varsize_number_decode_u64(block_number_bytes),
                 ),
                 GrandpaConsensusLogRef::Resume,
@@ -522,8 +522,8 @@ fn grandpa_authority_ref<
         "grandpa_authority_ref",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::bytes::complete::take(32u32),
-                nom::combinator::map_opt(nom::number::complete::le_u64, NonZeroU64::new),
+                nom::bytes::streaming::take(32u32),
+                nom::combinator::map_opt(nom::number::streaming::le_u64, NonZeroU64::new),
             )),
             |(public_key, weight)| GrandpaAuthorityRef {
                 public_key: TryFrom::try_from(public_key).unwrap(),

--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -167,7 +167,7 @@ impl Keystore {
                             ),
                             nom::bytes::streaming::tag("-"),
                             nom::combinator::map_opt(
-                                nom::bytes::streaming::take_while(|c: char| {
+                                nom::bytes::complete::take_while(|c: char| {
                                     c.is_ascii_digit() || ('a'..='f').contains(&c)
                                 }),
                                 |k: &str| {

--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -153,21 +153,21 @@ impl Keystore {
                     nom::combinator::all_consuming::<_, _, (&str, nom::error::ErrorKind), _>(
                         nom::combinator::complete(nom::sequence::tuple((
                             nom::combinator::map_opt(
-                                nom::bytes::complete::take(4u32),
+                                nom::bytes::streaming::take(4u32),
                                 KeyNamespace::from_string,
                             ),
-                            nom::bytes::complete::tag("-"),
+                            nom::bytes::streaming::tag("-"),
                             nom::combinator::map_opt(
-                                nom::bytes::complete::take(7u32),
+                                nom::bytes::streaming::take(7u32),
                                 |b| match b {
                                     "ed25519" => Some(PrivateKey::FileEd25519),
                                     "sr25519" => Some(PrivateKey::FileSr25519),
                                     _ => None,
                                 },
                             ),
-                            nom::bytes::complete::tag("-"),
+                            nom::bytes::streaming::tag("-"),
                             nom::combinator::map_opt(
-                                nom::bytes::complete::take_while(|c: char| {
+                                nom::bytes::streaming::take_while(|c: char| {
                                     c.is_ascii_digit() || ('a'..='f').contains(&c)
                                 }),
                                 |k: &str| {

--- a/lib/src/identity/seed_phrase.rs
+++ b/lib/src/identity/seed_phrase.rs
@@ -101,7 +101,7 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                     nom::combinator::map_opt(
                         nom::sequence::preceded(
                             nom::bytes::streaming::tag("0x"),
-                            nom::character::streaming::hex_digit0,
+                            nom::character::complete::hex_digit0,
                         ),
                         |hex| {
                             let mut out = Box::new([0; 32]);
@@ -123,7 +123,7 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                 nom::combinator::map(
                     nom::sequence::preceded(
                         nom::bytes::streaming::tag("/"),
-                        nom::bytes::streaming::take_till1(|c| c == '/'),
+                        nom::bytes::complete::take_till1(|c| c == '/'),
                     ),
                     |code| DeriveJunction::from_components(false, code),
                 ),
@@ -131,7 +131,7 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                 nom::combinator::map(
                     nom::sequence::preceded(
                         nom::bytes::streaming::tag("//"),
-                        nom::bytes::streaming::take_till1(|c| c == '/'),
+                        nom::bytes::complete::take_till1(|c| c == '/'),
                     ),
                     |code| DeriveJunction::from_components(true, code),
                 ),

--- a/lib/src/identity/seed_phrase.rs
+++ b/lib/src/identity/seed_phrase.rs
@@ -97,7 +97,7 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
             // Either BIP39 words or some hexadecimal
             nom::branch::alt((
                 // Hexadecimal. Wrapped in `either::Left`
-                nom::combinator::map(
+                nom::combinator::complete(nom::combinator::map(
                     nom::combinator::map_opt(
                         nom::sequence::preceded(
                             nom::bytes::streaming::tag("0x"),
@@ -110,37 +110,37 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                         },
                     ),
                     either::Left,
-                ),
+                )),
                 // BIP39. Wrapped in `either::Right`
-                nom::combinator::map(
-                    nom::bytes::streaming::take_till(|c| c == '/'),
+                nom::combinator::complete(nom::combinator::map(
+                    nom::bytes::complete::take_till(|c| c == '/'),
                     either::Right,
-                ),
+                )),
             )),
             // Derivation path
-            nom::multi::many0(nom::combinator::complete(nom::branch::alt((
+            nom::multi::many0(nom::branch::alt((
                 // Soft
-                nom::combinator::map(
+                nom::combinator::complete(nom::combinator::map(
                     nom::sequence::preceded(
                         nom::bytes::streaming::tag("/"),
                         nom::bytes::complete::take_till1(|c| c == '/'),
                     ),
                     |code| DeriveJunction::from_components(false, code),
-                ),
+                )),
                 // Hard
-                nom::combinator::map(
+                nom::combinator::complete(nom::combinator::map(
                     nom::sequence::preceded(
                         nom::bytes::streaming::tag("//"),
                         nom::bytes::complete::take_till1(|c| c == '/'),
                     ),
                     |code| DeriveJunction::from_components(true, code),
-                ),
-            )))),
+                )),
+            ))),
             // Optional password
-            nom::combinator::opt(nom::sequence::preceded(
+            nom::combinator::opt(nom::combinator::complete(nom::sequence::preceded(
                 nom::bytes::streaming::tag("///"),
                 |s| Ok(("", s)), // Take the rest of the input after the `///`
-            )),
+            ))),
         )))(phrase);
 
     match parse_result {

--- a/lib/src/json_rpc/payment_info.rs
+++ b/lib/src/json_rpc/payment_info.rs
@@ -70,7 +70,7 @@ fn nom_decode_payment_info<'a, E: nom::error::ParseError<&'a [u8]>>(
         nom::sequence::tuple((
             move |bytes| {
                 if is_api_v2 {
-                    nom::number::complete::le_u64(bytes)
+                    nom::number::streaming::le_u64(bytes)
                 } else {
                     nom::combinator::map(
                         nom::sequence::tuple((
@@ -81,7 +81,7 @@ fn nom_decode_payment_info<'a, E: nom::error::ParseError<&'a [u8]>>(
                     )(bytes)
                 }
             },
-            nom::combinator::map_opt(nom::number::complete::u8, |n| match n {
+            nom::combinator::map_opt(nom::number::streaming::u8, |n| match n {
                 0 => Some(methods::DispatchClass::Normal),
                 1 => Some(methods::DispatchClass::Operational),
                 2 => Some(methods::DispatchClass::Mandatory),

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -847,7 +847,7 @@ impl HandshakeInProgress {
                             (&[u8], nom::error::ErrorKind),
                             _,
                         >(nom::combinator::map(
-                            nom::bytes::complete::take(32u32),
+                            nom::bytes::streaming::take(32u32),
                             |k| <&[u8; 32]>::try_from(k).unwrap(),
                         ));
                         match parser(available_message) {
@@ -885,10 +885,10 @@ impl HandshakeInProgress {
                             (&[u8], nom::error::ErrorKind),
                             _,
                         >(nom::sequence::tuple((
-                            nom::combinator::map(nom::bytes::complete::take(32u32), |k| {
+                            nom::combinator::map(nom::bytes::streaming::take(32u32), |k| {
                                 <&[u8; 32]>::try_from(k).unwrap()
                             }),
-                            nom::combinator::map(nom::bytes::complete::take(48u32), |k| {
+                            nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
                                 <&[u8; 48]>::try_from(k).unwrap()
                             }),
                             nom::combinator::rest,
@@ -1013,7 +1013,7 @@ impl HandshakeInProgress {
                             (&[u8], nom::error::ErrorKind),
                             _,
                         >(nom::sequence::tuple((
-                            nom::combinator::map(nom::bytes::complete::take(48u32), |k| {
+                            nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
                                 <&[u8; 48]>::try_from(k).unwrap()
                             }),
                             nom::combinator::rest,

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -238,15 +238,18 @@ fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
                     nom::bytes::streaming::tag(&[0, 0]),
                     nom::bytes::streaming::tag(&[0, 0, 0, 0]),
                     nom::branch::alt((
-                        nom::combinator::map(nom::bytes::streaming::tag(0u32.to_be_bytes()), |_| {
-                            GoAwayErrorCode::NormalTermination
-                        }),
-                        nom::combinator::map(nom::bytes::streaming::tag(1u32.to_be_bytes()), |_| {
-                            GoAwayErrorCode::ProtocolError
-                        }),
-                        nom::combinator::map(nom::bytes::streaming::tag(2u32.to_be_bytes()), |_| {
-                            GoAwayErrorCode::InternalError
-                        }),
+                        nom::combinator::map(
+                            nom::bytes::streaming::tag(0u32.to_be_bytes()),
+                            |_| GoAwayErrorCode::NormalTermination,
+                        ),
+                        nom::combinator::map(
+                            nom::bytes::streaming::tag(1u32.to_be_bytes()),
+                            |_| GoAwayErrorCode::ProtocolError,
+                        ),
+                        nom::combinator::map(
+                            nom::bytes::streaming::tag(2u32.to_be_bytes()),
+                            |_| GoAwayErrorCode::InternalError,
+                        ),
                     )),
                 )),
                 |(_, _, _, error_code)| DecodedYamuxHeader::GoAway { error_code },

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -180,14 +180,14 @@ pub struct YamuxHeaderDecodeError {
 
 fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
     nom::sequence::preceded(
-        nom::bytes::complete::tag(&[0]),
+        nom::bytes::streaming::tag(&[0]),
         nom::branch::alt((
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::tag(&[0]),
+                    nom::bytes::streaming::tag(&[0]),
                     flags,
-                    nom::combinator::map_opt(nom::number::complete::be_u32, NonZeroU32::new),
-                    nom::number::complete::be_u32,
+                    nom::combinator::map_opt(nom::number::streaming::be_u32, NonZeroU32::new),
+                    nom::number::streaming::be_u32,
                 )),
                 |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Data {
                     syn,
@@ -200,10 +200,10 @@ fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
             ),
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::tag(&[1]),
+                    nom::bytes::streaming::tag(&[1]),
                     flags,
-                    nom::combinator::map_opt(nom::number::complete::be_u32, NonZeroU32::new),
-                    nom::number::complete::be_u32,
+                    nom::combinator::map_opt(nom::number::streaming::be_u32, NonZeroU32::new),
+                    nom::number::streaming::be_u32,
                 )),
                 |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Window {
                     syn,
@@ -216,35 +216,35 @@ fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
             ),
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::tag(&[2]),
-                    nom::bytes::complete::tag(&[0x0, 0x1]),
-                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
-                    nom::number::complete::be_u32,
+                    nom::bytes::streaming::tag(&[2]),
+                    nom::bytes::streaming::tag(&[0x0, 0x1]),
+                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
+                    nom::number::streaming::be_u32,
                 )),
                 |(_, _, _, opaque_value)| DecodedYamuxHeader::PingRequest { opaque_value },
             ),
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::tag(&[2]),
-                    nom::bytes::complete::tag(&[0x0, 0x2]),
-                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
-                    nom::number::complete::be_u32,
+                    nom::bytes::streaming::tag(&[2]),
+                    nom::bytes::streaming::tag(&[0x0, 0x2]),
+                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
+                    nom::number::streaming::be_u32,
                 )),
                 |(_, _, _, opaque_value)| DecodedYamuxHeader::PingResponse { opaque_value },
             ),
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::tag(&[3]),
-                    nom::bytes::complete::tag(&[0, 0]),
-                    nom::bytes::complete::tag(&[0, 0, 0, 0]),
+                    nom::bytes::streaming::tag(&[3]),
+                    nom::bytes::streaming::tag(&[0, 0]),
+                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
                     nom::branch::alt((
-                        nom::combinator::map(nom::bytes::complete::tag(0u32.to_be_bytes()), |_| {
+                        nom::combinator::map(nom::bytes::streaming::tag(0u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::NormalTermination
                         }),
-                        nom::combinator::map(nom::bytes::complete::tag(1u32.to_be_bytes()), |_| {
+                        nom::combinator::map(nom::bytes::streaming::tag(1u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::ProtocolError
                         }),
-                        nom::combinator::map(nom::bytes::complete::tag(2u32.to_be_bytes()), |_| {
+                        nom::combinator::map(nom::bytes::streaming::tag(2u32.to_be_bytes()), |_| {
                             GoAwayErrorCode::InternalError
                         }),
                     )),
@@ -256,7 +256,7 @@ fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
 }
 
 fn flags(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], (bool, bool, bool, bool)> {
-    nom::combinator::map_opt(nom::number::complete::be_u16, |flags| {
+    nom::combinator::map_opt(nom::number::streaming::be_u16, |flags| {
         let syn = (flags & 0x1) != 0;
         let ack = (flags & 0x2) != 0;
         let fin = (flags & 0x4) != 0;

--- a/lib/src/network/protocol/block_announces.rs
+++ b/lib/src/network/protocol/block_announces.rs
@@ -121,8 +121,8 @@ pub fn decode_block_announce(
                     }
                 }),
                 nom::branch::alt((
-                    nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| false),
-                    nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| true),
+                    nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| false),
+                    nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| true),
                 )),
                 crate::util::nom_bytes_decode,
             )),
@@ -174,13 +174,13 @@ pub fn decode_block_announces_handshake(
         nom::combinator::all_consuming(nom::combinator::complete(nom::combinator::map(
             nom::sequence::tuple((
                 nom::branch::alt((
-                    nom::combinator::map(nom::bytes::complete::tag(&[0b1]), |_| Role::Full),
-                    nom::combinator::map(nom::bytes::complete::tag(&[0b10]), |_| Role::Light),
-                    nom::combinator::map(nom::bytes::complete::tag(&[0b100]), |_| Role::Authority),
+                    nom::combinator::map(nom::bytes::streaming::tag(&[0b1]), |_| Role::Full),
+                    nom::combinator::map(nom::bytes::streaming::tag(&[0b10]), |_| Role::Light),
+                    nom::combinator::map(nom::bytes::streaming::tag(&[0b100]), |_| Role::Authority),
                 )),
                 crate::util::nom_varsize_number_decode_u64(expected_block_number_bytes),
-                nom::bytes::complete::take(32u32),
-                nom::bytes::complete::take(32u32),
+                nom::bytes::streaming::take(32u32),
+                nom::bytes::streaming::take(32u32),
             )),
             |(role, best_number, best_hash, genesis_hash)| BlockAnnouncesHandshakeRef {
                 role,

--- a/lib/src/network/protocol/block_request.rs
+++ b/lib/src/network/protocol/block_request.rs
@@ -404,7 +404,7 @@ fn decode_justifications<'a, E: nom::error::ParseError<&'a [u8]>>(
             num_elems,
             nom::combinator::map(
                 nom::sequence::tuple((
-                    nom::bytes::complete::take(4u32),
+                    nom::bytes::streaming::take(4u32),
                     crate::util::nom_bytes_decode,
                 )),
                 move |(consensus_engine, justification)| Justification {

--- a/lib/src/network/protocol/grandpa.rs
+++ b/lib/src/network/protocol/grandpa.rs
@@ -350,7 +350,10 @@ fn catch_up_request(bytes: &[u8]) -> nom::IResult<&[u8], CatchUpRequest> {
     nom::error::context(
         "catch_up_request",
         nom::combinator::map(
-            nom::sequence::tuple((nom::number::streaming::le_u64, nom::number::streaming::le_u64)),
+            nom::sequence::tuple((
+                nom::number::streaming::le_u64,
+                nom::number::streaming::le_u64,
+            )),
             |(round_number, set_id)| CatchUpRequest {
                 round_number,
                 set_id,

--- a/lib/src/network/protocol/grandpa_warp_sync.rs
+++ b/lib/src/network/protocol/grandpa_warp_sync.rs
@@ -82,7 +82,7 @@ pub fn decode_grandpa_warp_sync_response(
     nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
             decode_fragments(block_number_bytes),
-            nom::number::complete::le_u8,
+            nom::number::streaming::le_u8,
         )),
         |(fragments, is_finished)| GrandpaWarpSyncResponse {
             fragments,

--- a/lib/src/sync/para.rs
+++ b/lib/src/sync/para.rs
@@ -116,8 +116,8 @@ fn persisted_validation_data<'a, E: nom::error::ParseError<&'a [u8]>>(
         nom::sequence::tuple((
             crate::util::nom_bytes_decode,
             crate::util::nom_varsize_number_decode_u64(block_number_bytes),
-            nom::bytes::complete::take(32u32),
-            nom::number::complete::le_u32,
+            nom::bytes::streaming::take(32u32),
+            nom::number::streaming::le_u32,
         )),
         |(parent_head, relay_parent_number, relay_parent_storage_root, max_pov_size)| {
             PersistedValidationDataRef {

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -761,12 +761,12 @@ fn transaction_validity(
         "transaction validity",
         nom::branch::alt((
             nom::combinator::map(
-                nom::sequence::preceded(nom::bytes::complete::tag(&[0]), valid_transaction),
+                nom::sequence::preceded(nom::bytes::streaming::tag(&[0]), valid_transaction),
                 Ok,
             ),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[1]),
+                    nom::bytes::streaming::tag(&[1]),
                     transaction_validity_error,
                 ),
                 Err,
@@ -780,10 +780,10 @@ fn valid_transaction(bytes: &[u8]) -> nom::IResult<&[u8], ValidTransaction> {
         "valid transaction",
         nom::combinator::map(
             nom::sequence::tuple((
-                nom::number::complete::le_u64,
+                nom::number::streaming::le_u64,
                 tags,
                 tags,
-                nom::combinator::map_opt(nom::number::complete::le_u64, NonZeroU64::new),
+                nom::combinator::map_opt(nom::number::streaming::le_u64, NonZeroU64::new),
                 util::nom_bool_decode,
             )),
             |(priority, requires, provides, longevity, propagate)| ValidTransaction {
@@ -802,11 +802,11 @@ fn transaction_validity_error(bytes: &[u8]) -> nom::IResult<&[u8], TransactionVa
         "transaction validity error",
         nom::branch::alt((
             nom::combinator::map(
-                nom::sequence::preceded(nom::bytes::complete::tag(&[0]), invalid_transaction),
+                nom::sequence::preceded(nom::bytes::streaming::tag(&[0]), invalid_transaction),
                 TransactionValidityError::Invalid,
             ),
             nom::combinator::map(
-                nom::sequence::preceded(nom::bytes::complete::tag(&[1]), unknown_transaction),
+                nom::sequence::preceded(nom::bytes::streaming::tag(&[1]), unknown_transaction),
                 TransactionValidityError::Unknown,
             ),
         )),
@@ -817,38 +817,38 @@ fn invalid_transaction(bytes: &[u8]) -> nom::IResult<&[u8], InvalidTransaction> 
     nom::error::context(
         "invalid transaction",
         nom::branch::alt((
-            nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                 InvalidTransaction::Call
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| {
                 InvalidTransaction::Payment
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[2]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[2]), |_| {
                 InvalidTransaction::Future
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[3]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[3]), |_| {
                 InvalidTransaction::Stale
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[4]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[4]), |_| {
                 InvalidTransaction::BadProof
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[5]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[5]), |_| {
                 InvalidTransaction::AncientBirthBlock
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[6]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[6]), |_| {
                 InvalidTransaction::ExhaustsResources
             }),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[7]),
-                    nom::bytes::complete::take(1u32),
+                    nom::bytes::streaming::tag(&[7]),
+                    nom::bytes::streaming::take(1u32),
                 ),
                 |n: &[u8]| InvalidTransaction::Custom(n[0]),
             ),
-            nom::combinator::map(nom::bytes::complete::tag(&[8]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[8]), |_| {
                 InvalidTransaction::BadMandatory
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[9]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[9]), |_| {
                 InvalidTransaction::MandatoryDispatch
             }),
         )),
@@ -859,16 +859,16 @@ fn unknown_transaction(bytes: &[u8]) -> nom::IResult<&[u8], UnknownTransaction> 
     nom::error::context(
         "unknown transaction",
         nom::branch::alt((
-            nom::combinator::map(nom::bytes::complete::tag(&[0]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[0]), |_| {
                 UnknownTransaction::CannotLookup
             }),
-            nom::combinator::map(nom::bytes::complete::tag(&[1]), |_| {
+            nom::combinator::map(nom::bytes::streaming::tag(&[1]), |_| {
                 UnknownTransaction::NoUnsignedValidator
             }),
             nom::combinator::map(
                 nom::sequence::preceded(
-                    nom::bytes::complete::tag(&[2]),
-                    nom::bytes::complete::take(1u32),
+                    nom::bytes::streaming::tag(&[2]),
+                    nom::bytes::streaming::take(1u32),
                 ),
                 |n: &[u8]| UnknownTransaction::Custom(n[0]),
             ),

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -167,7 +167,7 @@ macro_rules! decode_scale_compact {
                 0b01 => {
                     if bytes.len() < 2 {
                         return Err(nom::Err::Incomplete(nom::Needed::Size(
-                            core::num::NonZeroUsize::new(2).unwrap(),
+                            core::num::NonZeroUsize::new(2 - bytes.len()).unwrap(),
                         )));
                     }
 
@@ -188,7 +188,7 @@ macro_rules! decode_scale_compact {
                 0b10 => {
                     if bytes.len() < 4 {
                         return Err(nom::Err::Incomplete(nom::Needed::Size(
-                            core::num::NonZeroUsize::new(4).unwrap(),
+                            core::num::NonZeroUsize::new(4 - bytes.len()).unwrap(),
                         )));
                     }
 
@@ -227,7 +227,7 @@ macro_rules! decode_scale_compact {
 
                     if bytes.len() < num_bytes + 1 {
                         return Err(nom::Err::Incomplete(nom::Needed::Size(
-                            core::num::NonZeroUsize::new(num_bytes + 1).unwrap(),
+                            core::num::NonZeroUsize::new(num_bytes + 1 - bytes.len()).unwrap(),
                         )));
                     }
 

--- a/lib/src/util/leb128.rs
+++ b/lib/src/util/leb128.rs
@@ -152,10 +152,7 @@ pub(crate) fn nom_leb128_u64<'a, E: nom::error::ParseError<&'a [u8]>>(
         }
     }
 
-    Err(nom::Err::Error(nom::error::make_error(
-        bytes,
-        nom::error::ErrorKind::Eof,
-    )))
+    Err(nom::Err::Incomplete(nom::Needed::Unknown))
 }
 
 // TODO: document all this below

--- a/lib/src/util/protobuf.rs
+++ b/lib/src/util/protobuf.rs
@@ -205,8 +205,8 @@ pub(crate) fn tag_value_skip_decode<'a, E: nom::error::ParseError<&'a [u8]>>(
     nom::combinator::flat_map(tag_decode, |(_, wire_ty)| {
         move |inner_bytes| match wire_ty {
             0 => nom::combinator::map(leb128::nom_leb128_u64, |_| ())(inner_bytes),
-            5 => nom::combinator::map(nom::bytes::complete::take(4u32), |_| ())(inner_bytes),
-            1 => nom::combinator::map(nom::bytes::complete::take(8u32), |_| ())(inner_bytes),
+            5 => nom::combinator::map(nom::bytes::streaming::take(4u32), |_| ())(inner_bytes),
+            1 => nom::combinator::map(nom::bytes::streaming::take(8u32), |_| ())(inner_bytes),
             2 => nom::combinator::map(nom::multi::length_data(leb128::nom_leb128_usize), |_| ())(
                 inner_bytes,
             ),

--- a/lib/src/verify/body_only.rs
+++ b/lib/src/verify/body_only.rs
@@ -775,7 +775,7 @@ fn check_check_inherents_output(output: &[u8]) -> Result<(), Error> {
                 num_elems,
                 num_elems,
                 nom::sequence::tuple((
-                    nom::combinator::map(nom::bytes::complete::take(8u8), |b| {
+                    nom::combinator::map(nom::bytes::streaming::take(8u8), |b| {
                         <[u8; 8]>::try_from(b).unwrap()
                     }),
                     crate::util::nom_bytes_decode,

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -880,12 +880,12 @@ pub(crate) fn connection_open_single_stream(connection_id: u32, initial_writable
 pub(crate) fn connection_open_multi_stream(connection_id: u32, handshake_ty: Vec<u8>) {
     let (_, (local_tls_certificate_sha256, remote_tls_certificate_sha256)) =
         nom::sequence::preceded(
-            nom::bytes::complete::tag::<_, _, nom::error::Error<&[u8]>>(&[0]),
+            nom::bytes::streaming::tag::<_, _, nom::error::Error<&[u8]>>(&[0]),
             nom::sequence::tuple((
-                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                     <&[u8; 32]>::try_from(b).unwrap()
                 }),
-                nom::combinator::map(nom::bytes::complete::take(32u32), |b| {
+                nom::combinator::map(nom::bytes::streaming::take(32u32), |b| {
                     <&[u8; 32]>::try_from(b).unwrap()
                 }),
             )),


### PR DESCRIPTION
In order to do https://github.com/smol-dot/smoldot/issues/918, I will need the help of a streaming parser.

While studying the difference between complete and streaming parsers, what strikes me is that a complete parser is exactly equivalent to `nom::combinator::complete(its_streaming_equivalent)`.
Because we don't know if we accidentally use a streaming parser somewhere, we already always use `nom::combinator::complete` everywhere as a safety thing. There is thus no drawback in switching everything to streaming parsers.

Switching everything to streaming parsers makes it less surprising. I actually don't really know why complete parsers are still a thing in `nom`.

The only slightly tricky conversions came from the fact that the APIs of the runtime version struct and that Wasm binaries and that seed phrases consist in a list of entries with no indication of the number of entries, and thus we have no way to differentiate "finished parsing" from "more data yet to come". This was solved by adding `nom::combinator::complete` in the appropriate location.
