### PR TITLE
Update smoldot-light-base to use read_write infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "lru",
  "no-std-net",
  "parking_lot",
+ "pin-project",
  "rand",
  "rand_chacha",
  "serde",

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -786,6 +786,20 @@ where
         }
     }
 
+    /// Returns `true` if [`MultiStreamConnectionTask::reset`] has been called in the past.
+    pub fn is_reset_called(&self) -> bool {
+        matches!(
+            self.connection,
+            MultiStreamConnectionTaskInner::ShutdownWaitingAck {
+                initiator: ShutdownInitiator::Api,
+                ..
+            } | MultiStreamConnectionTaskInner::ShutdownAcked {
+                initiator: ShutdownInitiator::Api,
+                ..
+            }
+        )
+    }
+
     /// Immediately destroys the substream with the given identifier.
     ///
     /// The given identifier is now considered invalid by the state machine.

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -30,6 +30,7 @@ itertools = "0.11.0"
 log = { version = "0.4.18", default-features = false }
 lru = { version = "0.11.0", default-features = false }
 no-std-net = { version = "0.6.0", default-features = false }
+pin-project = "1.1.2"
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.174", default-features = false, features = ["alloc", "derive"] }

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1059,6 +1059,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     "".into(),
                     tasks::single_stream_connection_task::<TPlat>(
                         connection,
+                        multiaddr.to_string(),
                         task.platform.clone(),
                         connection_id,
                         connection_task,
@@ -1099,6 +1100,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     "".into(),
                     tasks::webrtc_multi_stream_connection_task::<TPlat>(
                         connection,
+                        multiaddr.to_string(),
                         task.platform.clone(),
                         connection_id,
                         connection_task,

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -17,18 +17,14 @@
 
 use super::ToBackground;
 use crate::platform::{
-    address_parse, ConnectError, MultiStreamWebRtcConnection, PlatformRef, ReadBuffer,
-    SubstreamDirection,
+    address_parse, ConnectError, MultiStreamWebRtcConnection, PlatformRef, SubstreamDirection,
 };
 
-use alloc::vec::Vec;
-use core::{iter, mem, pin};
+use alloc::{boxed::Box, string::String};
+use core::{pin, time::Duration};
 use futures_lite::FutureExt as _;
-use futures_util::{future, FutureExt as _, StreamExt as _};
-use smoldot::{
-    libp2p::{collection::SubstreamFate, read_write::ReadWrite},
-    network::service,
-};
+use futures_util::{future, stream::FuturesUnordered, FutureExt as _, StreamExt as _};
+use smoldot::{libp2p::collection::SubstreamFate, network::service};
 
 /// Asynchronous task managing a specific connection, including the connection process and the
 /// processing of the connection after it's been open.
@@ -185,187 +181,146 @@ pub(super) async fn connection_task<TPlat: PlatformRef>(
 }
 
 /// Asynchronous task managing a specific single-stream connection after it's been open.
-// TODO: a lot of logging disappeared
 pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
-    mut connection: TPlat::Stream,
+    mut socket: TPlat::Stream,
+    address: String,
     platform: TPlat,
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<TPlat::Instant>,
-    coordinator_to_connection: async_channel::Receiver<
+    mut coordinator_to_connection: async_channel::Receiver<
         service::CoordinatorToConnection<TPlat::Instant>,
     >,
-    messages_tx: async_channel::Sender<ToBackground<TPlat>>,
+    connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
-    // We need to use `peek()` on this future later down this function.
-    let mut coordinator_to_connection = coordinator_to_connection.peekable();
+    let mut socket = pin::pin!(socket);
 
-    // `false` as long as the writing side of the connection is open.
-    let mut write_closed = false;
+    // Future that sends a message to the coordinator. Only one message is sent to the coordinator
+    // at a time. `None` if no message is being sent.
+    let mut message_sending = None;
 
-    // The main loop is as follows:
-    // - Update the state machine.
-    // - Wait until there's something to do.
-    // - Repeat.
     loop {
-        // Inject in the connection task the messages coming from the coordinator, if any.
-        loop {
-            let message = match coordinator_to_connection.next().now_or_never() {
-                Some(Some(msg)) => msg,
-                _ => break,
-            };
-            connection_task.inject_coordinator_message(message);
-        }
+        // Because only one message should be sent to the coordinator at a time, and that
+        // processing the socket might generate a message, we only process the socket if no
+        // message is currently being sent.
+        if message_sending.is_none() {
+            if let Ok(mut socket_read_write) = platform.read_write_access(socket.as_mut()) {
+                let read_bytes_before = socket_read_write.read_bytes;
+                let written_bytes_before = socket_read_write.write_bytes_queued;
+                let write_closed = socket_read_write.write_bytes_queueable.is_none();
 
-        let now = platform.now();
+                connection_task.read_write(&mut *socket_read_write);
 
-        let (read_bytes, written_bytes, wake_up_after) = if !connection_task.is_reset_called() {
-            let write_bytes_queueable = if !write_closed {
-                Some(platform.writable_bytes(&mut connection))
+                if socket_read_write.read_bytes != read_bytes_before
+                    || socket_read_write.write_bytes_queued != written_bytes_before
+                    || (!write_closed && socket_read_write.write_bytes_queueable.is_none())
+                {
+                    log::trace!(target: "connections",
+                        "Connection({address}) <=> read={}; written={}; wake_up_after={:?}; write_close={:?}",
+                        socket_read_write.read_bytes - read_bytes_before,
+                        socket_read_write.write_bytes_queued - written_bytes_before,
+                        socket_read_write.wake_up_after.as_ref().map(|w| {
+                            if *w > socket_read_write.now {
+                                w.clone() - socket_read_write.now.clone()
+                            } else {
+                                Duration::new(0, 0)
+                            }
+                        }),
+                        socket_read_write.write_bytes_queueable.is_none(),
+                    );
+                }
             } else {
-                None
-            };
-
-            let incoming_buffer = match platform.read_buffer(&mut connection) {
-                ReadBuffer::Reset => {
+                // Error on the socket.
+                if !connection_task.is_reset_called() {
+                    log::trace!(target: "connections", "Connection({address}) => Reset");
                     connection_task.reset();
-                    continue;
                 }
-                ReadBuffer::Open(b) => Some(b),
-                ReadBuffer::Closed => None,
-            };
-
-            // Perform a read-write. This updates the internal state of the connection task.
-            let mut read_write = ReadWrite {
-                now: now.clone(),
-                incoming_buffer: incoming_buffer.map(|b| b.to_vec()).unwrap_or_else(Vec::new), // TODO: extra copy
-                read_bytes: 0,
-                expected_incoming_bytes: if incoming_buffer.is_some() {
-                    Some(0)
-                } else {
-                    None
-                },
-                write_buffers: Vec::new(),
-                write_bytes_queued: 0,
-                write_bytes_queueable,
-                wake_up_after: None,
-            };
-            connection_task.read_write(&mut read_write);
-
-            // Because the `read_write` object borrows the connection, we need to drop it before we
-            // can modify the connection. Before dropping the `read_write`, clone some important
-            // information from it.
-            let read_bytes = read_write.read_bytes;
-            debug_assert!(read_bytes <= incoming_buffer.as_ref().map_or(0, |b| b.len()));
-            let write_size_closed = !write_closed && read_write.write_bytes_queueable.is_none();
-            let write_bytes_queued = read_write.write_bytes_queued;
-            let write_buffers = mem::take(&mut read_write.write_buffers);
-            debug_assert!(write_bytes_queued <= write_bytes_queueable.unwrap_or(0));
-            let wake_up_after = read_write.wake_up_after.clone();
-            drop(read_write);
-
-            // Now update the connection.
-            for buffer in write_buffers {
-                platform.send(&mut connection, &buffer);
             }
-            if write_size_closed {
-                platform.close_send(&mut connection);
-                debug_assert!(!write_closed);
-                write_closed = true;
-            }
-            platform.advance_read_cursor(&mut connection, read_bytes);
 
-            (read_bytes, write_bytes_queued, wake_up_after)
-        } else {
-            (0, 0, None)
-        };
+            // Try pull message to send to the coordinator.
 
-        // Try pull message to send to the coordinator.
-
-        // Calling this method takes ownership of the task and returns that task if it has
-        // more work to do. If `None` is returned, then the entire task is gone and the
-        // connection must be abruptly closed, which is what happens when we return from
-        // this function.
-        let (mut task_update, message) = connection_task.pull_message_to_coordinator();
-
-        let has_message = message.is_some();
-        if let Some(message) = message {
-            // Sending this message might take a long time (in case the coordinator is busy),
-            // but this is intentional and serves as a back-pressure mechanism.
-            // However, it is important to continue processing the messages coming from the
-            // coordinator, otherwise this could result in a deadlock.
-            let process_in = async {
-                loop {
-                    if let Some(message) = coordinator_to_connection.next().await {
-                        if let Some(task_update) = &mut task_update {
-                            task_update.inject_coordinator_message(message);
-                        }
-                    } else {
-                        break Err(());
-                    }
+            // Calling this method takes ownership of the task and returns that task if it has
+            // more work to do. If `None` is returned, then the entire task is gone and the
+            // connection must be abruptly closed, which is what happens when we return from
+            // this function.
+            let (task_update, message) = connection_task.pull_message_to_coordinator();
+            if let Some(task_update) = task_update {
+                connection_task = task_update;
+                debug_assert!(message_sending.is_none());
+                if let Some(message) = message {
+                    message_sending = Some(connection_to_coordinator.send(
+                        super::ToBackground::ConnectionMessage {
+                            connection_id,
+                            message,
+                        },
+                    ));
                 }
-            };
-
-            let send_out = async {
-                messages_tx
-                    .send(ToBackground::ConnectionMessage {
-                        connection_id,
-                        message,
-                    })
-                    .await
-                    .map_err(|_| ())
-            };
-
-            if send_out.or(process_in).await.is_err() {
+            } else {
                 return;
             }
         }
 
-        if let Some(task_update) = task_update {
-            connection_task = task_update;
-        } else {
-            // As documented in `update_stream`, we call this function one last time in order to
-            // give the possibility to the implementation to process closing the writing side
-            // before the connection is dropped.
-            platform.update_stream(&mut connection).await;
-            return;
+        // Now wait for something interesting to happen before looping again.
+
+        enum WhatHappened<TPlat: PlatformRef> {
+            CoordinatorMessage(service::CoordinatorToConnection<TPlat::Instant>),
+            CoordinatorDead,
+            SocketEvent,
+            MessageSent,
         }
 
-        // We must call `read_write` and `pull_message_to_coordinator` repeatedly until nothing
-        // happens anymore.
-        if has_message || read_bytes != 0 || written_bytes != 0 {
-            continue;
-        }
+        let what_happened: WhatHappened<TPlat> = {
+            let coordinator_message = async {
+                match coordinator_to_connection.next().await {
+                    Some(msg) => WhatHappened::CoordinatorMessage(msg),
+                    None => WhatHappened::CoordinatorDead,
+                }
+            };
 
-        // Starting from here, we block the current task until more processing needs to happen.
+            let socket_event = {
+                // The future returned by `wait_read_write_again` yields when `read_write_access`
+                // must be called. Because we only call `read_write_access` when `message_sending`
+                // is `None`, we also call `wait_read_write_again` only when `message_sending` is
+                // `None`.
+                let fut = if message_sending.is_none() {
+                    Some(platform.wait_read_write_again(socket.as_mut()))
+                } else {
+                    None
+                };
+                async {
+                    if let Some(fut) = fut {
+                        fut.await;
+                        WhatHappened::SocketEvent
+                    } else {
+                        future::pending().await
+                    }
+                }
+            };
 
-        // Future ready when the timeout indicated by the connection state machine is reached.
-        let poll_after = if wake_up_after
-            .as_ref()
-            .map_or(false, |wake_up_after| *wake_up_after <= now)
-        {
-            // "Wake up" immediately.
-            continue;
-        } else {
-            async {
-                if let Some(wake_up_after) = wake_up_after {
-                    platform.sleep_until(wake_up_after).await
+            let message_sent = async {
+                let result = if let Some(message_sending) = message_sending.as_mut() {
+                    message_sending.await
                 } else {
                     future::pending().await
+                };
+                message_sending = None;
+                if result.is_ok() {
+                    WhatHappened::MessageSent
+                } else {
+                    WhatHappened::CoordinatorDead
                 }
-            }
-        };
-        // Future that is woken up when new data is ready on the socket or more data is writable.
-        let stream_update = platform.update_stream(&mut connection);
-        // Future that is woken up when a new message is coming from the coordinator.
-        let message_from_coordinator = async {
-            pin::Pin::new(&mut coordinator_to_connection).peek().await;
+            };
+
+            coordinator_message.or(socket_event).or(message_sent).await
         };
 
-        // Combines the three futures above into one.
-        stream_update
-            .or(message_from_coordinator)
-            .or(poll_after)
-            .await;
+        match what_happened {
+            WhatHappened::CoordinatorMessage(message) => {
+                connection_task.inject_coordinator_message(message);
+            }
+            WhatHappened::CoordinatorDead => return,
+            WhatHappened::SocketEvent => {}
+            WhatHappened::MessageSent => {}
+        }
     }
 }
 
@@ -375,31 +330,30 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
 /// >           and writing sides of substreams never close, and adjusts the size of the write
 /// >           buffer to not go over the frame size limit of WebRTC. It can easily be made more
 /// >           general-purpose.
-// TODO: a lot of logging disappeared
 pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     mut connection: TPlat::MultiStream,
+    address: String,
     platform: TPlat,
     connection_id: service::ConnectionId,
     mut connection_task: service::MultiStreamConnectionTask<TPlat::Instant, usize>,
-    coordinator_to_connection: async_channel::Receiver<
+    mut coordinator_to_connection: async_channel::Receiver<
         service::CoordinatorToConnection<TPlat::Instant>,
     >,
-    messages_tx: async_channel::Sender<ToBackground<TPlat>>,
+    connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
-    // We need to use `peek()` on this future later down this function.
-    let mut coordinator_to_connection = coordinator_to_connection.peekable();
-
+    // Future that sends a message to the coordinator. Only one message is sent to the coordinator
+    // at a time. `None` if no message is being sent.
+    let mut message_sending = None;
     // Number of substreams that are currently being opened by the `PlatformRef` implementation
     // and that the `connection_task` state machine isn't aware of yet.
     let mut pending_opening_out_substreams = 0;
-    // Newly-open substream that has just been yielded by the connection.
-    let mut newly_open_substream = None;
-    // `true` if the remote has force-closed our connection.
-    let mut remote_has_reset = false;
-    // List of all currently open substreams. The index (as a `usize`) corresponds to the id
-    // of this substream within the `connection_task` state machine.
-    // For each stream, a boolean indicates whether the local writing side is closed.
-    let mut open_substreams = slab::Slab::<(TPlat::Stream, bool)>::with_capacity(16);
+    // Stream that yields an item whenever a substream is ready to be read-written.
+    // TODO: we box the future because of the type checker being annoying
+    let mut when_substreams_rw_ready = FuturesUnordered::<
+        pin::Pin<Box<dyn future::Future<Output = (pin::Pin<Box<TPlat::Stream>>, usize)> + Send>>,
+    >::new();
+    // Identifier to assign to the next substream.
+    let mut next_substream_id = 0; // TODO: weird API
 
     loop {
         // Start opening new outbound substreams, if needed.
@@ -411,224 +365,180 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
             pending_opening_out_substreams += 1;
         }
 
-        // The previous wait might have ended when the connection has finished opening a new
-        // substream. Notify the `connection_task` state machine.
-        if let Some((stream, direction)) = newly_open_substream.take() {
-            let outbound = match direction {
-                SubstreamDirection::Outbound => true,
-                SubstreamDirection::Inbound => false,
-            };
-            let id = open_substreams.insert((stream, true));
-            connection_task.add_substream(id, outbound);
-            if outbound {
-                pending_opening_out_substreams -= 1;
-            }
+        // Now wait for something interesting to happen before looping again.
+
+        enum WhatHappened<TPlat: PlatformRef> {
+            CoordinatorMessage(service::CoordinatorToConnection<TPlat::Instant>),
+            CoordinatorDead,
+            SocketEvent(pin::Pin<Box<TPlat::Stream>>, usize),
+            MessageSent,
+            NewSubstream(TPlat::Stream, SubstreamDirection),
+            ConnectionReset,
         }
 
-        // Inject in the connection task the messages coming from the coordinator, if any.
-        loop {
-            let message = match coordinator_to_connection.next().now_or_never() {
-                Some(Some(msg)) => msg,
-                _ => break,
+        let what_happened: WhatHappened<TPlat> = {
+            let coordinator_message = async {
+                match coordinator_to_connection.next().await {
+                    Some(msg) => WhatHappened::CoordinatorMessage(msg),
+                    None => WhatHappened::CoordinatorDead,
+                }
             };
-            connection_task.inject_coordinator_message(message);
-        }
 
-        let now = platform.now();
-
-        // When reading/writing substreams, the substream can ask to be woken up after a certain
-        // time. This variable stores the earliest time when we should be waking up.
-        let mut wake_up_after = None;
-
-        // Perform a read-write on all substreams.
-        // TODO: trying to read/write every single substream every single time is suboptimal, but making this not suboptimal is very complicated
-        for substream_id in open_substreams.iter().map(|(id, _)| id).collect::<Vec<_>>() {
-            loop {
-                let (substream, write_side_was_open) = &mut open_substreams[substream_id];
-
-                let write_bytes_queueable = if !*write_side_was_open {
-                    Some(platform.writable_bytes(substream))
+            let socket_event = {
+                // The future returned by `wait_read_write_again` yields when `read_write_access`
+                // must be called. Because we only call `read_write_access` when `message_sending`
+                // is `None`, we also call `wait_read_write_again` only when `message_sending` is
+                // `None`.
+                let fut = if message_sending.is_none() {
+                    Some(when_substreams_rw_ready.select_next_some())
                 } else {
                     None
                 };
-
-                let incoming_buffer = match platform.read_buffer(substream) {
-                    ReadBuffer::Open(buf) => buf,
-                    ReadBuffer::Closed => panic!(), // Forbidden for WebRTC.
-                    ReadBuffer::Reset => {
-                        // Inform the connection task. The substream is now considered dead.
-                        connection_task.reset_substream(&substream_id);
-                        open_substreams.remove(substream_id);
-                        break;
+                async move {
+                    if let Some(fut) = fut {
+                        let (stream, substream_id) = fut.await;
+                        WhatHappened::SocketEvent(stream, substream_id)
+                    } else {
+                        future::pending().await
                     }
-                };
-
-                let mut read_write = ReadWrite {
-                    now: now.clone(),
-                    incoming_buffer: incoming_buffer.to_vec(), // TODO: extra copy
-                    read_bytes: 0,
-                    expected_incoming_bytes: Some(0),
-                    write_buffers: Vec::new(),
-                    write_bytes_queued: 0,
-                    write_bytes_queueable,
-                    wake_up_after,
-                };
-
-                debug_assert!(read_write.write_bytes_queueable.is_some());
-
-                let substream_fate =
-                    connection_task.substream_read_write(&substream_id, &mut read_write);
-
-                // Because the `read_write` object borrows the stream, we need to drop it before we
-                // can modify the connection. Before dropping the `read_write`, clone some important
-                // information from it.
-                let read_bytes = read_write.read_bytes;
-                debug_assert!(read_bytes <= incoming_buffer.len());
-                let written_bytes = read_write.write_bytes_queued;
-                let write_buffers = mem::take(&mut read_write.write_buffers);
-                let must_close_writing_side =
-                    *write_side_was_open && read_write.write_bytes_queueable.is_none();
-                wake_up_after = read_write.wake_up_after.take();
-                drop(read_write);
-
-                // Now update the connection.
-                for buffer in write_buffers {
-                    platform.send(substream, &buffer);
                 }
-                if must_close_writing_side {
-                    platform.close_send(substream);
-                    *write_side_was_open = false;
-                }
-                platform.advance_read_cursor(substream, read_bytes);
+            };
 
-                // If the `connection_task` requires this substream to be killed, we drop the
-                // `Stream` object.
-                if matches!(substream_fate, SubstreamFate::Reset) {
-                    open_substreams.remove(substream_id);
-                    break;
-                }
-
-                if read_bytes == 0 && written_bytes == 0 {
-                    break;
-                }
-            }
-        }
-
-        // Try pull message to send to the coordinator.
-        {
-            // Calling this method takes ownership of the task and returns that task if it has
-            // more work to do. If `None` is returned, then the entire task is gone and the
-            // connection must be abruptly closed, which is what happens when we return from
-            // this function.
-            let (mut task_update, message) = connection_task.pull_message_to_coordinator();
-
-            let has_message = message.is_some();
-            if let Some(message) = message {
-                // Sending this message might take a long time (in case the coordinator is busy),
-                // but this is intentional and serves as a back-pressure mechanism.
-                // However, it is important to continue processing the messages coming from the
-                // coordinator, otherwise this could result in a deadlock.
-                let process_in = async {
-                    loop {
-                        if let Some(message) = coordinator_to_connection.next().await {
-                            if let Some(task_update) = &mut task_update {
-                                task_update.inject_coordinator_message(message);
-                            }
-                        } else {
-                            break Err(());
-                        }
-                    }
-                };
-
-                let send_out = async {
-                    messages_tx
-                        .send(ToBackground::ConnectionMessage {
-                            connection_id,
-                            message,
-                        })
-                        .await
-                        .map_err(|_| ())
-                };
-
-                if send_out.or(process_in).await.is_err() {
-                    return;
-                }
-            }
-
-            if let Some(task_update) = task_update {
-                connection_task = task_update;
-            } else {
-                return;
-            }
-
-            if has_message {
-                continue;
-            }
-        }
-
-        // Starting from here, we block the current task until more processing needs to happen.
-
-        // Future ready when the timeout indicated by the connection state machine is reached.
-        let poll_after = if wake_up_after
-            .as_ref()
-            .map_or(false, |wake_up_after| *wake_up_after <= now)
-        {
-            // "Wake up" immediately.
-            continue;
-        } else {
-            async {
-                if let Some(wake_up_after) = wake_up_after {
-                    platform.sleep_until(wake_up_after).await
+            let message_sent = async {
+                let result: Result<(), _> = if let Some(message_sending) = message_sending.as_mut()
+                {
+                    message_sending.await
                 } else {
                     future::pending().await
+                };
+                message_sending = None;
+                if result.is_ok() {
+                    WhatHappened::MessageSent
+                } else {
+                    WhatHappened::CoordinatorDead
                 }
-                None
+            };
+
+            // Future that is woken up when a new substream is available.
+            let next_substream = async {
+                if connection_task.is_reset_called() {
+                    future::pending().await
+                } else {
+                    match platform.next_substream(&mut connection).await {
+                        Some((stream, direction)) => WhatHappened::NewSubstream(stream, direction),
+                        None => WhatHappened::ConnectionReset,
+                    }
+                }
+            };
+
+            coordinator_message
+                .or(socket_event)
+                .or(message_sent)
+                .or(next_substream)
+                .await
+        };
+
+        match what_happened {
+            WhatHappened::CoordinatorMessage(message) => {
+                connection_task.inject_coordinator_message(message);
             }
-        };
+            WhatHappened::CoordinatorDead => return,
+            WhatHappened::SocketEvent(mut socket, substream_id) => {
+                debug_assert!(message_sending.is_none());
 
-        // Future that is woken up when new data is ready on any of the streams.
-        let streams_updated = {
-            let list =
-                iter::once(future::Either::Right(future::pending()))
-                    .chain(open_substreams.iter_mut().map(|(_, (stream, _))| {
-                        future::Either::Left(platform.update_stream(stream))
-                    }))
-                    .collect::<future::SelectAll<_>>();
-            async move {
-                list.await;
-                None
+                let substream_fate = if let Ok(mut socket_read_write) =
+                    platform.read_write_access(socket.as_mut())
+                {
+                    let read_bytes_before = socket_read_write.read_bytes;
+                    let written_bytes_before = socket_read_write.write_bytes_queued;
+                    let write_closed = socket_read_write.write_bytes_queueable.is_none();
+
+                    let substream_fate = connection_task
+                        .substream_read_write(&substream_id, &mut *socket_read_write);
+
+                    if socket_read_write.read_bytes != read_bytes_before
+                        || socket_read_write.write_bytes_queued != written_bytes_before
+                        || (!write_closed && socket_read_write.write_bytes_queueable.is_none())
+                    {
+                        log::trace!(target: "connections",
+                            "Connection({address}) <=> substream_id={substream_id}; read={}; written={}; wake_up_after={:?}; write_close={:?}; fate={substream_fate:?}",
+                            socket_read_write.read_bytes - read_bytes_before,
+                            socket_read_write.write_bytes_queued - written_bytes_before,
+                            socket_read_write.wake_up_after.as_ref().map(|w| {
+                                if *w > socket_read_write.now {
+                                    w.clone() - socket_read_write.now.clone()
+                                } else {
+                                    Duration::new(0, 0)
+                                }
+                            }),
+                            socket_read_write.write_bytes_queueable.is_none(),
+                        );
+                    }
+
+                    substream_fate
+                } else {
+                    // Error on the socket.
+                    if !connection_task.is_reset_called() {
+                        log::trace!(target: "connections", "Connection({address}) => SubstreamReset(substream_id={substream_id})");
+                        connection_task.reset();
+                    }
+                    SubstreamFate::Reset
+                };
+
+                // Try pull message to send to the coordinator.
+
+                // Calling this method takes ownership of the task and returns that task if it has
+                // more work to do. If `None` is returned, then the entire task is gone and the
+                // connection must be abruptly closed, which is what happens when we return from
+                // this function.
+                let (task_update, message) = connection_task.pull_message_to_coordinator();
+                if let Some(task_update) = task_update {
+                    connection_task = task_update;
+                    debug_assert!(message_sending.is_none());
+                    if let Some(message) = message {
+                        message_sending = Some(connection_to_coordinator.send(
+                            super::ToBackground::ConnectionMessage {
+                                connection_id,
+                                message,
+                            },
+                        ));
+                    }
+                } else {
+                    return;
+                }
+
+                // Put back the stream in `when_substreams_rw_ready`.
+                if let SubstreamFate::Continue = substream_fate {
+                    when_substreams_rw_ready.push({
+                        let platform = platform.clone();
+                        Box::pin(async move {
+                            platform.wait_read_write_again(socket.as_mut());
+                            (socket, substream_id)
+                        })
+                    });
+                }
             }
-        };
-
-        // Future that is woken up when a new message is coming from the coordinator.
-        let message_from_coordinator = async {
-            pin::Pin::new(&mut coordinator_to_connection).peek().await;
-            None
-        };
-
-        // Future that is woken up when a new substream is available.
-        let next_substream = async {
-            if remote_has_reset {
-                future::pending().await
-            } else {
-                Some(platform.next_substream(&mut connection).await)
-            }
-        };
-
-        // Do the actual waiting.
-        debug_assert!(newly_open_substream.is_none());
-        match poll_after
-            .or(message_from_coordinator)
-            .or(streams_updated)
-            .or(next_substream)
-            .await
-        {
-            None => {}
-            Some(Some(s)) => newly_open_substream = Some(s),
-            Some(None) => {
-                // `None` is returned if the remote has force-closed the connection.
+            WhatHappened::MessageSent => {}
+            WhatHappened::ConnectionReset => {
+                debug_assert!(!connection_task.is_reset_called());
+                log::trace!(target: "connections", "Connection({address}) => Reset");
                 connection_task.reset();
-                remote_has_reset = true;
+            }
+            WhatHappened::NewSubstream(substream, direction) => {
+                log::trace!(target: "connections", "Connection({address}) => NewSubstream({direction:?})");
+                let outbound = match direction {
+                    SubstreamDirection::Outbound => true,
+                    SubstreamDirection::Inbound => false,
+                };
+                let substream_id = next_substream_id;
+                next_substream_id += 1;
+                connection_task.add_substream(substream_id, outbound);
+                if outbound {
+                    pending_opening_out_substreams -= 1;
+                }
+
+                when_substreams_rw_ready
+                    .push(Box::pin(async move { (Box::pin(substream), substream_id) }));
             }
         }
     }

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -396,19 +396,3 @@ pub struct ConnectError {
     /// Human-readable error message.
     pub message: String,
 }
-
-/// State of the read buffer, as returned by [`PlatformRef::read_buffer`].
-#[derive(Debug)]
-pub enum ReadBuffer<'a> {
-    /// Reading side of the stream is fully open. Contains the data waiting to be processed.
-    Open(&'a [u8]),
-
-    /// The reading side of the stream has been closed by the remote.
-    ///
-    /// Note that this is forbidden for connections of
-    /// type [`MultiStreamAddress::WebRtc`].
-    Closed,
-
-    /// The stream has been abruptly closed by the remote.
-    Reset,
-}

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -19,15 +19,15 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use super::{
-    Address, ConnectError, ConnectionType, IpAddr, MultiStreamAddress, MultiStreamWebRtcConnection,
-    PlatformRef, ReadBuffer, SubstreamDirection,
+    with_buffers, Address, ConnectError, ConnectionType, IpAddr, MultiStreamAddress,
+    MultiStreamWebRtcConnection, PlatformRef, SubstreamDirection,
 };
 
-use alloc::{borrow::Cow, collections::VecDeque, sync::Arc};
-use core::{ops, pin::Pin, str, task::Poll, time::Duration};
-use futures_util::{future, AsyncRead, AsyncWrite, FutureExt as _};
+use alloc::{borrow::Cow, sync::Arc};
+use core::{pin::Pin, str, time::Duration};
+use futures_util::{future, FutureExt as _};
 use smoldot::libp2p::websocket;
-use std::{io::IoSlice, net::SocketAddr};
+use std::{io, net::SocketAddr};
 
 /// Implementation of the [`PlatformRef`] trait that leverages the operating system.
 pub struct DefaultPlatform {
@@ -54,7 +54,9 @@ impl PlatformRef for Arc<DefaultPlatform> {
         'static,
         Result<MultiStreamWebRtcConnection<Self::MultiStream>, ConnectError>,
     >;
+    type ReadWriteAccess<'a> = with_buffers::ReadWriteAccess<'a>;
     type StreamUpdateFuture<'a> = future::BoxFuture<'a, ()>;
+    type StreamErrorRef<'a> = &'a io::Error;
     type NextSubstreamFuture<'a> = future::Pending<Option<(Self::Stream, SubstreamDirection)>>;
 
     fn now_from_unix_epoch(&self) -> Duration {
@@ -183,20 +185,7 @@ impl PlatformRef for Arc<DefaultPlatform> {
                 }
             };
 
-            Ok(Stream {
-                socket,
-                buffers: Some((
-                    StreamReadBuffer::Open {
-                        buffer: vec![0; 16384],
-                        cursor: 0..0,
-                    },
-                    StreamWriteBuffer::Open {
-                        buffer: VecDeque::with_capacity(16384),
-                        must_close: false,
-                        must_flush: false,
-                    },
-                )),
-            })
+            Ok(Stream(with_buffers::WithBuffers::new(socket)))
         })
     }
 
@@ -216,215 +205,27 @@ impl PlatformRef for Arc<DefaultPlatform> {
         match *c {}
     }
 
-    fn update_stream<'a>(&self, stream: &'a mut Self::Stream) -> Self::StreamUpdateFuture<'a> {
-        Box::pin(future::poll_fn(|cx| {
-            let Some((read_buffer, write_buffer)) = stream.buffers.as_mut() else {
-                return Poll::Pending;
-            };
+    fn read_write_access<'a>(
+        &self,
+        stream: Pin<&'a mut Self::Stream>,
+    ) -> Result<Self::ReadWriteAccess<'a>, &'a io::Error> {
+        let stream = stream.project();
+        stream.0.read_write_access(std::time::Instant::now())
+    }
 
-            // Whether the future returned by `update_stream` should return `Ready` or `Pending`.
-            let mut update_stream_future_ready = false;
-
-            if let StreamReadBuffer::Open {
-                buffer: ref mut buf,
-                ref mut cursor,
-            } = read_buffer
-            {
-                // When reading data from the socket, `poll_read` might return "EOF". In that
-                // situation, we transition to the `Closed` state, which would discard the data
-                // currently in the buffer. For this reason, we only try to read if there is no
-                // data left in the buffer.
-                if cursor.start == cursor.end {
-                    if let Poll::Ready(result) = Pin::new(&mut stream.socket).poll_read(cx, buf) {
-                        update_stream_future_ready = true;
-                        match result {
-                            Err(_) => {
-                                // End the stream.
-                                stream.buffers = None;
-                                return Poll::Ready(());
-                            }
-                            Ok(0) => {
-                                // EOF.
-                                *read_buffer = StreamReadBuffer::Closed;
-                            }
-                            Ok(bytes) => {
-                                *cursor = 0..bytes;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let StreamWriteBuffer::Open {
-                buffer: ref mut buf,
-                must_flush,
-                must_close,
-            } = write_buffer
-            {
-                while !buf.is_empty() {
-                    let write_queue_slices = buf.as_slices();
-                    if let Poll::Ready(result) = Pin::new(&mut stream.socket).poll_write_vectored(
-                        cx,
-                        &[
-                            IoSlice::new(write_queue_slices.0),
-                            IoSlice::new(write_queue_slices.1),
-                        ],
-                    ) {
-                        if !*must_close {
-                            // In the situation where the API user wants to close the writing
-                            // side, simply sending the buffered data isn't enough to justify
-                            // making the future ready.
-                            update_stream_future_ready = true;
-                        }
-
-                        match result {
-                            Err(_) => {
-                                // End the stream.
-                                stream.buffers = None;
-                                return Poll::Ready(());
-                            }
-                            Ok(bytes) => {
-                                *must_flush = true;
-                                for _ in 0..bytes {
-                                    buf.pop_front();
-                                }
-                            }
-                        }
-                    } else {
-                        break;
-                    }
-                }
-
-                if buf.is_empty() && *must_close {
-                    if let Poll::Ready(result) = Pin::new(&mut stream.socket).poll_close(cx) {
-                        update_stream_future_ready = true;
-                        match result {
-                            Err(_) => {
-                                // End the stream.
-                                stream.buffers = None;
-                                return Poll::Ready(());
-                            }
-                            Ok(()) => {
-                                *write_buffer = StreamWriteBuffer::Closed;
-                            }
-                        }
-                    }
-                } else if *must_flush {
-                    if let Poll::Ready(result) = Pin::new(&mut stream.socket).poll_flush(cx) {
-                        update_stream_future_ready = true;
-                        match result {
-                            Err(_) => {
-                                // End the stream.
-                                stream.buffers = None;
-                                return Poll::Ready(());
-                            }
-                            Ok(()) => {
-                                *must_flush = false;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if update_stream_future_ready {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
+    fn wait_read_write_again<'a>(
+        &self,
+        stream: Pin<&'a mut Self::Stream>,
+    ) -> Self::StreamUpdateFuture<'a> {
+        let stream = stream.project();
+        Box::pin(stream.0.wait_read_write_again(|when| async move {
+            smol::Timer::at(when).await;
         }))
-    }
-
-    fn read_buffer<'a>(&self, stream: &'a mut Self::Stream) -> ReadBuffer<'a> {
-        match stream.buffers.as_ref().map(|(r, _)| r) {
-            None => ReadBuffer::Reset,
-            Some(StreamReadBuffer::Closed) => ReadBuffer::Closed,
-            Some(StreamReadBuffer::Open { buffer, cursor }) => {
-                ReadBuffer::Open(&buffer[cursor.clone()])
-            }
-        }
-    }
-
-    fn advance_read_cursor(&self, stream: &mut Self::Stream, extra_bytes: usize) {
-        let Some(StreamReadBuffer::Open { ref mut cursor, .. }) =
-            stream.buffers.as_mut().map(|(r, _)| r)
-        else {
-            assert_eq!(extra_bytes, 0);
-            return;
-        };
-
-        assert!(cursor.start + extra_bytes <= cursor.end);
-        cursor.start += extra_bytes;
-    }
-
-    fn writable_bytes(&self, stream: &mut Self::Stream) -> usize {
-        let Some(StreamWriteBuffer::Open {
-            ref mut buffer,
-            must_close: false,
-            ..
-        }) = stream.buffers.as_mut().map(|(_, w)| w)
-        else {
-            return 0;
-        };
-        buffer.capacity() - buffer.len()
-    }
-
-    fn send(&self, stream: &mut Self::Stream, data: &[u8]) {
-        debug_assert!(!data.is_empty());
-
-        // Because `writable_bytes` returns 0 if the writing side is closed, and because `data`
-        // must always have a size inferior or equal to `writable_bytes`, we know for sure that
-        // the writing side isn't closed.
-        let Some(StreamWriteBuffer::Open { ref mut buffer, .. }) =
-            stream.buffers.as_mut().map(|(_, w)| w)
-        else {
-            panic!()
-        };
-        buffer.reserve(data.len());
-        buffer.extend(data.iter().copied());
-    }
-
-    fn close_send(&self, stream: &mut Self::Stream) {
-        // It is not illegal to call this on an already-reset stream.
-        let Some((_, write_buffer)) = stream.buffers.as_mut() else {
-            return;
-        };
-
-        match write_buffer {
-            StreamWriteBuffer::Open {
-                must_close: must_close @ false,
-                ..
-            } => *must_close = true,
-            _ => {
-                // However, it is illegal to call this on a stream that was already close
-                // attempted.
-                panic!()
-            }
-        }
     }
 }
 
 /// Implementation detail of [`DefaultPlatform`].
-pub struct Stream {
-    socket: TcpOrWs,
-    /// Read and write buffers of the connection, or `None` if the socket has been reset.
-    buffers: Option<(StreamReadBuffer, StreamWriteBuffer)>,
-}
-
-enum StreamReadBuffer {
-    Open {
-        buffer: Vec<u8>,
-        cursor: ops::Range<usize>,
-    },
-    Closed,
-}
-
-enum StreamWriteBuffer {
-    Open {
-        buffer: VecDeque<u8>,
-        must_flush: bool,
-        must_close: bool,
-    },
-    Closed,
-}
+#[pin_project::pin_project]
+pub struct Stream(#[pin] with_buffers::WithBuffers<TcpOrWs>);
 
 type TcpOrWs = future::Either<smol::net::TcpStream, websocket::Connection<smol::net::TcpStream>>;

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -17,13 +17,12 @@
 
 use crate::{bindings, timers::Delay};
 
-use smoldot_light::platform::{ConnectError, SubstreamDirection};
+use smoldot_light::platform::{read_write, ConnectError, SubstreamDirection};
 
-use core::{future, mem, pin, str, task, time::Duration};
+use core::{future, iter, mem, ops, pin, str, task, time::Duration};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, VecDeque},
-    iter,
     sync::{
         atomic::{AtomicU64, Ordering},
         Mutex,
@@ -51,6 +50,8 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     type Stream = StreamWrapper; // Entry in the ̀`STREAMS` map and a read buffer.
     type StreamConnectFuture =
         pin::Pin<Box<dyn future::Future<Output = Result<Self::Stream, ConnectError>> + Send>>;
+    type ReadWriteAccess<'a> = ReadWriteAccess<'a>;
+    type StreamErrorRef<'a> = String;
     type MultiStreamConnectFuture = pin::Pin<
         Box<
             dyn future::Future<
@@ -284,16 +285,10 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                 }
                 ConnectionInner::SingleStreamMsNoiseYamux => {
                     debug_assert!(lock.streams.contains_key(&(connection_id, None)));
-
-                    let read_buffer = ReadBuffer {
-                        buffer: Vec::new().into(),
-                        buffer_first_offset: 0,
-                    };
-
                     Ok(StreamWrapper {
                         connection_id,
                         stream_id: None,
-                        read_buffer,
+                        read_buffer: Vec::new(),
                         is_reset: false,
                         writable_bytes: 0,
                         write_closable,
@@ -458,10 +453,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                 StreamWrapper {
                     connection_id,
                     stream_id: Some(stream_id),
-                    read_buffer: ReadBuffer {
-                        buffer: Vec::<u8>::new().into(),
-                        buffer_first_offset: 0,
-                    },
+                    read_buffer: Vec::new(),
                     is_reset: false,
                     writable_bytes: usize::try_from(initial_writable_bytes).unwrap(),
                     write_closable: false, // Note: this is currently hardcoded for WebRTC.
@@ -491,50 +483,53 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         }
     }
 
-    fn update_stream<'a>(
+    fn wait_read_write_again<'a>(
         &self,
-        StreamWrapper {
-            connection_id,
-            stream_id,
-            read_buffer,
-            is_reset,
-            writable_bytes,
-            ..
-        }: &'a mut Self::Stream,
+        stream: pin::Pin<&'a mut Self::Stream>,
     ) -> Self::StreamUpdateFuture<'a> {
         Box::pin(async move {
-            loop {
-                if *is_reset {
-                    future::pending::<()>().await;
-                }
+            let stream = stream.get_mut();
 
+            if stream.is_reset {
+                future::pending::<()>().await;
+            }
+
+            loop {
                 let listener = {
                     let mut lock = STATE.try_lock().unwrap();
-                    let stream = lock.streams.get_mut(&(*connection_id, *stream_id)).unwrap();
+                    let stream_inner = lock
+                        .streams
+                        .get_mut(&(stream.connection_id, stream.stream_id))
+                        .unwrap();
 
-                    if stream.reset {
-                        *is_reset = true;
+                    if stream_inner.reset {
+                        stream.is_reset = true;
                         return;
                     }
 
                     let mut shall_return = false;
 
-                    // Move the next buffer from `STATE` into `read_buffer`.
-                    if read_buffer.buffer_first_offset == read_buffer.buffer.len() {
-                        if let Some(msg) = stream.messages_queue.pop_front() {
-                            stream.messages_queue_total_size -= msg.len();
-                            read_buffer.buffer = msg;
-                            read_buffer.buffer_first_offset = 0;
+                    // Move the buffers from `STATE` into `read_buffer`.
+                    if !stream_inner.messages_queue.is_empty() {
+                        stream
+                            .read_buffer
+                            .reserve(stream_inner.messages_queue_total_size);
+
+                        while let Some(msg) = stream_inner.messages_queue.pop_front() {
+                            // TODO: could be optimized by reworking the bindings
+                            stream.read_buffer.extend_from_slice(&msg);
                             shall_return = true;
                         }
+
+                        stream_inner.messages_queue_total_size = 0;
                     }
 
-                    if stream.writable_bytes_extra != 0 {
+                    if stream_inner.writable_bytes_extra != 0 {
                         // As documented, the number of writable bytes must never exceed the
                         // initial writable bytes value. As such, this can't overflow unless there
                         // is a bug on the JavaScript side.
-                        *writable_bytes += stream.writable_bytes_extra;
-                        stream.writable_bytes_extra = 0;
+                        stream.writable_bytes += stream_inner.writable_bytes_extra;
+                        stream_inner.writable_bytes_extra = 0;
                         shall_return = true;
                     }
 
@@ -542,7 +537,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                         return;
                     }
 
-                    stream.something_happened.listen()
+                    stream_inner.something_happened.listen()
                 };
 
                 listener.await
@@ -550,125 +545,104 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         })
     }
 
-    fn read_buffer<'a>(
+    fn read_write_access<'a>(
         &self,
-        StreamWrapper {
-            read_buffer,
-            is_reset,
-            ..
-        }: &'a mut Self::Stream,
-    ) -> smoldot_light::platform::ReadBuffer<'a> {
-        if *is_reset {
-            return smoldot_light::platform::ReadBuffer::Reset;
+        stream: pin::Pin<&'a mut Self::Stream>,
+    ) -> Result<Self::ReadWriteAccess<'a>, Self::StreamErrorRef<'a>> {
+        let stream = stream.get_mut();
+
+        if stream.is_reset {
+            todo!()
         }
 
-        // TODO: doesn't detect closed
-
-        smoldot_light::platform::ReadBuffer::Open(
-            &read_buffer.buffer[read_buffer.buffer_first_offset..],
-        )
+        Ok(ReadWriteAccess {
+            read_write: read_write::ReadWrite {
+                now: Instant::now(),
+                incoming_buffer: mem::take(&mut stream.read_buffer),
+                expected_incoming_bytes: Some(0),
+                read_bytes: 0,
+                write_buffers: Vec::new(),
+                write_bytes_queued: 0,
+                write_bytes_queueable: if !stream.write_closed {
+                    Some(stream.writable_bytes)
+                } else {
+                    None
+                },
+                wake_up_after: None,
+            },
+            stream,
+        })
     }
+}
 
-    fn advance_read_cursor(
-        &self,
-        StreamWrapper {
-            read_buffer,
-            is_reset,
-            ..
-        }: &mut Self::Stream,
-        bytes: usize,
-    ) {
-        assert!(!*is_reset);
-        assert!(bytes <= read_buffer.buffer.len() - read_buffer.buffer_first_offset);
-        read_buffer.buffer_first_offset += bytes;
-        debug_assert!(read_buffer.buffer_first_offset <= read_buffer.buffer.len());
+pub(crate) struct ReadWriteAccess<'a> {
+    read_write: read_write::ReadWrite<Instant>,
+    stream: &'a mut StreamWrapper,
+}
+
+impl<'a> ops::Deref for ReadWriteAccess<'a> {
+    type Target = read_write::ReadWrite<Instant>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.read_write
     }
+}
 
-    fn writable_bytes(
-        &self,
-        StreamWrapper {
-            is_reset,
-            writable_bytes,
-            write_closed,
-            ..
-        }: &mut Self::Stream,
-    ) -> usize {
-        if *is_reset || *write_closed {
-            return 0;
-        }
-
-        *writable_bytes
+impl<'a> ops::DerefMut for ReadWriteAccess<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.read_write
     }
+}
 
-    fn send(
-        &self,
-        StreamWrapper {
-            connection_id,
-            stream_id,
-            write_closed,
-            writable_bytes,
-            ..
-        }: &mut Self::Stream,
-        data: &[u8],
-    ) {
-        assert!(!*write_closed);
-
+impl<'a> Drop for ReadWriteAccess<'a> {
+    fn drop(&mut self) {
         let mut lock = STATE.try_lock().unwrap();
-        let stream = lock.streams.get_mut(&(*connection_id, *stream_id)).unwrap();
 
-        if stream.reset {
-            return;
-        }
+        let stream_inner = lock
+            .streams
+            .get_mut(&(self.stream.connection_id, self.stream.stream_id))
+            .unwrap();
 
-        assert!(data.len() <= *writable_bytes);
-        *writable_bytes -= data.len();
+        self.stream.read_buffer = mem::take(&mut self.read_write.incoming_buffer);
 
-        // `unwrap()` is ok as there's no way that `data.len()` doesn't fit in a `u64`.
-        TOTAL_BYTES_SENT.fetch_add(u64::try_from(data.len()).unwrap(), Ordering::Relaxed);
+        for buffer in self.read_write.write_buffers.drain(..) {
+            assert!(buffer.len() <= self.stream.writable_bytes);
+            self.stream.writable_bytes -= buffer.len();
 
-        unsafe {
-            bindings::stream_send(
-                *connection_id,
-                stream_id.unwrap_or(0),
-                u32::try_from(data.as_ptr() as usize).unwrap(),
-                u32::try_from(data.len()).unwrap(),
-            );
-        }
-    }
+            // `unwrap()` is ok as there's no way that `buffer.len()` doesn't fit in a `u64`.
+            TOTAL_BYTES_SENT.fetch_add(u64::try_from(buffer.len()).unwrap(), Ordering::Relaxed);
 
-    fn close_send(
-        &self,
-        StreamWrapper {
-            connection_id,
-            stream_id,
-            write_closable,
-            write_closed,
-            ..
-        }: &mut Self::Stream,
-    ) {
-        assert!(!*write_closed);
-
-        let mut lock = STATE.try_lock().unwrap();
-        let stream = lock.streams.get_mut(&(*connection_id, *stream_id)).unwrap();
-
-        if stream.reset {
-            return;
-        }
-
-        if *write_closable {
-            unsafe {
-                bindings::stream_send_close(*connection_id, stream_id.unwrap_or(0));
+            if !stream_inner.reset {
+                unsafe {
+                    bindings::stream_send(
+                        self.stream.connection_id,
+                        self.stream.stream_id.unwrap_or(0),
+                        u32::try_from(buffer.as_ptr() as usize).unwrap(),
+                        u32::try_from(buffer.len()).unwrap(),
+                    );
+                }
             }
         }
 
-        *write_closed = true;
+        if self.read_write.write_bytes_queueable.is_none() && !self.stream.write_closed {
+            if !stream_inner.reset && self.stream.write_closable {
+                unsafe {
+                    bindings::stream_send_close(
+                        self.stream.connection_id,
+                        self.stream.stream_id.unwrap_or(0),
+                    );
+                }
+            }
+
+            self.stream.write_closed = true;
+        }
     }
 }
 
 pub(crate) struct StreamWrapper {
     connection_id: u32,
     stream_id: Option<u32>,
-    read_buffer: ReadBuffer,
+    read_buffer: Vec<u8>,
     /// `true` if the remote has reset the stream and `update_stream` has since then been called.
     is_reset: bool,
     writable_bytes: usize,
@@ -842,15 +816,6 @@ struct Stream {
     /// Event notified whenever one of the fields above is modified, such as a new message being
     /// queued.
     something_happened: event_listener::Event,
-}
-
-struct ReadBuffer {
-    /// Buffer containing incoming data.
-    buffer: Box<[u8]>,
-
-    /// The first bytes of [`ReadBuffer::buffer`] have already been processed are not considered
-    /// not part of the read buffer anymore.
-    buffer_first_offset: usize,
 }
 
 pub(crate) fn connection_open_single_stream(connection_id: u32, initial_writable_bytes: u32) {


### PR DESCRIPTION
Followup to https://github.com/smol-dot/smoldot/pull/947

This PR refactors the `light-base` networking service and the `PlatformRef` trait to be more in line with the `ReadWrite` pattern and thus simplify the code.

The `PlatformRef` trait now has only two functions regarding streams handling: `read_write_access` and `wait_read_write_again`. The good news is, this corresponds exactly to `WithBuffers::read_write_access` and `WithBuffers::wait_read_write_again`, so you can just wrap your socket around a `WithBuffers` and use these functions to implement the trait.

As can be seen in `default.rs`, the implementation is thus way easier.
