### PR TITLE
Extract target IP address correctly

### DIFF
--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -293,14 +293,14 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
                 case 16: {
                     const targetPort = buffer.readUInt16BE(mem, addrPtr + 1);
                     const remoteTlsCertificateSha256 = mem.slice(addrPtr + 3, addrPtr + 35);
-                    const targetIp = buffer.utf8BytesToString(mem, addrPtr + 35, addrLen - 3);
+                    const targetIp = buffer.utf8BytesToString(mem, addrPtr + 35, addrLen - 35);
                     address = { ty: "webrtc", ipVersion: '4', remoteTlsCertificateSha256, targetIp, targetPort }
                     break;
                 }
                 case 17: {
                     const targetPort = buffer.readUInt16BE(mem, addrPtr + 1);
                     const remoteTlsCertificateSha256 = mem.slice(addrPtr + 3, addrPtr + 35);
-                    const targetIp = buffer.utf8BytesToString(mem, addrPtr + 35, addrLen - 3);
+                    const targetIp = buffer.utf8BytesToString(mem, addrPtr + 35, addrLen - 35);
                     address = { ty: "webrtc", ipVersion: '6', remoteTlsCertificateSha256, targetIp, targetPort }
                     break;
                 }


### PR DESCRIPTION
Read length was not set correctly, resulting the code to copy garbage to the end of the address, causing the SDP to be rejected.

Tested with both IPv4 and IPv6 addresses to be working correctly

---
Following error was printed in the logs:
```
no-auto-bytecode-browser.js:434 Uncaught (in promise) DOMException: Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Failed to parse SessionDescription. o=testing 0 0 IN IP4 192.168.1.173e23xhWot7LDAÃ¯Â¿Â½ Expect line: o=
    at eval (webpack://test-browser-node/../smoldot/wasm-node/javascript/dist/mjs/no-auto-bytecode-browser.js?:434:26)
    at Generator.next (<anonymous>)
    at fulfilled (webpack://test-browser-node/../smoldot/wasm-node/javascript/dist/mjs/no-auto-bytecode-browser.js?:19:58)
```