### PR TITLE
Fix `wake_up_after` being ignored in established/tests

### DIFF
--- a/lib/src/libp2p/connection/established/tests.rs
+++ b/lib/src/libp2p/connection/established/tests.rs
@@ -204,6 +204,7 @@ impl TwoEstablished {
                 self.bob_to_alice_buffer_size,
                 alice_read_write.expected_incoming_bytes.unwrap_or(0),
             );
+            self.wake_up_after = alice_read_write.wake_up_after;
 
             if let Some(event) = alice_event {
                 return (self, either::Left(event));
@@ -237,6 +238,7 @@ impl TwoEstablished {
                 self.alice_to_bob_buffer_size,
                 bob_read_write.expected_incoming_bytes.unwrap_or(0),
             );
+            self.wake_up_after = bob_read_write.wake_up_after;
 
             if let Some(event) = bob_event {
                 return (self, either::Right(event));


### PR DESCRIPTION
Right now the tests pass anyway because of implementation details of `established.rs`.
However, this fix is needed for https://github.com/smol-dot/smoldot/pull/958.