### PR TITLE
Remove hardcoded chains from full node

### DIFF
--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -64,9 +64,9 @@ pub enum CliOptionsCommand {
 
 #[derive(Debug, clap::Parser)]
 pub struct CliOptionsRun {
-    /// Chain to connect to ("Polkadot", "Kusama", "Westend", or a file path).
-    #[arg(long, default_value = "polkadot")]
-    pub chain: CliChain,
+    /// Path of a file containing the specification of the chain to connect to.
+    #[arg(long)]
+    pub chain: PathBuf,
     /// Output to stdout: auto, none, informant, logs, logs-json.
     #[arg(long, default_value = "auto")]
     pub output: Output,
@@ -120,30 +120,6 @@ pub struct CliOptionsBlake264Hash {
 pub struct CliOptionsBlake2256Hash {
     /// Path of the file whose hash to compute.
     pub file: PathBuf,
-}
-
-#[derive(Debug, Clone)]
-pub enum CliChain {
-    Polkadot,
-    Kusama,
-    Westend,
-    Custom(PathBuf),
-}
-
-impl core::str::FromStr for CliChain {
-    type Err = core::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "polkadot" {
-            Ok(CliChain::Polkadot)
-        } else if s == "kusama" {
-            Ok(CliChain::Kusama)
-        } else if s == "westend" {
-            Ok(CliChain::Westend)
-        } else {
-            Ok(CliChain::Custom(s.parse()?))
-        }
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR removes the three hardcoded chains (Polkadot, Kusama, Westend) from the full node CLI.

I've decided to do that in lights of #993, where publishing the chain specs would require some tweaks to `Cargo.toml`, and would mean that the chain specs in this repository are no longer examples but canonical, which is not something I want.

Doing this change also solves a hacky `TODO` in the code.
