### PR TITLE
Publish new versions of smoldot on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arrayvec 0.7.4",
  "async-lock",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-channel",
  "async-lock",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 include.workspace = true
-publish = false
 default-run = "full-node"
 
 [[bin]]
@@ -37,6 +36,6 @@ serde_json = { version = "1.0.104", default-features = false, features = ["std"]
 siphasher = { version = "0.3.10", default-features = false }
 soketto = { version = "0.7.1", features = ["deflate"] }
 smol = "1.3.0"
-smoldot = { version = "0.9.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
+smoldot = { version = "0.10.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.2.6"
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "0.9.0"
+version = "0.10.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "0.7.0"
+version = "0.8.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true
@@ -37,7 +37,7 @@ serde = { version = "1.0.183", default-features = false, features = ["alloc", "d
 serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 siphasher = { version = "0.3.10", default-features = false }
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "0.9.0", path = "../lib", default-features = false }
+smoldot = { version = "0.10.0", path = "../lib", default-features = false }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # `std` feature

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -25,5 +25,5 @@ no-std-net = { version = "0.6.0", default-features = false }
 pin-project = "1.1.3"
 rand = "0.8.5"
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "0.9.0", path = "../../lib", default-features = false }
+smoldot = { version = "0.10.0", path = "../../lib", default-features = false }
 smoldot-light = { version = "0.7.0", path = "../../light-base", default-features = false }

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -26,4 +26,4 @@ pin-project = "1.1.3"
 rand = "0.8.5"
 slab = { version = "0.4.8", default-features = false }
 smoldot = { version = "0.10.0", path = "../../lib", default-features = false }
-smoldot-light = { version = "0.7.0", path = "../../light-base", default-features = false }
+smoldot-light = { version = "0.8.0", path = "../../light-base", default-features = false }


### PR DESCRIPTION
This is also the first time that `smoldot-full-node` is published.