### PR TITLE
More precise configuration for `sync_service`

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1136,12 +1136,15 @@ async fn start_services<TPlat: platform::PlatformRef>(
             sync_service::SyncService::new(sync_service::Config {
                 platform: platform.clone(),
                 log_name: log_name.clone(),
-                chain_information: chain_information.clone(),
                 block_number_bytes: usize::from(chain_spec.block_number_bytes()),
                 network_service: (network_service.clone(), 0),
                 network_events_receiver: network_event_receivers.pop().unwrap(),
                 chain_type: sync_service::ConfigChainType::Parachain(
                     sync_service::ConfigParachain {
+                        finalized_block_header: chain_information
+                            .as_ref()
+                            .finalized_block_header
+                            .scale_encoding_vec(usize::from(chain_spec.block_number_bytes())),
                         parachain_id: chain_spec.relay_chain().unwrap().1,
                         relay_chain_sync: relay_chain.runtime_service.clone(),
                         relay_chain_block_number_bytes: relay_chain
@@ -1175,13 +1178,13 @@ async fn start_services<TPlat: platform::PlatformRef>(
         let sync_service = Arc::new(
             sync_service::SyncService::new(sync_service::Config {
                 log_name: log_name.clone(),
-                chain_information: chain_information.clone(),
                 block_number_bytes: usize::from(chain_spec.block_number_bytes()),
                 platform: platform.clone(),
                 network_service: (network_service.clone(), 0),
                 network_events_receiver: network_event_receivers.pop().unwrap(),
                 chain_type: sync_service::ConfigChainType::RelayChain(
                     sync_service::ConfigRelayChain {
+                        chain_information: chain_information.clone(),
                         runtime_code_hint: runtime_code_hint.map(|hint| {
                             sync_service::ConfigRelayChainRuntimeCodeHint {
                                 storage_value: hint.code,

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -53,9 +53,6 @@ pub struct Config<TPlat: PlatformRef> {
     /// >           have been filtered out from this name.
     pub log_name: String,
 
-    /// State of the finalized chain.
-    pub chain_information: chain::chain_information::ValidChainInformation,
-
     /// Number of bytes of the block number in the networking protocol.
     pub block_number_bytes: usize,
 
@@ -84,6 +81,9 @@ pub enum ConfigChainType<TPlat: PlatformRef> {
 
 /// See [`ConfigChainType::RelayChain`].
 pub struct ConfigRelayChain {
+    /// State of the finalized chain.
+    pub chain_information: chain::chain_information::ValidChainInformation,
+
     /// Known valid Merkle value and storage value combination for the `:code` key.
     ///
     /// If provided, the warp syncing algorithm will first fetch the Merkle value of `:code`, and
@@ -111,6 +111,11 @@ pub struct ConfigParachain<TPlat: PlatformRef> {
 
     /// Number of bytes used by the block number in the relay chain.
     pub relay_chain_block_number_bytes: usize,
+
+    /// SCALE-encoded header of a known finalized block of the parachain. Used in the situation
+    /// where the API user subscribes using [`SyncService::subscribe_all`] before any parachain
+    /// block can be gathered.
+    pub finalized_block_header: Vec<u8>,
 
     /// Id of the parachain within the relay chain.
     ///
@@ -154,7 +159,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                     Box::pin(parachain::start_parachain(
                         log_target,
                         config.platform.clone(),
-                        config.chain_information,
+                        config_parachain.finalized_block_header,
                         config.block_number_bytes,
                         config_parachain.relay_chain_sync.clone(),
                         config_parachain.relay_chain_block_number_bytes,
@@ -171,7 +176,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                     Box::pin(standalone::start_standalone_chain(
                         log_target,
                         config.platform.clone(),
-                        config.chain_information,
+                        config_relay_chain.chain_information,
                         config.block_number_bytes,
                         config_relay_chain.runtime_code_hint,
                         from_foreground,


### PR DESCRIPTION
Step towards #908 

Removes the need to pass a `ChainInformation` object when building the sync service of a parachain.
