### PR TITLE
Cache request IDs in the warp sync state machine

### DIFF
--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -328,7 +328,6 @@ pub struct InProgressWarpSync<TSrc, TRq> {
     /// List of requests that have been added using [`InProgressWarpSync::add_source`].
     sources: slab::Slab<Source<TSrc>>,
     /// List of requests that have been added using [`InProgressWarpSync::add_request`].
-    // TODO: is the RequestDetail needed after we've cached the request_ids directly in the phase?
     in_progress_requests: slab::Slab<(SourceId, TRq, RequestDetail)>,
 }
 


### PR DESCRIPTION
At the moment, the `desired_requests` function performs a ton of looping around and checks.
This is very inefficient, as this function is called very very often.
Instead, this PR moves the checks to `add_request`, which is called way less often, by caching the IDs of interesting requests in progress.

The checks are now also `O(1)` rather than `O(n)` (where `n` is the number of requests).
