### PR TITLE
Fix `wake_up_after` being ignored in the wasm-node streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,6 +2442,7 @@ dependencies = [
  "async-task",
  "event-listener",
  "fnv",
+ "futures-lite",
  "futures-util",
  "hashbrown 0.14.0",
  "log",

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The block announces substream handshake of a parachain peer-to-peer network now properly contains the block that smoldot thinks is the best. The genesis block was previously always reported. ([#1012](https://github.com/smol-dot/smoldot/pull/1012))
 - Fix panic when removing a chain while a networking connection is being opened. ([#1011](https://github.com/smol-dot/smoldot/pull/1011))
 - Fix epoch start slot calculation when epochs have been skipped. ([#1015](https://github.com/smol-dot/smoldot/pull/1015))
+- Fix timeouts not working properly in the networking.
 
 ## 1.0.15 - 2023-08-08
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,7 +12,7 @@
 - The block announces substream handshake of a parachain peer-to-peer network now properly contains the block that smoldot thinks is the best. The genesis block was previously always reported. ([#1012](https://github.com/smol-dot/smoldot/pull/1012))
 - Fix panic when removing a chain while a networking connection is being opened. ([#1011](https://github.com/smol-dot/smoldot/pull/1011))
 - Fix epoch start slot calculation when epochs have been skipped. ([#1015](https://github.com/smol-dot/smoldot/pull/1015))
-- Fix timeouts not working properly in the networking.
+- Fix timeouts not working properly in the networking. ([#1023](https://github.com/smol-dot/smoldot/pull/1023))
 
 ## 1.0.15 - 2023-08-08
 

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -17,6 +17,7 @@ async-executor = { version = "1.5.1", default-features = false }
 async-task = { version = "4.4.0", default-features = false }
 event-listener = { version = "2.5.3" }
 fnv = { version = "1.0.7", default-features = false }
+futures-lite = { version = "1.13.0", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false }
 log = { version = "0.4.18", features = ["std"] }


### PR DESCRIPTION
Another big oops moment. The value of `wake_up_after` is currently ignored by the wasm-node implementation.