### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     - uses: baptiste0928/cargo-install@v2  # This action ensures that the compilation is cached.
       with:
         crate: cargo-fuzz
-        locked: false   # TODO: `cargo-fuzz fails to compile with --locked because its Cargo.lock contains very old dependencies`
+        locked: false   # TODO: `cargo-fuzz` fails to compile with --locked because its Cargo.lock contains very old dependencies
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
     - uses: baptiste0928/cargo-install@v2  # This action ensures that the compilation is cached.
       with:
         crate: cargo-fuzz
+        locked: false   # TODO: `cargo-fuzz fails to compile with --locked because its Cargo.lock contains very old dependencies`
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |


### PR DESCRIPTION
This PR fixes the CI failures in https://github.com/smol-dot/smoldot/pull/1048 and https://github.com/smol-dot/smoldot/pull/1049

The problem happened because `cargo-install`, the GitHub action that installs `cargo-fuzz`, started using `locked: true` by default in its version 2.
Unfortunately, `cargo-fuzz` has a very old `Cargo.lock` and thus fails to compile with `locked: true`.
Because `cargo-install` caches the compiled version, the compilation failure wasn't immediately detected when updating `cargo-install` to version 2.
