### PR TITLE
No longer cargo publish dry-run the light and full nodes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,10 +250,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: cargo publish --dry-run --locked
         working-directory: ./lib
-      - run: cargo publish --dry-run --locked
-        working-directory: ./light-base
-      - run: cargo publish --dry-run --locked
-        working-directory: ./full-node
+        # Note that no dry run is performed for the crates that have dependencies towards the
+        # library, as `cargo publish --dry-run` tries to build them against the version on
+        # `crates.io`, which causes build failures if its public API has changed.
+        # TODO: is there a way to solve that? ^
       - run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: cargo publish --no-verify


### PR DESCRIPTION
As shown in https://github.com/smol-dot/smoldot/pull/1010, as soon as we modify the public API of the library, `cargo publish --dry-run` will fail for the `smoldot-light-base` or `smoldot-full-node` crate if they make use that public API.

This PR removes these checks and adds a TODO, but I don't think that there's a solution to this problem.
