### PR TITLE
Fix network_service discarding events

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -988,10 +988,11 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 async { WhatHappened::Message(task.messages_rx.next().await.unwrap()) };
             let can_generate_event = matches!(task.event_senders, either::Left(_));
             let service_event = async {
-                if let (true, Some(event)) = (
-                    can_generate_event,
-                    task.network.next_event(task.platform.now()),
-                ) {
+                if let Some(event) = if can_generate_event {
+                    task.network.next_event(task.platform.now())
+                } else {
+                    None
+                } {
                     WhatHappened::NetworkEvent(event)
                 } else if let Some(start_connect) =
                     task.network.next_start_connect(|| task.platform.now())

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Fix several potential panics due to mismatches in the state of the networking.
+- Fix several potential panics due to mismatches in the state of the networking. ([#967](https://github.com/smol-dot/smoldot/pull/967))
 
 ## 1.0.13 - 2023-07-16
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -8,6 +8,10 @@
 - A JSON-RPC error is now returned if the JSON-RPC client tries to open more than two simultaneous `chainHead_unstable_follow` subscriptions, in accordance with the latest changes in the JSON-RPC API specification. ([#962](https://github.com/smol-dot/smoldot/pull/962))
 - Rename `chainHead_unstable_storageContinue` to `chainHead_unstable_continue`, in accordance with the latest changes in the JSON-RPC API specification. ([#965](https://github.com/smol-dot/smoldot/pull/965))
 
+### Fixed
+
+- Fix several potential panics due to mismatches in the state of the networking.
+
 ## 1.0.13 - 2023-07-16
 
 ### Added


### PR DESCRIPTION
Fix #956

Right now, if `can_generate_events` is `false`, we call `next_event` anyway but discard the event. This is obviously the wrong thing to do.