### PR TITLE
Don't require the genesis state for parachains

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -799,7 +799,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                                 "Chain specification of {} contains a `genesis.raw` item. It is \
                                 possible to significantly improve the initialization time by \
                                 replacing the `\"raw\": ...` field with \
-                                `\"stateTrieRoot\": \"0x{}\"`",
+                                `\"stateRootHash\": \"0x{}\"`",
                                 log_name, hex::encode(genesis_block_state_root)
                             )
                         }

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- It is now possible for parachain chain specifications to include just a `genesis.stateRootHash` field (and no `genesis.raw` field). A warning in the logs is now printed for all chain specifications that include a `genesis.raw` field.
+- It is now possible for parachain chain specifications to include just a `genesis.stateRootHash` field (and no `genesis.raw` field). A warning in the logs is now printed for all chain specifications that include a `genesis.raw` field. ([#1034](https://github.com/smol-dot/smoldot/pull/1034))
 
 ## 1.0.16 - 2023-08-14
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- It is now possible for parachain chain specifications to include just a `genesis.stateRootHash` field (and no `genesis.raw` field). A warning in the logs is now printed for all chain specifications that include a `genesis.raw` field.
+
 ## 1.0.16 - 2023-08-14
 
 ### Changed


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/908
cc https://github.com/smol-dot/smoldot/issues/864

When it comes to relay chains, it is mandatory for the chain spec to contain either the genesis state or a checkpoint, as otherwise it's not possible to verify warp sync proofs and in general not possible to sync at all.

When it comes to parachains, however, it is in principle possible to do with neither, as all the information we need is found in the relay chain.

However, before this PR, the restriction of having either the genesis state or checkpoint applied to both relay chains and parachains. Given that parachains can't have checkpoints, this has the consequence that the genesis state of parachains always had to be provided, and thus smoldot always had to build the runtime and calculate the state root, which uses a lot of CPU.
This PR fixes this.
