### PR TITLE
Always start the JSON-RPC service in the full node

### DIFF
--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -377,8 +377,8 @@ async fn run(cli_options: cli::CliOptionsRun) {
         relay_chain,
         libp2p_key,
         listen_addresses: cli_options.listen_addr,
-        json_rpc: if let Some(address) = cli_options.json_rpc_address.0 {
-            Some(smoldot_full_node::JsonRpcConfig {
+        json_rpc_listen: if let Some(address) = cli_options.json_rpc_address.0 {
+            Some(smoldot_full_node::JsonRpcListenConfig {
                 address,
                 max_json_rpc_clients: cli_options.json_rpc_max_clients,
             })

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -52,8 +52,8 @@ pub struct Config {
     /// Database to access blocks.
     pub database: Arc<database_thread::DatabaseThread>,
 
-    /// Where to bind the WebSocket server.
-    pub bind_address: SocketAddr,
+    /// Where to bind the WebSocket server. If `None`, no TCP server is started.
+    pub bind_address: Option<SocketAddr>,
 
     /// Maximum number of requests to process in parallel.
     pub max_parallel_requests: u32,
@@ -71,7 +71,9 @@ pub struct Config {
     pub genesis_block_hash: [u8; 32],
 }
 
-/// Running JSON-RPC service. Holds a server open for as long as it is alive.
+/// Running JSON-RPC service.
+///
+/// If [`Config::bind_address`] is `Some`, holds a TCP server open for as long as it is alive.
 ///
 /// In addition to a TCP/IP server, this service also provides a virtual JSON-RPC endpoint that
 /// can be used through [`JsonRpcService::send_request`] and [`JsonRpcService::next_response`].
@@ -80,7 +82,7 @@ pub struct JsonRpcService {
     service_dropped: event_listener::Event,
 
     /// Address the server is listening on. Not necessarily equal to [`Config::bind_address`].
-    listen_addr: SocketAddr,
+    listen_addr: Option<SocketAddr>,
 
     /// I/O for the virtual endpoint.
     virtual_client_io: service::SerializedRequestsIo,
@@ -95,24 +97,29 @@ impl Drop for JsonRpcService {
 impl JsonRpcService {
     /// Initializes a new [`JsonRpcService`].
     pub async fn new(config: Config) -> Result<Self, InitError> {
-        let tcp_listener = match TcpListener::bind(&config.bind_address).await {
-            Ok(s) => s,
-            Err(error) => {
-                return Err(InitError::ListenError {
-                    bind_address: config.bind_address,
-                    error,
-                })
-            }
-        };
+        let (tcp_listener, listen_addr) = match &config.bind_address {
+            Some(addr) => match TcpListener::bind(addr).await {
+                Ok(listener) => {
+                    let listen_addr = match listener.local_addr() {
+                        Ok(addr) => addr,
+                        Err(error) => {
+                            return Err(InitError::ListenError {
+                                bind_address: addr.clone(),
+                                error,
+                            })
+                        }
+                    };
 
-        let listen_addr = match tcp_listener.local_addr() {
-            Ok(addr) => addr,
-            Err(error) => {
-                return Err(InitError::ListenError {
-                    bind_address: config.bind_address,
-                    error,
-                })
-            }
+                    (Some(listener), Some(listen_addr))
+                }
+                Err(error) => {
+                    return Err(InitError::ListenError {
+                        bind_address: addr.clone(),
+                        error,
+                    })
+                }
+            },
+            None => (None, None),
         };
 
         let service_dropped = event_listener::Event::new();
@@ -144,17 +151,19 @@ impl JsonRpcService {
             });
         }
 
-        let background = JsonRpcBackground {
-            tcp_listener,
-            on_service_dropped,
-            tasks_executor: config.tasks_executor.clone(),
-            log_callback: config.log_callback,
-            to_requests_handlers,
-            num_json_rpc_clients: Arc::new(AtomicU32::new(0)),
-            max_json_rpc_clients: config.max_json_rpc_clients,
-        };
+        if let Some(tcp_listener) = tcp_listener {
+            let background = JsonRpcBackground {
+                tcp_listener,
+                on_service_dropped,
+                tasks_executor: config.tasks_executor.clone(),
+                log_callback: config.log_callback,
+                to_requests_handlers,
+                num_json_rpc_clients: Arc::new(AtomicU32::new(0)),
+                max_json_rpc_clients: config.max_json_rpc_clients,
+            };
 
-        (config.tasks_executor)(Box::pin(async move { background.run().await }));
+            (config.tasks_executor)(Box::pin(async move { background.run().await }));
+        }
 
         Ok(JsonRpcService {
             service_dropped,
@@ -163,9 +172,11 @@ impl JsonRpcService {
         })
     }
 
-    /// Returns the address the server is listening on. Not necessarily equal
-    /// to [`Config::bind_address`].
-    pub fn listen_addr(&self) -> SocketAddr {
+    /// Returns the address the server is listening on.
+    ///
+    /// Returns `None` if and only if [`Config::bind_address`] was `None`. However, if `Some`,
+    /// the address is not necessarily equal to the one in [`Config::bind_address`].
+    pub fn listen_addr(&self) -> Option<SocketAddr> {
         self.listen_addr.clone()
     }
 

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -54,8 +54,8 @@ pub struct Config<'a> {
     pub libp2p_key: Box<[u8; 32]>,
     /// List of addresses to listen on.
     pub listen_addresses: Vec<multiaddr::Multiaddr>,
-    /// Configuration of the JSON-RPC server. If `None`, no server is started.
-    pub json_rpc: Option<JsonRpcConfig>,
+    /// Configuration of the JSON-RPC server. If `None`, no TCP server is started.
+    pub json_rpc_listen: Option<JsonRpcListenConfig>,
     /// Function that can be used to spawn background tasks.
     ///
     /// The tasks passed as parameter must be executed until they shut down.
@@ -66,8 +66,8 @@ pub struct Config<'a> {
     pub jaeger_agent: Option<SocketAddr>,
 }
 
-/// See [`Config::json_rpc`].
-pub struct JsonRpcConfig {
+/// See [`Config::json_rpc_listen`].
+pub struct JsonRpcListenConfig {
     /// Bind point of the JSON-RPC server.
     pub address: SocketAddr,
     /// Maximum number of JSON-RPC clients that can be connected at the same time.
@@ -122,7 +122,7 @@ pub struct ChainConfig<'a> {
 /// Running client. As long as this object is alive, the client reads/writes the database and has
 /// a JSON-RPC server open.
 pub struct Client {
-    json_rpc_service: Option<json_rpc_service::JsonRpcService>,
+    json_rpc_service: json_rpc_service::JsonRpcService,
     consensus_service: Arc<consensus_service::ConsensusService>,
     relay_chain_consensus_service: Option<Arc<consensus_service::ConsensusService>>,
     network_service: Arc<network_service::NetworkService>,
@@ -132,9 +132,9 @@ pub struct Client {
 impl Client {
     /// Returns the address the JSON-RPC server is listening on.
     ///
-    /// Returns `None` if and only if [`Config::json_rpc`] was `None`.
+    /// Returns `None` if and only if [`Config::json_rpc_listen`] was `None`.
     pub fn json_rpc_server_addr(&self) -> Option<SocketAddr> {
-        self.json_rpc_service.as_ref().map(|j| j.listen_addr())
+        self.json_rpc_service.listen_addr()
     }
 
     /// Returns the best block according to the networking.
@@ -171,15 +171,9 @@ impl Client {
     ///
     /// The virtual endpoint doesn't have any limit.
     ///
-    /// Returns an error if the JSON-RPC request is malformed or if [`Config::json_rpc`] was
-    /// `None`.
-    pub fn send_json_rpc_request(&self, request: String) -> Result<(), SendJsonRpcRequestError> {
-        match &self.json_rpc_service {
-            Some(s) => s
-                .send_request(request)
-                .map_err(SendJsonRpcRequestError::ParseError),
-            None => Err(SendJsonRpcRequestError::NoJsonRpcService),
-        }
+    /// Returns an error if the JSON-RPC request is malformed.
+    pub fn send_json_rpc_request(&self, request: String) -> Result<(), JsonRpcRequestParseError> {
+        self.json_rpc_service.send_request(request)
     }
 
     /// Returns the new JSON-RPC response or notification for requests sent using
@@ -187,13 +181,8 @@ impl Client {
     ///
     /// If this function is called multiple times simultaneously, only one invocation will receive
     /// each response. Which one is unspecified.
-    ///
-    /// If [`Config::json_rpc`] was `None`, then this function waits forever and never returns.
     pub async fn next_json_rpc_response(&self) -> String {
-        match &self.json_rpc_service {
-            Some(s) => s.next_response().await,
-            None => future::pending().await,
-        }
+        self.json_rpc_service.next_response().await
     }
 }
 
@@ -220,15 +209,6 @@ pub enum StartError {
     RelayChainKeystoreInit(io::Error),
     /// Error initializing the Jaeger service.
     JaegerInit(io::Error),
-}
-
-/// Error potentially returned by [`Client::send_json_rpc_request`].
-#[derive(Debug, derive_more::Display)]
-pub enum SendJsonRpcRequestError {
-    /// Failed to parse the JSON-RPC request.
-    ParseError(JsonRpcRequestParseError),
-    /// No JSON-RPC service was started.
-    NoJsonRpcService,
 }
 
 /// Runs the node using the given configuration.
@@ -578,34 +558,31 @@ pub async fn start(mut config: Config<'_>) -> Result<Client, StartError> {
     // Start the JSON-RPC service.
     // It only needs to be kept alive in order to function.
     //
-    // Note that initialization can panic if, for example, the port is already occupied. It is
+    // Note that initialization can fail if, for example, the port is already occupied. It is
     // preferable to fail to start the node altogether rather than make the user believe that they
     // are connected to the JSON-RPC endpoint of the node while they are in reality connected to
     // something else.
-    let json_rpc_service = if let Some(json_rpc_config) = config.json_rpc {
-        let result = json_rpc_service::JsonRpcService::new(json_rpc_service::Config {
-            tasks_executor: config.tasks_executor.clone(),
-            log_callback: config.log_callback.clone(),
-            database,
-            bind_address: json_rpc_config.address,
-            max_parallel_requests: 32,
-            max_json_rpc_clients: json_rpc_config.max_json_rpc_clients,
-            chain_name: chain_spec.name().to_owned(),
-            chain_properties_json: chain_spec.properties().to_owned(),
-            genesis_block_hash: genesis_chain_information
-                .as_ref()
-                .finalized_block_header
-                .hash(usize::from(chain_spec.block_number_bytes())),
-        })
-        .await;
-
-        Some(match result {
-            Ok(service) => service,
-            Err(err) => return Err(StartError::JsonRpcServiceInit(err)),
-        })
-    } else {
-        None
-    };
+    let json_rpc_service = json_rpc_service::JsonRpcService::new(json_rpc_service::Config {
+        tasks_executor: config.tasks_executor.clone(),
+        log_callback: config.log_callback.clone(),
+        database,
+        bind_address: config
+            .json_rpc_listen
+            .as_ref()
+            .map(|cfg| cfg.address.clone()),
+        max_parallel_requests: 32,
+        max_json_rpc_clients: config
+            .json_rpc_listen
+            .map_or(0, |cfg| cfg.max_json_rpc_clients),
+        chain_name: chain_spec.name().to_owned(),
+        chain_properties_json: chain_spec.properties().to_owned(),
+        genesis_block_hash: genesis_chain_information
+            .as_ref()
+            .finalized_block_header
+            .hash(usize::from(chain_spec.block_number_bytes())),
+    })
+    .await
+    .map_err(StartError::JsonRpcServiceInit)?;
 
     // Spawn the task printing the informant.
     // This is not just a dummy task that just prints on the output, but is actually the main

--- a/full-node/tests/author.rs
+++ b/full-node/tests/author.rs
@@ -35,7 +35,7 @@ fn basic_block_generated() {
             relay_chain: None,
             libp2p_key: Box::new([0; 32]),
             listen_addresses: Vec::new(),
-            json_rpc: None,
+            json_rpc_listen: None,
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
             log_callback: Arc::new(move |_, _| {}),
             jaeger_agent: None,

--- a/full-node/tests/json-rpc-basic.rs
+++ b/full-node/tests/json-rpc-basic.rs
@@ -18,39 +18,6 @@
 use std::sync::Arc;
 
 #[test]
-fn send_request_errs_if_no_server() {
-    smol::block_on(async move {
-        let client = smoldot_full_node::start(smoldot_full_node::Config {
-            chain: smoldot_full_node::ChainConfig {
-                chain_spec: (&include_bytes!("./substrate-node-template.json")[..]).into(),
-                additional_bootnodes: Vec::new(),
-                keystore_memory: vec![],
-                sqlite_database_path: None,
-                sqlite_cache_size: 256 * 1024 * 1024,
-                keystore_path: None,
-            },
-            relay_chain: None,
-            libp2p_key: Box::new([0; 32]),
-            listen_addresses: Vec::new(),
-            json_rpc: None,
-            tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
-            log_callback: Arc::new(move |_, _| {}),
-            jaeger_agent: None,
-        })
-        .await
-        .unwrap();
-
-        assert!(matches!(
-            client.send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_genesisHash","params":[]}"#
-                    .to_owned(),
-            ),
-            Err(smoldot_full_node::SendJsonRpcRequestError::NoJsonRpcService)
-        ));
-    });
-}
-
-#[test]
 fn send_request_errs_if_malformed() {
     smol::block_on(async move {
         let client = smoldot_full_node::start(smoldot_full_node::Config {
@@ -65,10 +32,7 @@ fn send_request_errs_if_malformed() {
             relay_chain: None,
             libp2p_key: Box::new([0; 32]),
             listen_addresses: Vec::new(),
-            json_rpc: Some(smoldot_full_node::JsonRpcConfig {
-                address: "127.0.0.1:0".parse().unwrap(),
-                max_json_rpc_clients: 0,
-            }),
+            json_rpc_listen: None,
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
             log_callback: Arc::new(move |_, _| {}),
             jaeger_agent: None,
@@ -78,7 +42,7 @@ fn send_request_errs_if_malformed() {
 
         assert!(matches!(
             client.send_json_rpc_request(r#"thisisnotproperjsonrpc"#.to_owned(),),
-            Err(smoldot_full_node::SendJsonRpcRequestError::ParseError(_))
+            Err(smoldot_full_node::JsonRpcRequestParseError { .. })
         ));
     });
 }
@@ -98,10 +62,7 @@ fn send_request_works_if_unknown_request() {
             relay_chain: None,
             libp2p_key: Box::new([0; 32]),
             listen_addresses: Vec::new(),
-            json_rpc: Some(smoldot_full_node::JsonRpcConfig {
-                address: "127.0.0.1:0".parse().unwrap(),
-                max_json_rpc_clients: 0,
-            }),
+            json_rpc_listen: None,
             tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
             log_callback: Arc::new(move |_, _| {}),
             jaeger_agent: None,

--- a/full-node/tests/json-rpc-general-requests.rs
+++ b/full-node/tests/json-rpc-general-requests.rs
@@ -30,10 +30,7 @@ async fn start_client() -> smoldot_full_node::Client {
         relay_chain: None,
         libp2p_key: Box::new([0; 32]),
         listen_addresses: Vec::new(),
-        json_rpc: Some(smoldot_full_node::JsonRpcConfig {
-            address: "127.0.0.1:0".parse().unwrap(),
-            max_json_rpc_clients: 0,
-        }),
+        json_rpc_listen: None,
         tasks_executor: Arc::new(|task| smol::spawn(task).detach()),
         log_callback: Arc::new(move |_, _| {}),
         jaeger_agent: None,


### PR DESCRIPTION
Before this PR, the full node only starts the JSON-RPC service if a listen address is provided.

After https://github.com/smol-dot/smoldot/pull/1075, this is a bit awkward as it forces you to open a TCP listener even if you only want to communicate locally with the JSON-RPC service.

This PR changes that to always start a JSON-RPC service no matter what, and the TCP listener is started only if a listen address is provided.

The potential resources saving for not starting a JSON-RPC service are IMO negligible and not worth the complexity.
