### PR TITLE
Remove `error` field from `inaccessible` event

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -733,7 +733,7 @@ pub enum ChainHeadCallEvent<'a> {
     #[serde(rename = "done")]
     Done { output: HexString },
     #[serde(rename = "inaccessible")]
-    Inaccessible { error: Cow<'a, str> },
+    Inaccessible {},
     #[serde(rename = "error")]
     Error { error: Cow<'a, str> },
     #[serde(rename = "disjoint")]

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1231,7 +1231,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             };
                                             let storage_value = match storage_value {
                                                 Ok(v) => v,
-                                                Err(error) => {
+                                                Err(_) => {
                                                     runtime_call_lock.unlock(
                                                         runtime_host::RuntimeHostVm::StorageGet(
                                                             get,
@@ -1240,9 +1240,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     );
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible {
-                                                            error: error.to_string().into(),
-                                                        },
+                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
                                                     }).await;
                                                     break;
                                                 }
@@ -1261,7 +1259,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             };
                                             let merkle_value = match merkle_value {
                                                 Ok(v) => v,
-                                                Err(error) => {
+                                                Err(_) => {
                                                     runtime_call_lock.unlock(
                                                         runtime_host::RuntimeHostVm::ClosestDescendantMerkleValue(
                                                             mv,
@@ -1270,9 +1268,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     );
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible {
-                                                            error: error.to_string().into(),
-                                                        },
+                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
                                                     }).await;
                                                     break;
                                                 }
@@ -1293,7 +1289,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             };
                                             let next_key = match next_key {
                                                 Ok(v) => v,
-                                                Err(error) => {
+                                                Err(_) => {
                                                     runtime_call_lock.unlock(
                                                         runtime_host::RuntimeHostVm::NextKey(
                                                             nk,
@@ -1302,9 +1298,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     );
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible {
-                                                            error: error.to_string().into(),
-                                                        },
+                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
                                                     }).await;
                                                     break;
                                                 }


### PR DESCRIPTION
Backports https://github.com/paritytech/json-rpc-interface-spec/pull/65

This is not worth mentioning in the CHANGELOG, given that events will be refactored with https://github.com/smol-dot/smoldot/issues/960.
