### PR TITLE
Remove `AccessError` from database

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -1409,7 +1409,7 @@ async fn blocks_request_response(
     database: &database_thread::DatabaseThread,
     block_number_bytes: usize,
     config: protocol::BlocksRequestConfig,
-) -> Result<Vec<protocol::BlockData>, full_sqlite::AccessError> {
+) -> Result<Vec<protocol::BlockData>, full_sqlite::CorruptedError> {
     database
         .with_database(move |database| {
             let num_blocks = cmp::min(

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -218,7 +218,7 @@ impl SqliteFullDatabase {
     /// In order to avoid race conditions, the known finalized block hash must be passed as
     /// parameter. If the finalized block in the database doesn't match the hash passed as
     /// parameter, most likely because it has been updated in a parallel thread, a
-    /// [`StorageAccessError::Pruned`] error is returned.
+    /// [`StorageAccessError::StoragePruned`] error is returned.
     pub fn to_chain_information(
         &self,
         finalized_block_hash: &[u8; 32],

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -43,12 +43,13 @@
 //! # About errors handling
 //!
 //! Most of the functions and methods in this module return a `Result` containing notably an
-//! [`AccessError`]. This kind of errors can happen if the operating system returns an error when
-//! accessing the file system, or if the database has been corrupted, for example by the user
+//! [`CorruptedError`]. This kind of errors can happen if the operating system returns an error
+//! when accessing the file system, or if the database has been corrupted, for example by the user
 //! manually modifying it.
 //!
-//! There isn't much that can be done to properly handle an [`AccessError`]. The only reasonable
-//! solutions are either to stop the program, or to delete the entire database and recreate it.
+//! There isn't much that can be done to properly handle an [`CorruptedError`]. The only
+//! reasonable solutions are either to stop the program, or to delete the entire database and
+//! recreate it.
 //!
 //! # Schema
 //!
@@ -104,22 +105,21 @@ pub struct SqliteFullDatabase {
 
 impl SqliteFullDatabase {
     /// Returns the hash of the block in the database whose storage is currently accessible.
-    pub fn best_block_hash(&self) -> Result<[u8; 32], AccessError> {
+    pub fn best_block_hash(&self) -> Result<[u8; 32], CorruptedError> {
         let connection = self.database.lock();
 
-        let val = meta_get_blob(&connection, "best")?
-            .ok_or(AccessError::Corrupted(CorruptedError::MissingMetaKey))?;
+        let val = meta_get_blob(&connection, "best")?.ok_or(CorruptedError::MissingMetaKey)?;
         if val.len() == 32 {
             let mut out = [0; 32];
             out.copy_from_slice(&val);
             Ok(out)
         } else {
-            Err(AccessError::Corrupted(CorruptedError::InvalidBlockHashLen))
+            Err(CorruptedError::InvalidBlockHashLen)
         }
     }
 
     /// Returns the hash of the finalized block in the database.
-    pub fn finalized_block_hash(&self) -> Result<[u8; 32], AccessError> {
+    pub fn finalized_block_hash(&self) -> Result<[u8; 32], CorruptedError> {
         let database = self.database.lock();
         finalized_hash(&database)
     }
@@ -132,7 +132,7 @@ impl SqliteFullDatabase {
     pub fn block_scale_encoded_header(
         &self,
         block_hash: &[u8; 32],
-    ) -> Result<Option<Vec<u8>>, AccessError> {
+    ) -> Result<Option<Vec<u8>>, CorruptedError> {
         let connection = self.database.lock();
 
         let out = connection
@@ -155,7 +155,7 @@ impl SqliteFullDatabase {
     pub fn block_extrinsics(
         &self,
         block_hash: &[u8; 32],
-    ) -> Result<Option<impl ExactSizeIterator<Item = Vec<u8>>>, AccessError> {
+    ) -> Result<Option<impl ExactSizeIterator<Item = Vec<u8>>>, CorruptedError> {
         let connection = self.database.lock();
 
         // TODO: doesn't detect if block is absent
@@ -175,7 +175,7 @@ impl SqliteFullDatabase {
     pub fn block_hash_by_number(
         &self,
         block_number: u64,
-    ) -> Result<impl ExactSizeIterator<Item = [u8; 32]>, AccessError> {
+    ) -> Result<impl ExactSizeIterator<Item = [u8; 32]>, CorruptedError> {
         let connection = self.database.lock();
         let result = block_hashes_by_number(&connection, block_number)?;
         Ok(result.into_iter())
@@ -185,7 +185,7 @@ impl SqliteFullDatabase {
     pub fn best_block_hash_by_number(
         &self,
         block_number: u64,
-    ) -> Result<Option<[u8; 32]>, AccessError> {
+    ) -> Result<Option<[u8; 32]>, CorruptedError> {
         let connection = self.database.lock();
 
         let block_number = match i64::try_from(block_number) {
@@ -195,15 +195,16 @@ impl SqliteFullDatabase {
 
         let result = connection
             .prepare_cached(r#"SELECT hash FROM blocks WHERE number = ? AND is_best_chain = TRUE"#)
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?
             .query_row((block_number,), |row| row.get::<_, Vec<u8>>(0))
             .optional()
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))
             .and_then(|value| {
                 let Some(value) = value else { return Ok(None) };
-                Ok(Some(<[u8; 32]>::try_from(&value[..]).map_err(|_| {
-                    AccessError::Corrupted(CorruptedError::InvalidBlockHashLen)
-                })?))
+                Ok(Some(
+                    <[u8; 32]>::try_from(&value[..])
+                        .map_err(|_| CorruptedError::InvalidBlockHashLen)?,
+                ))
             })?;
 
         Ok(result)
@@ -224,11 +225,11 @@ impl SqliteFullDatabase {
     ) -> Result<chain_information::ValidChainInformation, StorageAccessError> {
         let connection = self.database.lock();
         if finalized_hash(&connection)? != *finalized_block_hash {
-            return Err(StorageAccessError::Pruned);
+            return Err(StorageAccessError::StoragePruned);
         }
 
         let finalized_block_header = block_header(&connection, finalized_block_hash)?
-            .ok_or(AccessError::Corrupted(CorruptedError::MissingBlockHeader))?;
+            .ok_or(CorruptedError::MissingBlockHeader)?;
 
         let finality = match (
             grandpa_authorities_set_id(&connection)?,
@@ -248,9 +249,9 @@ impl SqliteFullDatabase {
                 chain_information::ChainInformationFinality::Outsourced
             }
             _ => {
-                return Err(StorageAccessError::Access(AccessError::Corrupted(
+                return Err(StorageAccessError::Corrupted(
                     CorruptedError::ConsensusAlgorithmMix,
-                )))
+                ))
             }
         };
 
@@ -284,9 +285,9 @@ impl SqliteFullDatabase {
             }
             (None, None, None) => chain_information::ChainInformationConsensus::Unknown,
             _ => {
-                return Err(StorageAccessError::Access(AccessError::Corrupted(
+                return Err(StorageAccessError::Corrupted(
                     CorruptedError::ConsensusAlgorithmMix,
-                )))
+                ))
             }
         };
 
@@ -295,8 +296,7 @@ impl SqliteFullDatabase {
                 finalized_block_header: {
                     let header = header::decode(&finalized_block_header, self.block_number_bytes)
                         .map_err(CorruptedError::BlockHeaderCorrupted)
-                        .map_err(AccessError::Corrupted)
-                        .map_err(StorageAccessError::Access)?;
+                        .map_err(StorageAccessError::Corrupted)?;
                     Box::new(header.into())
                 },
                 consensus,
@@ -304,9 +304,9 @@ impl SqliteFullDatabase {
             },
         ) {
             Ok(ci) => Ok(ci),
-            Err(err) => Err(StorageAccessError::Access(AccessError::Corrupted(
+            Err(err) => Err(StorageAccessError::Corrupted(
                 CorruptedError::InvalidChainInformation(err),
-            ))),
+            )),
         }
     }
 
@@ -341,11 +341,9 @@ impl SqliteFullDatabase {
         let mut database = self.database.lock();
 
         // Start a transaction to insert everything at once.
-        let transaction = database.transaction().map_err(|err| {
-            InsertError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                InternalError(err),
-            )))
-        })?;
+        let transaction = database
+            .transaction()
+            .map_err(|err| InsertError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
 
         // Make sure that the block to insert isn't already in the database.
         if has_block(&transaction, &block_hash)? {
@@ -362,11 +360,7 @@ impl SqliteFullDatabase {
         // Note that this is immediately disabled again when we `COMMIT` later down below.
         transaction
             .execute("PRAGMA defer_foreign_keys = ON", ())
-            .map_err(|err| {
-                InsertError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                    InternalError(err),
-                )))
-            })?;
+            .map_err(|err| InsertError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
 
         transaction
             .prepare_cached(
@@ -404,7 +398,7 @@ impl SqliteFullDatabase {
             new_trie_nodes,
             trie_entries_version,
         )
-        .map_err(InsertError::Access)?;
+        .map_err(InsertError::Corrupted)?;
 
         // Change the best chain to be the new block.
         if is_new_best {
@@ -418,11 +412,9 @@ impl SqliteFullDatabase {
         }
 
         // If everything is successful, we commit.
-        transaction.commit().map_err(|err| {
-            InsertError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                InternalError(err),
-            )))
-        })?;
+        transaction
+            .commit()
+            .map_err(|err| InsertError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
 
         Ok(())
     }
@@ -450,9 +442,7 @@ impl SqliteFullDatabase {
 
         // Start a transaction to insert everything at once.
         let transaction = database.transaction().map_err(|err| {
-            SetFinalizedError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                InternalError(err),
-            )))
+            SetFinalizedError::Corrupted(CorruptedError::Internal(InternalError(err)))
         })?;
 
         // Fetch the header of the block to finalize.
@@ -460,8 +450,7 @@ impl SqliteFullDatabase {
             .ok_or(SetFinalizedError::UnknownBlock)?;
         let new_finalized_header = header::decode(&new_finalized_header, self.block_number_bytes)
             .map_err(CorruptedError::BlockHeaderCorrupted)
-            .map_err(AccessError::Corrupted)
-            .map_err(SetFinalizedError::Access)?;
+            .map_err(SetFinalizedError::Corrupted)?;
 
         // Fetch the current finalized block.
         let current_finalized = finalized_num(&transaction)?;
@@ -489,23 +478,20 @@ impl SqliteFullDatabase {
 
         // Now update the finalized block storage.
         for height in current_finalized + 1..=new_finalized_header.number {
-            let block_hash =
-                {
-                    let list = block_hashes_by_number(&transaction, height)?;
-                    debug_assert_eq!(list.len(), 1);
-                    list.into_iter().next().ok_or(SetFinalizedError::Access(
-                        AccessError::Corrupted(CorruptedError::MissingBlockHeader),
-                    ))?
-                };
+            let block_hash = {
+                let list = block_hashes_by_number(&transaction, height)?;
+                debug_assert_eq!(list.len(), 1);
+                list.into_iter().next().ok_or(SetFinalizedError::Corrupted(
+                    CorruptedError::MissingBlockHeader,
+                ))?
+            };
 
-            let block_header =
-                block_header(&transaction, &block_hash)?.ok_or(SetFinalizedError::Access(
-                    AccessError::Corrupted(CorruptedError::MissingBlockHeader),
-                ))?;
+            let block_header = block_header(&transaction, &block_hash)?.ok_or(
+                SetFinalizedError::Corrupted(CorruptedError::MissingBlockHeader),
+            )?;
             let block_header = header::decode(&block_header, self.block_number_bytes)
                 .map_err(CorruptedError::BlockHeaderCorrupted)
-                .map_err(AccessError::Corrupted)
-                .map_err(SetFinalizedError::Access)?;
+                .map_err(SetFinalizedError::Corrupted)?;
 
             // TODO: the code below is very verbose and redundant with other similar code in smoldot ; could be improved
 
@@ -600,9 +586,7 @@ impl SqliteFullDatabase {
 
         // If everything went well up to this point, commit the transaction.
         transaction.commit().map_err(|err| {
-            SetFinalizedError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                InternalError(err),
-            )))
+            SetFinalizedError::Corrupted(CorruptedError::Internal(InternalError(err)))
         })?;
 
         Ok(())
@@ -610,14 +594,14 @@ impl SqliteFullDatabase {
 
     /// Removes from the database all blocks that aren't a descendant of the current finalized
     /// block.
-    pub fn purge_finality_orphans(&self) -> Result<(), AccessError> {
+    pub fn purge_finality_orphans(&self) -> Result<(), CorruptedError> {
         let mut database = self.database.lock();
 
         // TODO: untested
 
         let transaction = database
             .transaction()
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
         // Temporarily disable foreign key checks in order to make the insertion easier, as we
         // don't have to make sure that trie nodes are sorted.
@@ -625,7 +609,7 @@ impl SqliteFullDatabase {
         // TODO: is this really necessary?
         transaction
             .execute("PRAGMA defer_foreign_keys = ON", ())
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
         let current_finalized = finalized_num(&transaction)?;
 
@@ -633,11 +617,11 @@ impl SqliteFullDatabase {
             .prepare_cached(
                 r#"SELECT hash FROM blocks WHERE number <= ? AND is_best_chain = FALSE"#,
             )
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?
             .query_map((current_finalized,), |row| row.get::<_, Vec<u8>>(0))
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
         for block in blocks {
             purge_block(&transaction, &block)?;
@@ -646,7 +630,7 @@ impl SqliteFullDatabase {
         // If everything went well up to this point, commit the transaction.
         transaction
             .commit()
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
         Ok(())
     }
@@ -700,9 +684,9 @@ impl SqliteFullDatabase {
             WHERE blocks.hash = :block_hash;
             "#)
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
+                StorageAccessError::Corrupted(CorruptedError::Internal(
                     InternalError(err),
-                )))
+                ))
             })?;
 
         let key_vectored = parent_tries_paths_nibbles
@@ -725,9 +709,7 @@ impl SqliteFullDatabase {
                 },
             )
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                    InternalError(err),
-                )))
+                StorageAccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
             })?;
 
         if !has_block {
@@ -735,15 +717,14 @@ impl SqliteFullDatabase {
         }
 
         if !block_has_storage {
-            return Err(StorageAccessError::Pruned);
+            return Err(StorageAccessError::StoragePruned);
         }
 
         let Some(value) = value else { return Ok(None) };
 
         let trie_entry_version = u8::try_from(trie_entry_version.unwrap())
             .map_err(|_| CorruptedError::InvalidTrieEntryVersion)
-            .map_err(AccessError::Corrupted)
-            .map_err(StorageAccessError::Access)?;
+            .map_err(StorageAccessError::Corrupted)?;
         Ok(Some((value, trie_entry_version)))
     }
 
@@ -860,9 +841,9 @@ impl SqliteFullDatabase {
             LIMIT 1"#,
             )
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
+                StorageAccessError::Corrupted(CorruptedError::Internal(
                     InternalError(err),
-                )))
+                ))
             })?;
 
         let parent_tries_paths_nibbles = parent_tries_paths_nibbles
@@ -898,9 +879,7 @@ impl SqliteFullDatabase {
                 },
             )
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                    InternalError(err),
-                )))
+                StorageAccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
             })?;
 
         if !has_block {
@@ -908,7 +887,7 @@ impl SqliteFullDatabase {
         }
 
         if !block_has_storage {
-            return Err(StorageAccessError::Pruned);
+            return Err(StorageAccessError::StoragePruned);
         }
 
         if parent_tries_paths_nibbles_length != 0 {
@@ -978,9 +957,9 @@ impl SqliteFullDatabase {
             LIMIT 1"#,
             )
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
+                StorageAccessError::Corrupted(CorruptedError::Internal(
                     InternalError(err),
-                )))
+                ))
             })?;
 
         let key_vectored = parent_tries_paths_nibbles
@@ -1002,9 +981,7 @@ impl SqliteFullDatabase {
                 },
             )
             .map_err(|err| {
-                StorageAccessError::Access(AccessError::Corrupted(CorruptedError::Internal(
-                    InternalError(err),
-                )))
+                StorageAccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
             })?;
 
         if !has_block {
@@ -1012,7 +989,7 @@ impl SqliteFullDatabase {
         }
 
         if !block_has_storage {
-            return Err(StorageAccessError::Pruned);
+            return Err(StorageAccessError::StoragePruned);
         }
 
         Ok(merkle_value)
@@ -1053,24 +1030,12 @@ pub enum InsertTrieNodeStorageValue<'a> {
     SameAsParent,
 }
 
-/// Error while accessing some information.
-// TODO: completely replace with just CorruptedError?
-#[derive(Debug, derive_more::Display, derive_more::From)]
-pub enum AccessError {
-    /// Database could be accessed, but its content is invalid.
-    ///
-    /// While these corruption errors are probably unrecoverable, the inner error might however
-    /// be useful for debugging purposes.
-    #[display(fmt = "Database corrupted: {_0}")]
-    Corrupted(CorruptedError),
-}
-
 /// Error while calling [`SqliteFullDatabase::insert`].
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum InsertError {
     /// Error accessing the database.
     #[display(fmt = "{_0}")]
-    Access(AccessError),
+    Corrupted(CorruptedError),
     /// Block was already in the database.
     Duplicate,
     /// Error when decoding the header to import.
@@ -1086,7 +1051,7 @@ pub enum InsertError {
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum SetFinalizedError {
     /// Error accessing the database.
-    Access(AccessError),
+    Corrupted(CorruptedError),
     /// New finalized block isn't in the database.
     UnknownBlock,
     /// New finalized block must be a child of the previous finalized block.
@@ -1097,9 +1062,9 @@ pub enum SetFinalizedError {
 #[derive(Debug, derive_more::Display, derive_more::From)]
 pub enum StorageAccessError {
     /// Error accessing the database.
-    Access(AccessError),
+    Corrupted(CorruptedError),
     /// Storage of the block hash passed as parameter is no longer in the database.
-    Pruned,
+    StoragePruned,
     /// Requested block couldn't be found in the database.
     UnknownBlock,
 }
@@ -1145,23 +1110,26 @@ pub struct InternalError(rusqlite::Error);
 fn meta_get_blob(
     database: &rusqlite::Connection,
     key: &str,
-) -> Result<Option<Vec<u8>>, AccessError> {
+) -> Result<Option<Vec<u8>>, CorruptedError> {
     let value = database
         .prepare_cached(r#"SELECT value_blob FROM meta WHERE key = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((key,), |row| row.get::<_, Vec<u8>>(0))
         .optional()
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(value)
 }
 
-fn meta_get_number(database: &rusqlite::Connection, key: &str) -> Result<Option<u64>, AccessError> {
+fn meta_get_number(
+    database: &rusqlite::Connection,
+    key: &str,
+) -> Result<Option<u64>, CorruptedError> {
     let value = database
         .prepare_cached(r#"SELECT value_number FROM meta WHERE key = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((key,), |row| row.get::<_, i64>(0))
         .optional()
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(value.map(|value| u64::from_ne_bytes(value.to_ne_bytes())))
 }
 
@@ -1169,12 +1137,12 @@ fn meta_set_blob(
     database: &rusqlite::Connection,
     key: &str,
     value: &[u8],
-) -> Result<(), AccessError> {
+) -> Result<(), CorruptedError> {
     database
         .prepare_cached(r#"INSERT OR REPLACE INTO meta(key, value_blob) VALUES (?, ?)"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute((key, value))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(())
 }
 
@@ -1182,51 +1150,50 @@ fn meta_set_number(
     database: &rusqlite::Connection,
     key: &str,
     value: u64,
-) -> Result<(), AccessError> {
+) -> Result<(), CorruptedError> {
     database
         .prepare_cached(r#"INSERT OR REPLACE INTO meta(key, value_number) VALUES (?, ?)"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute((key, i64::from_ne_bytes(value.to_ne_bytes())))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(())
 }
 
-fn has_block(database: &rusqlite::Connection, hash: &[u8]) -> Result<bool, AccessError> {
+fn has_block(database: &rusqlite::Connection, hash: &[u8]) -> Result<bool, CorruptedError> {
     database
         .prepare_cached(r#"SELECT COUNT(*) FROM blocks WHERE hash = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((hash,), |row| Ok(row.get_unwrap::<_, i64>(0) != 0))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))
 }
 
 // TODO: the fact that the meta table stores blobs makes it impossible to use joins ; fix that
-fn finalized_num(database: &rusqlite::Connection) -> Result<u64, AccessError> {
-    meta_get_number(database, "finalized")?
-        .ok_or(AccessError::Corrupted(CorruptedError::MissingMetaKey))
+fn finalized_num(database: &rusqlite::Connection) -> Result<u64, CorruptedError> {
+    meta_get_number(database, "finalized")?.ok_or(CorruptedError::MissingMetaKey)
 }
 
-fn finalized_hash(database: &rusqlite::Connection) -> Result<[u8; 32], AccessError> {
+fn finalized_hash(database: &rusqlite::Connection) -> Result<[u8; 32], CorruptedError> {
     let value = database
         .prepare_cached(r#"SELECT hash FROM blocks WHERE number = (SELECT value_number FROM meta WHERE key = "finalized")"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((), |row| row.get::<_, Vec<u8>>(0))
         .optional()
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
-        .ok_or(AccessError::Corrupted(CorruptedError::InvalidFinalizedNum))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
+        .ok_or(CorruptedError::InvalidFinalizedNum)?;
 
     if value.len() == 32 {
         let mut out = [0; 32];
         out.copy_from_slice(&value);
         Ok(out)
     } else {
-        Err(AccessError::Corrupted(CorruptedError::InvalidBlockHashLen))
+        Err(CorruptedError::InvalidBlockHashLen)
     }
 }
 
 fn block_hashes_by_number(
     database: &rusqlite::Connection,
     number: u64,
-) -> Result<Vec<[u8; 32]>, AccessError> {
+) -> Result<Vec<[u8; 32]>, CorruptedError> {
     let number = match i64::try_from(number) {
         Ok(n) => n,
         Err(_) => return Ok(Vec::new()),
@@ -1234,15 +1201,12 @@ fn block_hashes_by_number(
 
     database
         .prepare_cached(r#"SELECT hash FROM blocks WHERE number = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_map((number,), |row| row.get::<_, Vec<u8>>(0))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .map(|value| {
-            let value = value.map_err(|err| {
-                AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-            })?;
-            <[u8; 32]>::try_from(&value[..])
-                .map_err(|_| AccessError::Corrupted(CorruptedError::InvalidBlockHashLen))
+            let value = value.map_err(|err| CorruptedError::Internal(InternalError(err)))?;
+            <[u8; 32]>::try_from(&value[..]).map_err(|_| CorruptedError::InvalidBlockHashLen)
         })
         .collect::<Result<Vec<_>, _>>()
 }
@@ -1250,22 +1214,21 @@ fn block_hashes_by_number(
 fn block_header(
     database: &rusqlite::Connection,
     hash: &[u8; 32],
-) -> Result<Option<Vec<u8>>, AccessError> {
+) -> Result<Option<Vec<u8>>, CorruptedError> {
     database
         .prepare_cached(r#"SELECT header FROM blocks WHERE hash = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((&hash[..],), |row| row.get::<_, Vec<u8>>(0))
         .optional()
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))
 }
 
 fn set_best_chain(
     database: &rusqlite::Connection,
     new_best_block_hash: &[u8],
-) -> Result<(), AccessError> {
+) -> Result<(), CorruptedError> {
     // TODO: can this not be embedded in the SQL statement below?
-    let current_best = meta_get_blob(&database, "best")?
-        .ok_or(AccessError::Corrupted(CorruptedError::MissingMetaKey))?;
+    let current_best = meta_get_blob(&database, "best")?.ok_or(CorruptedError::MissingMetaKey)?;
 
     // TODO: untested except in the most basic situation
     // In the SQL below, the temporary table `changes` is built by walking down (highest to lowest
@@ -1311,12 +1274,12 @@ fn set_best_chain(
         WHERE blocks.hash = changes.block_to_include OR blocks.hash = changes.block_to_retract;
             "#,
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute(rusqlite::named_params! {
             ":current_best": current_best,
             ":new_best": new_best_block_hash
         })
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     meta_set_blob(&database, "best", new_best_block_hash)?;
     Ok(())
@@ -1328,7 +1291,7 @@ fn insert_storage<'a>(
     parent_block_hash: Option<&[u8]>,
     new_trie_nodes: impl Iterator<Item = InsertTrieNode<'a>>,
     entries_version: u8,
-) -> Result<(), AccessError> {
+) -> Result<(), CorruptedError> {
     // Create a temporary table where we store the newly-created trie nodes that must inherit the
     // storage value of the parent block. These trie nodes are processed later.
     database
@@ -1340,31 +1303,29 @@ fn insert_storage<'a>(
     "#,
             (),
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     // TODO: should check whether the existing merkle values that are referenced from inserted nodes exist in the parent's storage
     // TODO: is it correct to have OR IGNORE everywhere?
     let mut insert_node_statement = database
         .prepare_cached("INSERT OR IGNORE INTO trie_node(hash, partial_key) VALUES(?, ?)")
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     let mut insert_node_storage_statement = database
         .prepare_cached("INSERT OR IGNORE INTO trie_node_storage(node_hash, value, trie_root_ref, trie_entry_version) VALUES(?, ?, ?, ?)")
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     let mut insert_node_storage_copy_statement = database
         .prepare_cached(r#"INSERT OR IGNORE INTO temp_pending_parent_copies(node_hash) VALUES (?)"#)
-        .map_err(|err: rusqlite::Error| {
-            AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-        })?;
+        .map_err(|err: rusqlite::Error| CorruptedError::Internal(InternalError(err)))?;
     let mut insert_child_statement = database
         .prepare_cached(
             "INSERT OR IGNORE INTO trie_node_child(hash, child_num, child_hash) VALUES(?, ?, ?)",
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     for trie_node in new_trie_nodes {
         assert!(trie_node.partial_key_nibbles.iter().all(|n| *n < 16)); // TODO: document
         insert_node_statement
             .execute((&trie_node.merkle_value, trie_node.partial_key_nibbles))
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+            .map_err(|err: rusqlite::Error| CorruptedError::Internal(InternalError(err)))?;
         match trie_node.storage_value {
             InsertTrieNodeStorageValue::Value {
                 value,
@@ -1385,18 +1346,14 @@ fn insert_storage<'a>(
                         },
                         entries_version,
                     ))
-                    .map_err(|err| {
-                        AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-                    })?;
+                    .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
             }
             InsertTrieNodeStorageValue::SameAsParent => {
                 // TODO: error if parent_block_hash is None
 
                 insert_node_storage_copy_statement
                     .execute((&trie_node.merkle_value,))
-                    .map_err(|err| {
-                        AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-                    })?;
+                    .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
             }
             InsertTrieNodeStorageValue::NoValue => {}
         }
@@ -1405,9 +1362,7 @@ fn insert_storage<'a>(
                 let child_num = vec![u8::try_from(child_num).unwrap_or_else(|_| unreachable!())];
                 insert_child_statement
                     .execute((&trie_node.merkle_value, child_num, child))
-                    .map_err(|err| {
-                        AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-                    })?;
+                    .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
             }
         }
     }
@@ -1455,11 +1410,11 @@ fn insert_storage<'a>(
         WHERE LENGTH(node_with_key.search_remain) = 0;
             "#,
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute(rusqlite::named_params! {
             ":parent_block_hash": parent_block_hash,
         })
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     database
         .execute(
@@ -1468,34 +1423,34 @@ fn insert_storage<'a>(
     "#,
             (),
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     Ok(())
 }
 
-fn purge_block(database: &rusqlite::Connection, hash: &[u8]) -> Result<(), AccessError> {
+fn purge_block(database: &rusqlite::Connection, hash: &[u8]) -> Result<(), CorruptedError> {
     purge_block_storage(database, hash)?;
     database
         .prepare_cached("DELETE FROM blocks_body WHERE hash = ?")
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute((&hash[..],))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     database
         .prepare_cached("DELETE FROM blocks WHERE hash = ?")
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute((&hash[..],))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(())
 }
 
-fn purge_block_storage(database: &rusqlite::Connection, hash: &[u8]) -> Result<(), AccessError> {
+fn purge_block_storage(database: &rusqlite::Connection, hash: &[u8]) -> Result<(), CorruptedError> {
     // TODO: untested
 
     let state_trie_root_hash = database
         .prepare_cached(r#"SELECT state_trie_root_hash FROM blocks WHERE hash = ?"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_row((hash,), |row| row.get::<_, Vec<u8>>(0))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     database
         .prepare_cached(
@@ -1504,11 +1459,11 @@ fn purge_block_storage(database: &rusqlite::Connection, hash: &[u8]) -> Result<(
             WHERE hash = :block_hash
         "#,
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute(rusqlite::named_params! {
             ":block_hash": &hash[..],
         })
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
 
     // TODO: doesn't delete everything in the situation where a single node with a merkle value is referenced multiple times from the same trie
     // TODO: currently doesn't follow `trie_root_ref`
@@ -1532,43 +1487,42 @@ fn purge_block_storage(database: &rusqlite::Connection, hash: &[u8]) -> Result<(
             DELETE FROM trie_node
             WHERE hash IN (SELECT node_hash FROM to_delete)
         "#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .execute(rusqlite::named_params! {
             ":state_trie_root_hash": &state_trie_root_hash,
             ":block_hash": hash,
         })
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?;
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(())
 }
 
-fn grandpa_authorities_set_id(database: &rusqlite::Connection) -> Result<Option<u64>, AccessError> {
+fn grandpa_authorities_set_id(
+    database: &rusqlite::Connection,
+) -> Result<Option<u64>, CorruptedError> {
     meta_get_number(database, "grandpa_authorities_set_id")
 }
 
 fn grandpa_finalized_triggered_authorities(
     database: &rusqlite::Connection,
-) -> Result<Vec<header::GrandpaAuthority>, AccessError> {
+) -> Result<Vec<header::GrandpaAuthority>, CorruptedError> {
     database
         .prepare_cached(
             r#"SELECT public_key, weight FROM grandpa_triggered_authorities ORDER BY idx ASC"#,
         )
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_map((), |row| {
             let pk = row.get::<_, Vec<u8>>(0)?;
             let weight = row.get::<_, i64>(1)?;
             Ok((pk, weight))
         })
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .map(|result| {
-            let (public_key, weight) = result.map_err(|err| {
-                AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-            })?;
+            let (public_key, weight) =
+                result.map_err(|err| CorruptedError::Internal(InternalError(err)))?;
             let public_key = <[u8; 32]>::try_from(&public_key[..])
-                .map_err(|_| CorruptedError::InvalidBlockHashLen)
-                .map_err(AccessError::Corrupted)?;
+                .map_err(|_| CorruptedError::InvalidBlockHashLen)?;
             let weight = NonZeroU64::new(u64::from_ne_bytes(weight.to_ne_bytes()))
-                .ok_or(CorruptedError::InvalidNumber)
-                .map_err(AccessError::Corrupted)?;
+                .ok_or(CorruptedError::InvalidNumber)?;
             Ok(header::GrandpaAuthority { public_key, weight })
         })
         .collect::<Result<Vec<_>, _>>()
@@ -1576,33 +1530,30 @@ fn grandpa_finalized_triggered_authorities(
 
 fn grandpa_finalized_scheduled_change(
     database: &rusqlite::Connection,
-) -> Result<Option<(u64, Vec<header::GrandpaAuthority>)>, AccessError> {
+) -> Result<Option<(u64, Vec<header::GrandpaAuthority>)>, CorruptedError> {
     if let Some(height) = meta_get_number(database, "grandpa_scheduled_target")? {
         // TODO: duplicated from above except different table name
         let out = database
             .prepare_cached(
                 r#"SELECT public_key, weight FROM grandpa_scheduled_authorities ORDER BY idx ASC"#,
             )
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?
             .query_map((), |row| {
                 let pk = row.get::<_, Vec<u8>>(0)?;
                 let weight = row.get::<_, i64>(1)?;
                 Ok((pk, weight))
             })
-            .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?
             .map(|result| {
-                let (public_key, weight) = result.map_err(|err| {
-                    AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-                })?;
+                let (public_key, weight) =
+                    result.map_err(|err| CorruptedError::Internal(InternalError(err)))?;
                 let public_key = <[u8; 32]>::try_from(&public_key[..])
-                    .map_err(|_| CorruptedError::InvalidBlockHashLen)
-                    .map_err(AccessError::Corrupted)?;
+                    .map_err(|_| CorruptedError::InvalidBlockHashLen)?;
                 let weight = NonZeroU64::new(u64::from_ne_bytes(weight.to_ne_bytes()))
-                    .ok_or(CorruptedError::InvalidNumber)
-                    .map_err(AccessError::Corrupted)?;
+                    .ok_or(CorruptedError::InvalidNumber)?;
                 Ok(header::GrandpaAuthority { public_key, weight })
             })
-            .collect::<Result<Vec<_>, AccessError>>()?;
+            .collect::<Result<Vec<_>, CorruptedError>>()?;
 
         Ok(Some((height, out)))
     } else {
@@ -1610,30 +1561,25 @@ fn grandpa_finalized_scheduled_change(
     }
 }
 
-fn expect_nz_u64(value: u64) -> Result<NonZeroU64, AccessError> {
-    NonZeroU64::new(value)
-        .ok_or(CorruptedError::InvalidNumber)
-        .map_err(AccessError::Corrupted)
+fn expect_nz_u64(value: u64) -> Result<NonZeroU64, CorruptedError> {
+    NonZeroU64::new(value).ok_or(CorruptedError::InvalidNumber)
 }
 
 fn aura_finalized_authorities(
     database: &rusqlite::Connection,
-) -> Result<Vec<header::AuraAuthority>, AccessError> {
+) -> Result<Vec<header::AuraAuthority>, CorruptedError> {
     database
         .prepare_cached(r#"SELECT public_key FROM aura_finalized_authorities ORDER BY idx ASC"#)
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .query_map((), |row| row.get::<_, Vec<u8>>(0))
-        .map_err(|err| AccessError::Corrupted(CorruptedError::Internal(InternalError(err))))?
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
         .map(|result| {
-            let public_key = result.map_err(|err| {
-                AccessError::Corrupted(CorruptedError::Internal(InternalError(err)))
-            })?;
+            let public_key = result.map_err(|err| CorruptedError::Internal(InternalError(err)))?;
             let public_key = <[u8; 32]>::try_from(&public_key[..])
-                .map_err(|_| CorruptedError::InvalidBlockHashLen)
-                .map_err(AccessError::Corrupted)?;
+                .map_err(|_| CorruptedError::InvalidBlockHashLen)?;
             Ok(header::AuraAuthority { public_key })
         })
-        .collect::<Result<Vec<_>, AccessError>>()
+        .collect::<Result<Vec<_>, CorruptedError>>()
 }
 
 fn encode_babe_epoch_information(info: chain_information::BabeEpochInformationRef) -> Vec<u8> {
@@ -1663,7 +1609,7 @@ fn encode_babe_epoch_information(info: chain_information::BabeEpochInformationRe
 
 fn decode_babe_epoch_information(
     value: &[u8],
-) -> Result<chain_information::BabeEpochInformation, AccessError> {
+) -> Result<chain_information::BabeEpochInformation, CorruptedError> {
     let result = nom::combinator::all_consuming(nom::combinator::map(
         nom::sequence::tuple((
             nom::number::streaming::le_u64,
@@ -1720,7 +1666,5 @@ fn decode_babe_epoch_information(
         Ok(_) | Err(()) => Err(()),
     };
 
-    result
-        .map_err(|()| CorruptedError::InvalidBabeEpochInformation)
-        .map_err(AccessError::Corrupted)
+    result.map_err(|()| CorruptedError::InvalidBabeEpochInformation)
 }


### PR DESCRIPTION
The `AccessError` enum only contains one variant for `Corrupted`, so let's remove the enum altogether.