### PR TITLE
Fix full node docs not being generated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ./repo -> target
-      - run: cargo doc --verbose --all-features --no-deps --package smoldot --package smoldot-light
+      - run: cargo doc --verbose --all-features --no-deps --package smoldot --package smoldot-light --package smoldot-full-node
         working-directory: ./repo
       - run: |
           mkdir -p ./doc


### PR DESCRIPTION
The `README` contains a dead link to the documentation of the full node, and that's because it's not generated by the CI.