### PR TITLE
Refactor the complicated match block when adding a chain

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -839,7 +839,6 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 };
 
                 let platform = self.platform.clone();
-                let known_nodes = known_nodes.clone();
 
                 async move {
                     // Wait for the chain to finish initializing to proceed.


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/860
Step towards https://github.com/smol-dot/smoldot/issues/908

This PR refactors the big `match` block at the start of `add_chain` and splits it into multiple steps.
I've been careful to not change anything in the logic, except for an additional TODO and the fact that we now print whether the database has been used (https://github.com/smol-dot/smoldot/issues/860) and whether the database was of the wrong chain.
