### PR TITLE
Update to Rust 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
@@ -65,7 +65,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
@@ -99,7 +99,7 @@ jobs:
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
       # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -119,7 +119,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2
@@ -128,7 +128,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v3
@@ -147,7 +147,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -188,7 +188,7 @@ jobs:
   wasm-node-versions-match:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
       - run: apt-get update && apt install -y jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
   build-js-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
         with:
@@ -82,7 +82,7 @@ jobs:
   build-rust-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
         with:
@@ -103,7 +103,7 @@ jobs:
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - run: apt update && apt install -y jq
       - run: rustup component add llvm-tools-preview
@@ -173,7 +173,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.8.1
@@ -214,7 +214,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: 1.71
+          toolchain: 1.72
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
@@ -241,7 +241,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
       - uses: actions/checkout@v3
       - run: cargo publish --dry-run --locked

--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-update:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.71
+      image: rust:1.72
     steps:
     - uses: actions/checkout@v3
     # Note: `cargo update --workspace` doesn't seem to have any effect.

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -1663,12 +1663,11 @@ impl ReadyToRun {
                 })
             }
             HostFunction::ext_crypto_finish_batch_verify_version_1 => {
-                let Some(outcome) = self.inner.signatures_batch_verification.take()
-                else {
+                let Some(outcome) = self.inner.signatures_batch_verification.take() else {
                     return HostVm::Error {
                         error: Error::NoBatchVerify,
                         prototype: self.inner.into_prototype(),
-                    }
+                    };
                 };
 
                 HostVm::ReadyToRun(ReadyToRun {

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -1248,8 +1248,7 @@ impl CipherState {
                 debug_assert!(overlapping_data.len() < 64);
 
                 // Return if iterator has finished.
-                let Some(mac_deref) = mac.as_mut()
-                else {
+                let Some(mac_deref) = mac.as_mut() else {
                     return None;
                 };
 

--- a/lib/src/libp2p/read_write.rs
+++ b/lib/src/libp2p/read_write.rs
@@ -132,10 +132,9 @@ impl<TNow> ReadWrite<TNow> {
     pub fn incoming_bytes_take_array<const N: usize>(
         &mut self,
     ) -> Result<Option<[u8; N]>, IncomingBytesTakeError> {
-        let Some(vec) = self.incoming_bytes_take(N)?
-            else {
-                return Ok(None)
-            };
+        let Some(vec) = self.incoming_bytes_take(N)? else {
+            return Ok(None);
+        };
 
         let bytes = <&[u8; N]>::try_from(&vec[..]).unwrap();
         Ok(Some(*bytes))

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1517,7 +1517,9 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
 
                 for (call, proof) in calls {
                     let CallProof::Downloaded(proof) = mem::replace(proof, CallProof::NotStarted)
-                        else { unreachable!() };
+                    else {
+                        unreachable!()
+                    };
                     let decoded_proof =
                         match proof_decode::decode_and_verify_proof(proof_decode::Config {
                             proof: proof.into_iter(),

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -370,8 +370,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::chainHead_unstable_continue`].
     pub(super) async fn chain_head_continue(self: &Arc<Self>, request: service::RequestProcess) {
-        let methods::MethodCall::chainHead_unstable_continue { .. } = request.request()
-        else {
+        let methods::MethodCall::chainHead_unstable_continue { .. } = request.request() else {
             unreachable!()
         };
         // TODO: not implemented properly
@@ -874,11 +873,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
     }
 
     async fn start_chain_head_body(&mut self, request: service::RequestProcess) {
-        let methods::MethodCall::chainHead_unstable_body {
-            hash,
-            ..
-        } = request.request()
-        else {
+        let methods::MethodCall::chainHead_unstable_body { hash, .. } = request.request() else {
             unreachable!()
         };
 

--- a/light-base/src/platform/address_parse.rs
+++ b/light-base/src/platform/address_parse.rs
@@ -110,10 +110,9 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
-            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data())
-                else {
-                    return Err(Error::InvalidMultihashLength);
-                };
+            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data()) else {
+                return Err(Error::InvalidMultihashLength);
+            };
             AddressOrMultiStreamAddress::MultiStreamAddress(MultiStreamAddress::WebRtc {
                 ip: IpAddr::V4(ip),
                 port,
@@ -132,10 +131,9 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
-            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data())
-                else {
-                    return Err(Error::InvalidMultihashLength);
-                };
+            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data()) else {
+                return Err(Error::InvalidMultihashLength);
+            };
             AddressOrMultiStreamAddress::MultiStreamAddress(MultiStreamAddress::WebRtc {
                 ip: IpAddr::V6(ip),
                 port,

--- a/wasm-node/javascript/prepare.mjs
+++ b/wasm-node/javascript/prepare.mjs
@@ -38,7 +38,7 @@ if (buildProfile != 'debug' && buildProfile != 'min-size-release')
 // The Rust version is pinned because the wasi target is still unstable. Without pinning, it is
 // possible for the wasm-js bindings to change between two Rust versions. Feel free to update
 // this version pin whenever you like, provided it continues to build.
-const rustVersion = '1.71.0';
+const rustVersion = '1.72.0';
 
 // Assume that the user has `rustup` installed and make sure that `rust_version` is available.
 // Because `rustup install` requires an Internet connection, check whether the toolchain is


### PR DESCRIPTION
https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html

There isn't much noticeable, except for the fact that `rustfmt` now supports `let-else`.