### PR TITLE
Fix some networking tests

### DIFF
--- a/lib/src/libp2p/connection/single_stream_handshake/tests.rs
+++ b/lib/src/libp2p/connection/single_stream_handshake/tests.rs
@@ -17,11 +17,13 @@
 
 #![cfg(test)]
 
+use core::{cmp, mem};
+
 use super::{super::super::read_write::ReadWrite, Handshake, NoiseKey};
 
 #[test]
 fn handshake_basic_works() {
-    fn test_with_buffer_sizes(size1: usize, size2: usize) {
+    fn test_with_buffer_sizes(mut size1: usize, mut size2: usize) {
         let key1 = NoiseKey::new(&rand::random(), &rand::random());
         let key2 = NoiseKey::new(&rand::random(), &rand::random());
 
@@ -43,9 +45,9 @@ fn handshake_basic_works() {
                         incoming_buffer: buf_2_to_1,
                         expected_incoming_bytes: Some(0),
                         read_bytes: 0,
-                        write_buffers: Vec::new(),
-                        write_bytes_queued: 0,
+                        write_bytes_queued: buf_1_to_2.len(),
                         write_bytes_queueable: Some(size1 - buf_1_to_2.len()),
+                        write_buffers: vec![mem::take(&mut buf_1_to_2)],
                         wake_up_after: None,
                     };
                     handshake1 = nego.read_write(&mut read_write).unwrap();
@@ -56,6 +58,7 @@ fn handshake_basic_works() {
                             .drain(..)
                             .flat_map(|b| b.into_iter()),
                     );
+                    size2 = cmp::max(size2, read_write.expected_incoming_bytes.unwrap_or(0));
                 }
             }
 
@@ -67,9 +70,9 @@ fn handshake_basic_works() {
                         incoming_buffer: buf_1_to_2,
                         expected_incoming_bytes: Some(0),
                         read_bytes: 0,
-                        write_buffers: Vec::new(),
-                        write_bytes_queued: 0,
+                        write_bytes_queued: buf_2_to_1.len(),
                         write_bytes_queueable: Some(size2 - buf_2_to_1.len()),
+                        write_buffers: vec![mem::take(&mut buf_2_to_1)],
                         wake_up_after: None,
                     };
                     handshake2 = nego.read_write(&mut read_write).unwrap();
@@ -80,6 +83,7 @@ fn handshake_basic_works() {
                             .drain(..)
                             .flat_map(|b| b.into_iter()),
                     );
+                    size1 = cmp::max(size1, read_write.expected_incoming_bytes.unwrap_or(0));
                 }
             }
         }


### PR DESCRIPTION
Fixes the way the networking tests work to conform to the `read_write` API.
Does not fix the underlying logic.
