### PR TITLE
No longer clone the chain spec when creating services

### DIFF
--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -124,7 +124,7 @@ pub struct ConfigParachain<TPlat: PlatformRef> {
     ///
     /// > **Note**: This information is normally found in the chain specification of the
     /// >           parachain.
-    pub parachain_id: u32,
+    pub para_id: u32,
 }
 
 /// Identifier for a blocks request to be performed.
@@ -163,7 +163,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                         config.block_number_bytes,
                         config_parachain.relay_chain_sync.clone(),
                         config_parachain.relay_chain_block_number_bytes,
-                        config_parachain.parachain_id,
+                        config_parachain.para_id,
                         from_foreground,
                         config.network_service.0.clone(),
                         config.network_service.1,


### PR DESCRIPTION
Right now we always do `chain_spec.clone()` in order to send the copy of the chain spec to the background task that creates all the services. This is pretty wasteful, especially if the chain spec contains the genesis state.

This PR instead extracts all the necessary fields beforehand.
