### PR TITLE
Calculate correct start slot for skipped epoch transition

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix panic when removing a chain while a networking connection is being opened. ([#1011](https://github.com/smol-dot/smoldot/pull/1011))
+- Fix epoch start slot calculation when epochs have been skipped. ([#1015](https://github.com/smol-dot/smoldot/pull/1015))
 
 ## 1.0.15 - 2023-08-08
 


### PR DESCRIPTION
Small followup to https://github.com/smol-dot/smoldot/pull/991
- Removes some assertions that no longer hold now that epochs can be skipped
- When an epoch is skipped we need to adjust the starting slot of the next epoch 