### PR TITLE
Finish backporting changes to JSON-RPC API

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -770,7 +770,7 @@ pub enum ChainHeadStorageReturn<'a> {
         #[serde(rename = "operationId")]
         operation_id: Cow<'a, str>,
         #[serde(rename = "discardedItems")]
-        discarded_items: u64,
+        discarded_items: usize,
     },
     #[serde(rename = "limitReached")]
     LimitReached {},

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -449,13 +449,13 @@ define_methods! {
     chainHead_unstable_body(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
         hash: HashHexString
-    ) -> Cow<'a, str>,
+    ) -> ChainHeadBodyCallReturn<'a>,
     chainHead_unstable_call(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
         hash: HashHexString,
         function: Cow<'a, str>,
         #[rename = "callParameters"] call_parameters: HexString
-    ) -> Cow<'a, str>,
+    ) -> ChainHeadBodyCallReturn<'a>,
     chainHead_unstable_follow(
         #[rename = "withRuntime"] with_runtime: bool
     ) -> Cow<'a, str>,
@@ -478,7 +478,7 @@ define_methods! {
         hash: HashHexString,
         items: Vec<ChainHeadStorageRequestItem>,
         #[rename = "childTrie"] child_trie: Option<HexString>
-    ) -> Cow<'a, str>,
+    ) -> ChainHeadStorageReturn<'a>,
     chainHead_unstable_continue(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
         #[rename = "operationId"] operation_id: Cow<'a, str>
@@ -748,6 +748,32 @@ pub enum FollowEvent<'a> {
     },
     #[serde(rename = "stop")]
     Stop {},
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "result")]
+pub enum ChainHeadBodyCallReturn<'a> {
+    #[serde(rename = "started")]
+    Started {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+    },
+    #[serde(rename = "limitReached")]
+    LimitReached {},
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "result")]
+pub enum ChainHeadStorageReturn<'a> {
+    #[serde(rename = "started")]
+    Started {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+        #[serde(rename = "discardedItems")]
+        discarded_items: u64,
+    },
+    #[serde(rename = "limitReached")]
+    LimitReached {},
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -464,14 +464,9 @@ define_methods! {
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
         hash: HashHexString
     ) -> Option<HexString>,
-    chainHead_unstable_stopBody(
-        subscription: Cow<'a, str>
-    ) -> (),
-    chainHead_unstable_stopCall(
-        subscription: Cow<'a, str>
-    ) -> (),
-    chainHead_unstable_stopStorage(
-        subscription: Cow<'a, str>
+    chainHead_unstable_stopOperation(
+        #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
+        #[rename = "operationId"] operation_id: Cow<'a, str>
     ) -> (),
     chainHead_unstable_storage(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -520,10 +520,7 @@ define_methods! {
     state_storage(subscription: Cow<'a, str>, result: StorageChangeSet) -> (),
 
     // The functions below are experimental and are defined in the document https://github.com/paritytech/json-rpc-interface-spec/
-    chainHead_unstable_bodyEvent(subscription: Cow<'a, str>, result: ChainHeadBodyEvent) -> (),
-    chainHead_unstable_callEvent(subscription: Cow<'a, str>, result: ChainHeadCallEvent<'a>) -> (),
     chainHead_unstable_followEvent(subscription: Cow<'a, str>, result: FollowEvent<'a>) -> (),
-    chainHead_unstable_storageEvent(subscription: Cow<'a, str>, result: ChainHeadStorageEvent<'a>) -> (),
     transaction_unstable_watchEvent(subscription: Cow<'a, str>, result: TransactionWatchEvent<'a>) -> (),
 
     // This function is a custom addition in smoldot. As of the writing of this comment, there is
@@ -777,30 +774,6 @@ pub enum ChainHeadStorageReturn<'a> {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "event")]
-pub enum ChainHeadBodyEvent {
-    #[serde(rename = "done")]
-    Done { value: Vec<HexString> },
-    #[serde(rename = "inaccessible")]
-    Inaccessible {},
-    #[serde(rename = "disjoint")]
-    Disjoint {},
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "event")]
-pub enum ChainHeadCallEvent<'a> {
-    #[serde(rename = "done")]
-    Done { output: HexString },
-    #[serde(rename = "inaccessible")]
-    Inaccessible {},
-    #[serde(rename = "error")]
-    Error { error: Cow<'a, str> },
-    #[serde(rename = "disjoint")]
-    Disjoint {},
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ChainHeadStorageRequestItem {
     pub key: HexString,
     #[serde(rename = "type")]
@@ -833,25 +806,6 @@ pub enum ChainHeadStorageType {
     DescendantsValues,
     #[serde(rename = "descendants-hashes")]
     DescendantsHashes,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "event")]
-pub enum ChainHeadStorageEvent<'a> {
-    #[serde(rename = "items")]
-    Items {
-        items: Vec<ChainHeadStorageResponseItem>,
-    },
-    #[serde(rename = "done")]
-    Done,
-    #[serde(rename = "waiting-for-continue")]
-    WaitingForContinue,
-    #[serde(rename = "inaccessible")]
-    Inaccessible {},
-    #[serde(rename = "error")]
-    Error { error: Cow<'a, str> },
-    #[serde(rename = "disjoint")]
-    Disjoint {},
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -710,6 +710,42 @@ pub enum FollowEvent<'a> {
         #[serde(rename = "prunedBlockHashes")]
         pruned_blocks_hashes: Vec<HashHexString>,
     },
+    #[serde(rename = "operation-body-done")]
+    OperationBodyDone {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+        value: Vec<HexString>,
+    },
+    #[serde(rename = "operation-call-done")]
+    OperationCallDone {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+        output: HexString,
+    },
+    #[serde(rename = "operation-inaccessible")]
+    OperationInaccessible {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+    },
+    #[serde(rename = "operation-storage-items")]
+    OperationStorageItems {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+        items: Vec<ChainHeadStorageResponseItem>,
+    },
+    #[serde(rename = "operation-storage-done")]
+    OperationStorageDone {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+    },
+    #[serde(rename = "operation-waiting-for-continue")]
+    OperationWaitingForContinue,
+    #[serde(rename = "operation-error")]
+    OperationError {
+        #[serde(rename = "operationId")]
+        operation_id: Cow<'a, str>,
+        error: Cow<'a, str>,
+    },
     #[serde(rename = "stop")]
     Stop {},
 }

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -429,9 +429,12 @@ impl ClientMainTask {
                 | methods::MethodCall::rpc_methods { .. }
                 | methods::MethodCall::sudo_unstable_p2pDiscover { .. }
                 | methods::MethodCall::sudo_unstable_version { .. }
+                | methods::MethodCall::chainHead_unstable_body { .. }
+                | methods::MethodCall::chainHead_unstable_call { .. }
                 | methods::MethodCall::chainHead_unstable_continue { .. }
                 | methods::MethodCall::chainHead_unstable_finalizedDatabase { .. }
                 | methods::MethodCall::chainHead_unstable_header { .. }
+                | methods::MethodCall::chainHead_unstable_storage { .. }
                 | methods::MethodCall::chainHead_unstable_unpin { .. } => {
                     // Simple one-request-one-response.
                     return Event::HandleRequest {
@@ -455,10 +458,7 @@ impl ClientMainTask {
                 | methods::MethodCall::state_subscribeStorage { .. }
                 | methods::MethodCall::transaction_unstable_submitAndWatch { .. }
                 | methods::MethodCall::network_unstable_subscribeEvents { .. }
-                | methods::MethodCall::chainHead_unstable_body { .. }
-                | methods::MethodCall::chainHead_unstable_call { .. }
-                | methods::MethodCall::chainHead_unstable_follow { .. }
-                | methods::MethodCall::chainHead_unstable_storage { .. } => {
+                | methods::MethodCall::chainHead_unstable_follow { .. } => {
                     // Subscription starting requests.
 
                     // We must check the maximum number of subscriptions.
@@ -1178,17 +1178,8 @@ impl SubscriptionStartProcess {
                     &self.subscription_id,
                 ))
             }
-            methods::MethodCall::chainHead_unstable_body { .. } => {
-                methods::Response::chainHead_unstable_body(Cow::Borrowed(&self.subscription_id))
-            }
-            methods::MethodCall::chainHead_unstable_call { .. } => {
-                methods::Response::chainHead_unstable_call(Cow::Borrowed(&self.subscription_id))
-            }
             methods::MethodCall::chainHead_unstable_follow { .. } => {
                 methods::Response::chainHead_unstable_follow(Cow::Borrowed(&self.subscription_id))
-            }
-            methods::MethodCall::chainHead_unstable_storage { .. } => {
-                methods::Response::chainHead_unstable_storage(Cow::Borrowed(&self.subscription_id))
             }
             _ => unreachable!(),
         }

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -434,6 +434,7 @@ impl ClientMainTask {
                 | methods::MethodCall::chainHead_unstable_continue { .. }
                 | methods::MethodCall::chainHead_unstable_finalizedDatabase { .. }
                 | methods::MethodCall::chainHead_unstable_header { .. }
+                | methods::MethodCall::chainHead_unstable_stopOperation { .. }
                 | methods::MethodCall::chainHead_unstable_storage { .. }
                 | methods::MethodCall::chainHead_unstable_unpin { .. } => {
                     // Simple one-request-one-response.
@@ -530,9 +531,6 @@ impl ClientMainTask {
                 | methods::MethodCall::network_unstable_unsubscribeEvents {
                     subscription, ..
                 }
-                | methods::MethodCall::chainHead_unstable_stopBody { subscription, .. }
-                | methods::MethodCall::chainHead_unstable_stopStorage { subscription, .. }
-                | methods::MethodCall::chainHead_unstable_stopCall { subscription, .. }
                 | methods::MethodCall::chainHead_unstable_unfollow {
                     follow_subscription: subscription,
                     ..
@@ -560,15 +558,6 @@ impl ClientMainTask {
                                     methods::MethodCall::network_unstable_unsubscribeEvents {
                                         ..
                                     } => methods::Response::network_unstable_unsubscribeEvents(()),
-                                    methods::MethodCall::chainHead_unstable_stopBody { .. } => {
-                                        methods::Response::chainHead_unstable_stopBody(())
-                                    }
-                                    methods::MethodCall::chainHead_unstable_stopStorage {
-                                        ..
-                                    } => methods::Response::chainHead_unstable_stopStorage(()),
-                                    methods::MethodCall::chainHead_unstable_stopCall { .. } => {
-                                        methods::Response::chainHead_unstable_stopCall(())
-                                    }
                                     methods::MethodCall::chainHead_unstable_unfollow { .. } => {
                                         methods::Response::chainHead_unstable_unfollow(())
                                     }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -347,9 +347,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             | methods::MethodCall::chainHead_unstable_follow { .. }
             | methods::MethodCall::chainHead_unstable_genesisHash { .. }
             | methods::MethodCall::chainHead_unstable_header { .. }
-            | methods::MethodCall::chainHead_unstable_stopBody { .. }
-            | methods::MethodCall::chainHead_unstable_stopCall { .. }
-            | methods::MethodCall::chainHead_unstable_stopStorage { .. }
+            | methods::MethodCall::chainHead_unstable_stopOperation { .. }
             | methods::MethodCall::chainHead_unstable_storage { .. }
             | methods::MethodCall::chainHead_unstable_unfollow { .. }
             | methods::MethodCall::chainHead_unstable_unpin { .. }
@@ -461,6 +459,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             }
             methods::MethodCall::chainHead_unstable_storage { .. } => {
                 self.chain_head_storage(request).await;
+            }
+            methods::MethodCall::chainHead_unstable_stopOperation { .. } => {
+                self.chain_head_stop_operation(request).await;
             }
             methods::MethodCall::chainHead_unstable_header { .. } => {
                 self.chain_head_unstable_header(request).await;
@@ -620,9 +621,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             | methods::MethodCall::chainHead_unstable_follow { .. }
             | methods::MethodCall::chainHead_unstable_genesisHash { .. }
             | methods::MethodCall::chainHead_unstable_header { .. }
-            | methods::MethodCall::chainHead_unstable_stopBody { .. }
-            | methods::MethodCall::chainHead_unstable_stopCall { .. }
-            | methods::MethodCall::chainHead_unstable_stopStorage { .. }
+            | methods::MethodCall::chainHead_unstable_stopOperation { .. }
             | methods::MethodCall::chainHead_unstable_storage { .. }
             | methods::MethodCall::chainHead_unstable_unfollow { .. }
             | methods::MethodCall::chainHead_unstable_unpin { .. }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -108,9 +108,7 @@ struct Background<TPlat: PlatformRef> {
     chain_head_follow_tasks: Mutex<
         hashbrown::HashMap<
             String,
-            service::DeliverSender<
-                either::Either<service::RequestProcess, service::SubscriptionStartProcess>,
-            >,
+            service::DeliverSender<service::RequestProcess>,
             fnv::FnvBuildHasher,
         >,
     >,
@@ -449,11 +447,20 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 self.system_version(request).await;
             }
 
+            methods::MethodCall::chainHead_unstable_body { .. } => {
+                self.chain_head_unstable_body(request).await;
+            }
+            methods::MethodCall::chainHead_unstable_call { .. } => {
+                self.chain_head_call(request).await;
+            }
             methods::MethodCall::chainHead_unstable_continue { .. } => {
                 self.chain_head_continue(request).await;
             }
             methods::MethodCall::chainHead_unstable_genesisHash {} => {
                 self.chain_head_unstable_genesis_hash(request).await;
+            }
+            methods::MethodCall::chainHead_unstable_storage { .. } => {
+                self.chain_head_storage(request).await;
             }
             methods::MethodCall::chainHead_unstable_header { .. } => {
                 self.chain_head_unstable_header(request).await;
@@ -645,15 +652,6 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 unreachable!()
             }
 
-            methods::MethodCall::chainHead_unstable_body { .. } => {
-                self.chain_head_unstable_body(request).await;
-            }
-            methods::MethodCall::chainHead_unstable_call { .. } => {
-                self.chain_head_call(request).await;
-            }
-            methods::MethodCall::chainHead_unstable_storage { .. } => {
-                self.chain_head_storage(request).await;
-            }
             methods::MethodCall::chainHead_unstable_follow { .. } => {
                 self.chain_head_follow(request).await;
             }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -884,9 +884,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         Ok(block_data) => {
                             subscription
                                 .send_notification(
-                                    methods::ServerToClient::chainHead_unstable_bodyEvent {
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::ChainHeadBodyEvent::Done {
+                                        result: methods::FollowEvent::OperationBodyDone {
+                                            operation_id: todo!(),
                                             value: block_data
                                                 .body
                                                 .unwrap()
@@ -901,9 +902,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         Err(()) => {
                             subscription
                                 .send_notification(
-                                    methods::ServerToClient::chainHead_unstable_bodyEvent {
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::ChainHeadBodyEvent::Inaccessible {},
+                                        result: methods::FollowEvent::OperationInaccessible {
+                                            operation_id: todo!(),
+                                        },
                                     },
                                 )
                                 .await;
@@ -967,9 +970,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             // return.
                             subscription
                                 .send_notification(
-                                    methods::ServerToClient::chainHead_unstable_storageEvent {
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::ChainHeadStorageEvent::Error {
+                                        result: methods::FollowEvent::OperationError {
+                                            operation_id: todo!(),
                                             error: err.to_string().into(),
                                         },
                                     },
@@ -1077,9 +1081,12 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             if !items.is_empty() {
                                 subscription
                                     .send_notification(
-                                        methods::ServerToClient::chainHead_unstable_storageEvent {
+                                        methods::ServerToClient::chainHead_unstable_followEvent {
                                             subscription: (&subscription_id).into(),
-                                            result: methods::ChainHeadStorageEvent::Items { items },
+                                            result: methods::FollowEvent::OperationStorageItems {
+                                                operation_id: todo!(),
+                                                items
+                                            },
                                         },
                                     )
                                     .await;
@@ -1087,9 +1094,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
 
                             subscription
                                 .send_notification(
-                                    methods::ServerToClient::chainHead_unstable_storageEvent {
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::ChainHeadStorageEvent::Done,
+                                        result: methods::FollowEvent::OperationStorageDone {
+                                            operation_id: todo!(),
+                                        },
                                     },
                                 )
                                 .await;
@@ -1097,9 +1106,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         Err(_) => {
                             subscription
                                 .send_notification(
-                                    methods::ServerToClient::chainHead_unstable_storageEvent {
+                                    methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
-                                        result: methods::ChainHeadStorageEvent::Inaccessible {},
+                                        result: methods::FollowEvent::OperationInaccessible {
+                                            operation_id: todo!(),
+                                        },
                                     },
                                 )
                                 .await;
@@ -1200,9 +1211,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         }) {
                             Err((error, prototype)) => {
                                 runtime_call_lock.unlock(prototype);
-                                subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                     subscription: (&subscription_id).into(),
-                                    result: methods::ChainHeadCallEvent::Error {
+                                    result: methods::FollowEvent::OperationError {
+                                        operation_id: todo!(),
                                         error: error.to_string().into(),
                                     },
                                 }).await;
@@ -1215,9 +1227,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                 success.virtual_machine.value().as_ref().to_owned();
                                             runtime_call_lock
                                                 .unlock(success.virtual_machine.into_prototype());
-                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
-                                                result: methods::ChainHeadCallEvent::Done {
+                                                result: methods::FollowEvent::OperationCallDone {
+                                                    operation_id: todo!(),
                                                     output: methods::HexString(output),
                                                 },
                                             }).await;
@@ -1225,9 +1238,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                         }
                                         runtime_host::RuntimeHostVm::Finished(Err(error)) => {
                                             runtime_call_lock.unlock(error.prototype);
-                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
-                                                result: methods::ChainHeadCallEvent::Error {
+                                                result: methods::FollowEvent::OperationError {
+                                                    operation_id: todo!(),
                                                     error: error.detail.to_string().into(),
                                                 },
                                             }).await;
@@ -1248,9 +1262,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                         )
                                                         .into_prototype(),
                                                     );
-                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
+                                                        result: methods::FollowEvent::OperationInaccessible {
+                                                            operation_id: todo!(),
+                                                        },
                                                     }).await;
                                                     break;
                                                 }
@@ -1276,9 +1292,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                         )
                                                         .into_prototype(),
                                                     );
-                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
+                                                        result: methods::FollowEvent::OperationInaccessible {
+                                                            operation_id: todo!(),
+                                                        },
                                                     }).await;
                                                     break;
                                                 }
@@ -1306,9 +1324,11 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                         )
                                                         .into_prototype(),
                                                     );
-                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                                    subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
-                                                        result: methods::ChainHeadCallEvent::Inaccessible { },
+                                                        result: methods::FollowEvent::OperationInaccessible {
+                                                            operation_id: todo!(),
+                                                        },
                                                     }).await;
                                                     break;
                                                 }
@@ -1323,9 +1343,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                         }
                                         runtime_host::RuntimeHostVm::Offchain(ctx) => {
                                             runtime_call_lock.unlock(runtime_host::RuntimeHostVm::Offchain(ctx).into_prototype());
-                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                                            subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
-                                                result: methods::ChainHeadCallEvent::Error {
+                                                result: methods::FollowEvent::OperationError {
+                                                    operation_id: todo!(),
                                                     error: "Runtime has called an offchain host function".to_string().into(),
                                                 },
                                             }).await;
@@ -1337,49 +1358,55 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         }
                     }
                     Err(runtime_service::RuntimeCallError::InvalidRuntime(error)) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: error.to_string().into(),
                             },
                         }).await;
                     }
                     Err(runtime_service::RuntimeCallError::StorageRetrieval(error)) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: error.to_string().into(),
                             },
                         }).await;
                     }
                     Err(runtime_service::RuntimeCallError::MissingProofEntry(_error)) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: "incomplete call proof".into(),
                             },
                         }).await;
                     }
                     Err(runtime_service::RuntimeCallError::InvalidChildTrieRoot) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: "invalid call proof".into(),
                             },
                         }).await;
                     }
                     Err(runtime_service::RuntimeCallError::CallProof(error)) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: error.to_string().into(),
                             },
                         }).await
                     }
                     Err(runtime_service::RuntimeCallError::StorageQuery(error)) => {
-                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_callEvent {
+                        subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
-                            result: methods::ChainHeadCallEvent::Error {
+                            result: methods::FollowEvent::OperationError {
+                                operation_id: todo!(),
                                 error: format!("failed to fetch call proof: {error}").into(),
                             },
                         }).await;

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -307,7 +307,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     next_operation_id: 1,
                     to_main_task: to_operation_handlers,
                     from_operation_handlers,
-                    available_operation_slots: 32,
+                    available_operation_slots: 32, // TODO: make configurable? adjust dynamically?
                 }
                 .run(subscription, subscription_id, rx)
             });

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -315,6 +315,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     log_target,
                     runtime_service,
                     sync_service,
+                    next_operation_id: 1,
                 }
                 .run(subscription, subscription_id, rx)
             });
@@ -517,6 +518,9 @@ struct ChainHeadFollowTask<TPlat: PlatformRef> {
     log_target: String,
     runtime_service: Arc<runtime_service::RuntimeService<TPlat>>,
     sync_service: Arc<sync_service::SyncService<TPlat>>,
+
+    /// Identifier to assign to the next body/call/storage operation.
+    next_operation_id: u128,
 }
 
 enum Subscription<TPlat: PlatformRef> {
@@ -847,6 +851,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             }
         };
 
+        let operation_id = self.next_operation_id.to_string();
+        self.next_operation_id += 1;
+
         let mut subscription = request.accept();
         let subscription_id = subscription.subscription_id().to_owned();
 
@@ -887,7 +894,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                     methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::OperationBodyDone {
-                                            operation_id: todo!(),
+                                            operation_id: (&operation_id).into(),
                                             value: block_data
                                                 .body
                                                 .unwrap()
@@ -905,7 +912,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                     methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::OperationInaccessible {
-                                            operation_id: todo!(),
+                                            operation_id: (&operation_id).into(),
                                         },
                                     },
                                 )
@@ -952,6 +959,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             return;
         }
 
+        let operation_id = self.next_operation_id.to_string();
+        self.next_operation_id += 1;
+
         let mut subscription = request.accept();
         let subscription_id = subscription.subscription_id().to_owned();
 
@@ -973,7 +983,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                     methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::OperationError {
-                                            operation_id: todo!(),
+                                            operation_id: (&operation_id).into(),
                                             error: err.to_string().into(),
                                         },
                                     },
@@ -1084,7 +1094,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                         methods::ServerToClient::chainHead_unstable_followEvent {
                                             subscription: (&subscription_id).into(),
                                             result: methods::FollowEvent::OperationStorageItems {
-                                                operation_id: todo!(),
+                                                operation_id: (&operation_id).into(),
                                                 items
                                             },
                                         },
@@ -1097,7 +1107,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                     methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::OperationStorageDone {
-                                            operation_id: todo!(),
+                                            operation_id: (&operation_id).into(),
                                         },
                                     },
                                 )
@@ -1109,7 +1119,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                     methods::ServerToClient::chainHead_unstable_followEvent {
                                         subscription: (&subscription_id).into(),
                                         result: methods::FollowEvent::OperationInaccessible {
-                                            operation_id: todo!(),
+                                            operation_id: (&operation_id).into(),
                                         },
                                     },
                                 )
@@ -1176,6 +1186,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             }
         };
 
+        let operation_id = self.next_operation_id.to_string();
+        self.next_operation_id += 1;
+
         let mut subscription = request.accept();
         let subscription_id = subscription.subscription_id().to_owned();
 
@@ -1214,7 +1227,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                 subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                     subscription: (&subscription_id).into(),
                                     result: methods::FollowEvent::OperationError {
-                                        operation_id: todo!(),
+                                        operation_id: (&operation_id).into(),
                                         error: error.to_string().into(),
                                     },
                                 }).await;
@@ -1230,7 +1243,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
                                                 result: methods::FollowEvent::OperationCallDone {
-                                                    operation_id: todo!(),
+                                                    operation_id: (&operation_id).into(),
                                                     output: methods::HexString(output),
                                                 },
                                             }).await;
@@ -1241,7 +1254,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
                                                 result: methods::FollowEvent::OperationError {
-                                                    operation_id: todo!(),
+                                                    operation_id: (&operation_id).into(),
                                                     error: error.detail.to_string().into(),
                                                 },
                                             }).await;
@@ -1265,7 +1278,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
                                                         result: methods::FollowEvent::OperationInaccessible {
-                                                            operation_id: todo!(),
+                                                            operation_id: (&operation_id).into(),
                                                         },
                                                     }).await;
                                                     break;
@@ -1295,7 +1308,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
                                                         result: methods::FollowEvent::OperationInaccessible {
-                                                            operation_id: todo!(),
+                                                            operation_id: (&operation_id).into(),
                                                         },
                                                     }).await;
                                                     break;
@@ -1327,7 +1340,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                                     subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                         subscription: (&subscription_id).into(),
                                                         result: methods::FollowEvent::OperationInaccessible {
-                                                            operation_id: todo!(),
+                                                            operation_id: (&operation_id).into(),
                                                         },
                                                     }).await;
                                                     break;
@@ -1346,7 +1359,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                                             subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                                                 subscription: (&subscription_id).into(),
                                                 result: methods::FollowEvent::OperationError {
-                                                    operation_id: todo!(),
+                                                    operation_id: (&operation_id).into(),
                                                     error: "Runtime has called an offchain host function".to_string().into(),
                                                 },
                                             }).await;
@@ -1361,7 +1374,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: error.to_string().into(),
                             },
                         }).await;
@@ -1370,7 +1383,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: error.to_string().into(),
                             },
                         }).await;
@@ -1379,7 +1392,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: "incomplete call proof".into(),
                             },
                         }).await;
@@ -1388,7 +1401,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: "invalid call proof".into(),
                             },
                         }).await;
@@ -1397,7 +1410,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: error.to_string().into(),
                             },
                         }).await
@@ -1406,7 +1419,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         subscription.send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
                             subscription: (&subscription_id).into(),
                             result: methods::FollowEvent::OperationError {
-                                operation_id: todo!(),
+                                operation_id: (&operation_id).into(),
                                 error: format!("failed to fetch call proof: {error}").into(),
                             },
                         }).await;

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Remove `networkConfig` parameter from all `chainHead` JSON-RPC functions, in accordance with the latest changes to the JSON-RPC API specification. ([#963](https://github.com/smol-dot/smoldot/pull/963))
 - A JSON-RPC error is now returned if the JSON-RPC client tries to open more than two simultaneous `chainHead_unstable_follow` subscriptions, in accordance with the latest changes in the JSON-RPC API specification. ([#962](https://github.com/smol-dot/smoldot/pull/962))
 - Rename `chainHead_unstable_storageContinue` to `chainHead_unstable_continue`, in accordance with the latest changes in the JSON-RPC API specification. ([#965](https://github.com/smol-dot/smoldot/pull/965))
+- Merge `chainHead_unstable_stopBody`, `chainHead_unstable_stopCall`, and `chainHead_unstable_stopStorage` into `chainHead_unstable_stopOperation`, in accordance with the latest changes in the JSON-RPC API specification. ([#966](https://github.com/smol-dot/smoldot/pull/966))
+- Merge `chainHead_unstable_body`, `chainHead_unstable_call`, and `chainHead_unstable_storage` are now simple request-response functions that generate their notifications onto the corresponding `chainHead_unstable_follow` subscription, in accordance with the latest changes in the JSON-RPC API specification. ([#966](https://github.com/smol-dot/smoldot/pull/966))
 
 ## 1.0.13 - 2023-07-16
 

--- a/wasm-node/javascript/test/chainHead.mjs
+++ b/wasm-node/javascript/test/chainHead.mjs
@@ -99,7 +99,7 @@ test('chainHead_unstable_body works', async t => {
     .then(async (chain) => {
       while (true) {
         const parsed = JSON.parse(await chain.nextJsonRpcResponse());
-        if (parsed.method == "chainHead_unstable_bodyEvent" && parsed.params.result.event == "inaccessible") {
+        if (parsed.method == "chainHead_unstable_followEvent" && parsed.params.result.event == "operation-inaccessible") {
           t.pass();
           break;
         }


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/960

This finishes backporting https://github.com/paritytech/json-rpc-interface-spec/pull/66

Overall it was pretty straight forward, however this is completely untested.

In terms of code, I'm moderately happy about it. There's a lot of boilerplate because we're no longer using the "infrastructure" that `ClientMainTask` is providing.
I'm not completely sure what to do here. Assuming that the full node will implement the API as well, it would make sense to integrate these new features into the `ClientMainTask`. However this is complicated and I don't really know how I'd do that.
