### PR TITLE
Use rustsec/audit-check instead of actions-rs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,10 @@ name: recurrent-audit
 on:
   schedule:
     - cron: '0 0 * * *'
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 
 permissions:
   contents: read
@@ -11,10 +15,8 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    container:
-      image: rust
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR "modernizes" a bit the recurrent audit.
It uses a more maintained action, and is now also performed on any modification to a `Cargo.toml` or `Cargo.lock`.