### PR TITLE
Only print trie root in chain spec warning if there's a checkpoint

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -798,7 +798,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         }
 
                         if print_warning_genesis_root_chainspec {
-                            log::warn!(
+                            log::info!(
                                 target: "smoldot",
                                 "Chain specification of {} contains a `genesis.raw` item. It is \
                                 possible to significantly improve the initialization time by \

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -388,7 +388,8 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                     (
                         Some(genesis_chain_information),
                         scale_encoded,
-                        chain_spec.light_sync_state().is_some(),
+                        chain_spec.light_sync_state().is_some()
+                            || chain_spec.relay_chain().is_some(),
                         state_root,
                     )
                 }

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -373,7 +373,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         let (
             genesis_chain_information,
             genesis_block_header,
-            genesis_root_in_chain_spec,
+            print_warning_genesis_root_chainspec,
             genesis_block_state_root,
         ) = {
             // TODO: don't build the chain information if only the genesis hash is needed: https://github.com/smol-dot/smoldot/issues/1017
@@ -388,7 +388,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                     (
                         Some(genesis_chain_information),
                         scale_encoded,
-                        false,
+                        chain_spec.light_sync_state().is_some(),
                         state_root,
                     )
                 }
@@ -402,7 +402,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                         digest: header::DigestRef::empty().into(),
                     }
                     .scale_encoding_vec(usize::from(chain_spec.block_number_bytes()));
-                    (None, header, true, state_root)
+                    (None, header, false, state_root)
                 }
                 Err(err) => return Err(AddChainError::InvalidGenesisStorage(err)),
             }
@@ -796,7 +796,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                             );
                         }
 
-                        if !genesis_root_in_chain_spec {
+                        if print_warning_genesis_root_chainspec {
                             log::warn!(
                                 target: "smoldot",
                                 "Chain specification of {} contains a `genesis.raw` item. It is \


### PR DESCRIPTION
After https://github.com/smol-dot/smoldot/pull/1034 we're printing a warning when the chain spec contains a `raw` key.
However, we shouldn't do this if the chain spec doesn't contain a checkpoint, as following the instructions printed in the warning will lead to an unusable chain spec.