### PR TITLE
Use correct multihash algorithm code for WebRTC addresses

### DIFF
--- a/light-base/src/platform/address_parse.rs
+++ b/light-base/src/platform/address_parse.rs
@@ -107,7 +107,7 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
         ) => {
             // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
             let multihash = multihash::MultihashRef::from_bytes(&hash).unwrap();
-            if multihash.hash_algorithm_code() != 12 {
+            if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
             let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data())
@@ -129,7 +129,7 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
         ) => {
             // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
             let multihash = multihash::MultihashRef::from_bytes(&hash).unwrap();
-            if multihash.hash_algorithm_code() != 12 {
+            if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
             let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data())

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - It is now possible for parachain chain specifications to include just a `genesis.stateRootHash` field (and no `genesis.raw` field). A warning in the logs is now printed for all chain specifications that include a `genesis.raw` field. ([#1034](https://github.com/smol-dot/smoldot/pull/1034))
 
+### Fixed
+
+- Fix WebRTC addresses failing to be be parsed. ([#1036](https://github.com/smol-dot/smoldot/pull/1036))
+
 ## 1.0.16 - 2023-08-14
 
 ### Changed


### PR DESCRIPTION
Correct code for SHA256 multihash is `0x12`: https://github.com/multiformats/rust-multihash/blob/452a933396adcd5915c53563d5017df76ae3ec26/codetable/src/lib.rs#L44-L47