### PR TITLE
Add full node CLI options for the blake2 256 hash

### DIFF
--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -57,6 +57,9 @@ pub enum CliOptionsCommand {
     /// Computes the 64 bits BLAKE2 hash of a string payload and prints the hexadecimal-encoded hash.
     #[command(name = "blake2-64bits-hash")]
     Blake264BitsHash(CliOptionsBlake264Hash),
+    /// Computes the 256 bits BLAKE2 hash of a file and prints the hexadecimal-encoded hash.
+    #[command(name = "blake2-256bits-hash")]
+    Blake2256BitsHash(CliOptionsBlake2256Hash),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -111,6 +114,12 @@ pub struct CliOptionsRun {
 pub struct CliOptionsBlake264Hash {
     /// Payload whose hash to compute.
     pub payload: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct CliOptionsBlake2256Hash {
+    /// Path of the file whose hash to compute.
+    pub file: PathBuf,
 }
 
 #[derive(Debug, Clone)]

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -42,6 +42,11 @@ async fn async_main() {
             let hash = blake2_rfc::blake2b::blake2b(8, &[], opt.payload.as_bytes());
             println!("0x{}", hex::encode(hash));
         }
+        cli::CliOptionsCommand::Blake2256BitsHash(opt) => {
+            let content = fs::read(opt.file).expect("Failed to read file content");
+            let hash = blake2_rfc::blake2b::blake2b(32, &[], &content);
+            println!("0x{}", hex::encode(hash));
+        }
     }
 }
 


### PR DESCRIPTION
Computing the blake2 256 hash is very useful in the Polkadot world, for example to start a vote for a RFC.
I couldn't find any useful way to build such a hash :shrug: