### PR TITLE
Install Rust the same way in all CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
       image: rust:1.71
     steps:
       - uses: actions/checkout@v3
+    - run: sudo apt-get update && sudo apt install -y jq
       # Compares whether the version in `package.json` matches the version in `Cargo.toml`.
       - id: js-version
         run: echo "version=`jq .version ./wasm-node/javascript/package.json`" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,15 +98,14 @@ jobs:
 
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest
+    container:
+      image: rust:1.71
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        # Since build artifacts are specific to a nightly version, we pin the specific nightly
-        # version to use in order to not invalidate the build cache every day. The exact version
-        # is completely arbitrary.
-        toolchain: nightly-2023-07-15
-        override: true
+      # Since build artifacts are specific to a nightly version, we pin the specific nightly
+      # version to use in order to not invalidate the build cache every day. The exact version
+      # is completely arbitrary.
+    - run: rustup default nightly-2023-07-15
     - uses: baptiste0928/cargo-install@v2  # This action ensures that the compilation is cached.
       with:
         crate: cargo-fuzz
@@ -128,13 +127,11 @@ jobs:
 
   fmt:
     runs-on: ubuntu-latest
+    container:
+      image: rust:1.71
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
@@ -149,13 +146,14 @@ jobs:
   # TODO: as explained in the official repo (https://github.com/actions-rs/clippy), this action uses unstable GH actions features, but has the huge advantage of not requiring `GITHUB_TOKEN` and working on PRs from forked repositories ; should eventually replace `actions-rs/clippy@master` with a specific version
   clippy:
     runs-on: ubuntu-latest
+    container:
+      image: rust:1.71
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            components: clippy
-            override: true
+        # Since build artifacts are specific to a nightly version, we pin the specific nightly
+        # version to use in order to not invalidate the build cache every day. The exact version
+        # is completely arbitrary.
+      - run: rustup default nightly-2023-07-15
       - uses: Swatinem/rust-cache@v2  # Note that this is done after switching the compiler version to nightly
       - uses: actions-rs/clippy@master
         with:
@@ -189,12 +187,10 @@ jobs:
 
   wasm-node-versions-match:
     runs-on: ubuntu-latest
+    container:
+      image: rust:1.71
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
       # Compares whether the version in `package.json` matches the version in `Cargo.toml`.
       - id: js-version
         run: echo "version=`jq .version ./wasm-node/javascript/package.json`" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       image: rust:1.71
     steps:
       - uses: actions/checkout@v3
-    - run: sudo apt-get update && sudo apt install -y jq
+      - run: apt-get update && apt install -y jq
       # Compares whether the version in `package.json` matches the version in `Cargo.toml`.
       - id: js-version
         run: echo "version=`jq .version ./wasm-node/javascript/package.json`" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,6 +203,7 @@ jobs:
     # This action checks if a certain git tag exists. If not, it compiles the JavaScript package,
     # then commits the compilation artifacts, tags the commit, and pushes the tag.
     steps:
+      - run: apt-get update && apt install -y jq
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0   # Necessary below for checking if the tag exists.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,6 +223,8 @@ jobs:
         working-directory: ./wasm-node/javascript
       - run: cp ./README.md ./dist/mjs
         working-directory: ./wasm-node/javascript
+      - run: pwd
+      - run: ls -al
         # TODO: bypasses a `detected dubious ownership in repository` issue with older versions of git
       - run: git config --add safe.directory *  --global
       - run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: stable
+          toolchain: 1.71
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,7 @@ jobs:
     # then commits the compilation artifacts, tags the commit, and pushes the tag.
     steps:
       - run: apt-get update && apt install -y jq
+      - run: apt upgrade -y git
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0   # Necessary below for checking if the tag exists.
@@ -227,7 +228,7 @@ jobs:
       - run: pwd
       - run: ls -al
         # TODO: bypasses a `detected dubious ownership in repository` issue with older versions of git
-      - run: git config --add safe.directory *  --global
+      - run: git status
       - run: |
           git add --force ./wasm-node/javascript/dist/mjs  # --force bypasses the .gitignore
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,11 +180,6 @@ jobs:
         with:
           # Set the oldest version still maintained, in order to ensure compatibility. See <https://nodejs.dev/en/about/releases/>
           node-version: 16
-      - uses: actions-rs/toolchain@v1
-        with:
-          # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: stable
-          profile: minimal
       - uses: Swatinem/rust-cache@v2
       - run: npm install
         working-directory: ./wasm-node/javascript
@@ -201,6 +196,8 @@ jobs:
 
   deno-publish:
     runs-on: ubuntu-latest
+    container:
+      image: rust:1.71
     permissions:
       contents: write   # Necessary in order to push tags.
     # This action checks if a certain git tag exists. If not, it compiles the JavaScript package,
@@ -215,11 +212,6 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - uses: actions-rs/toolchain@v1
-        with:
-          # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: stable
-          profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
         run: echo "tag=light-js-deno-v`jq -r .version ./wasm-node/javascript/package.json`" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,6 +223,8 @@ jobs:
         working-directory: ./wasm-node/javascript
       - run: cp ./README.md ./dist/mjs
         working-directory: ./wasm-node/javascript
+        # TODO: bypasses a `detected dubious ownership in repository` issue with older versions of git
+      - run: git config --add safe.directory *  --global
       - run: |
           git add --force ./wasm-node/javascript/dist/mjs  # --force bypasses the .gitignore
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,15 +196,11 @@ jobs:
 
   deno-publish:
     runs-on: ubuntu-latest
-    container:
-      image: rust:1.71
     permissions:
       contents: write   # Necessary in order to push tags.
     # This action checks if a certain git tag exists. If not, it compiles the JavaScript package,
     # then commits the compilation artifacts, tags the commit, and pushes the tag.
     steps:
-      - run: apt-get update && apt install -y jq
-      - run: apt upgrade -y git
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0   # Necessary below for checking if the tag exists.
@@ -214,6 +210,12 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+      # TODO: do not use `actions-rs/toolchain` but instead use `image: rust:...` like all the other stages; unfortunately this causes incomprehensible `detected dubious ownership in repository` git errors
+      - uses: actions-rs/toolchain@v1
+        with:
+          # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
+          toolchain: stable
+          profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
         run: echo "tag=light-js-deno-v`jq -r .version ./wasm-node/javascript/package.json`" >> $GITHUB_OUTPUT
@@ -225,10 +227,6 @@ jobs:
         working-directory: ./wasm-node/javascript
       - run: cp ./README.md ./dist/mjs
         working-directory: ./wasm-node/javascript
-      - run: pwd
-      - run: ls -al
-        # TODO: bypasses a `detected dubious ownership in repository` issue with older versions of git
-      - run: git status
       - run: |
           git add --force ./wasm-node/javascript/dist/mjs  # --force bypasses the .gitignore
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Right now, some jobs use `container: image: rust:1.71` while some others use `actions-rs/toolchain`.
This PR switches everything to the `rust:1.71` image.

Fixes the CI failure in https://github.com/smol-dot/smoldot/pull/1065 and https://github.com/smol-dot/smoldot/pull/1068 by switching back to Rust 1.71 instead of the newly-released 1.72.