### PR TITLE
Fix a TODO in wasm-node/platform.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,7 @@ version = "1.0.15"
 dependencies = [
  "async-executor",
  "async-task",
+ "derive_more",
  "event-listener",
  "fnv",
  "futures-util",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-executor = { version = "1.5.1", default-features = false }
 async-task = { version = "4.4.0", default-features = false }
+derive_more = "0.99.17"
 event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
 futures-util = { version = "0.3.27", default-features = false }

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -51,7 +51,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     type StreamConnectFuture =
         pin::Pin<Box<dyn future::Future<Output = Result<Self::Stream, ConnectError>> + Send>>;
     type ReadWriteAccess<'a> = ReadWriteAccess<'a>;
-    type StreamErrorRef<'a> = String;
+    type StreamErrorRef<'a> = StreamError;
     type MultiStreamConnectFuture = pin::Pin<
         Box<
             dyn future::Future<
@@ -552,7 +552,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         let stream = stream.get_mut();
 
         if stream.is_reset {
-            todo!()
+            return Err(StreamError {});
         }
 
         Ok(ReadWriteAccess {
@@ -741,6 +741,10 @@ impl Drop for MultiStreamWrapper {
         }
     }
 }
+
+#[derive(Debug, derive_more::Display, Clone)]
+#[display(fmt = "stream error")]
+pub(crate) struct StreamError;
 
 static STATE: Mutex<NetworkState> = Mutex::new(NetworkState {
     next_connection_id: 0,


### PR DESCRIPTION
I'm not mentioning it in the CHANGELOG because this doesn't seem to happen in practice, but I've noticed this `todo!()` and it definitely shouldn't have made it to the main branch.