### PR TITLE
Use `num_traits::ToPrimitive` instead of `u32::TryFrom`

### DIFF
--- a/lib/src/verify/babe.rs
+++ b/lib/src/verify/babe.rs
@@ -482,7 +482,10 @@ pub fn verify_header(config: VerifyConfig) -> Result<VerifySuccess, VerifyError>
             hash % authorities_len
         };
 
-        if u32::try_from(expected_authority_index).map_or(true, |v| v != authority_index) {
+        if expected_authority_index
+            .to_u32()
+            .map_or(true, |v| v != authority_index)
+        {
             return Err(VerifyError::BadSecondarySlotAuthor);
         }
     }


### PR DESCRIPTION
I don't really understand why, but when experimenting with https://github.com/smol-dot/smoldot/issues/88 I got compilation errors saying that `TryFrom<BigInt>` wasn't implemented for `u32`. The source code of `num_bigint` seems to do a lot of conditional compilation magic, which I don't want to dig into, so the easiest way to fix this problem is to use the `num_traits::ToPrimitive` trait which we already import anyway.