### PR TITLE
`ChainInformationBuild` now accepts `Any` with a genesis block

### DIFF
--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1447,17 +1447,12 @@ impl<TSrc, TRq> BuildRuntime<TSrc, TRq> {
 
             let chain_info_builder = chain_information::build::ChainInformationBuild::new(
                 chain_information::build::Config {
-                    finalized_block_header: if header.number == 0 {
-                        chain_information::build::ConfigFinalizedBlockHeader::Genesis {
-                            state_trie_root_hash: header.state_root,
-                        }
-                    } else {
-                        chain_information::build::ConfigFinalizedBlockHeader::NonGenesis {
+                    finalized_block_header:
+                        chain_information::build::ConfigFinalizedBlockHeader::Any {
                             scale_encoded_header: header
                                 .scale_encoding_vec(self.inner.block_number_bytes),
                             known_finality: Some(chain_information_finality.clone()),
-                        }
-                    },
+                        },
                     block_number_bytes: self.inner.block_number_bytes,
                     runtime,
                 },


### PR DESCRIPTION
Doing so currently panics, because the internal logic is slightly different between the genesis and non-genesis block.

However, it's pretty error-prone to panic in this situation, and it's better if we just accept passing the genesis block even for the non-genesis variant.
That variant has thus been renamed `Any`.