### PR TITLE
Backport JSON-RPC change to `index` field in `bestChainBlockIncluded`

### DIFF
--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -836,7 +836,7 @@ pub enum TransactionWatchEvent<'a> {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TransactionWatchEventBlock {
     pub hash: HashHexString,
-    pub index: NumberAsString,
+    pub index: u32,
 }
 
 /// Unstable event.
@@ -925,34 +925,6 @@ pub enum NetworkEvent<'a> {
         substream_id: u32,
         reason: Cow<'a, str>,
     },
-}
-
-#[derive(Debug, Clone)]
-pub struct NumberAsString(pub u32);
-
-impl serde::Serialize for NumberAsString {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.to_string().serialize(serializer)
-    }
-}
-
-impl<'a> serde::Deserialize<'a> for NumberAsString {
-    fn deserialize<D>(deserializer: D) -> Result<NumberAsString, D::Error>
-    where
-        D: serde::Deserializer<'a>,
-    {
-        let string = String::deserialize(deserializer)?;
-        match string.parse() {
-            Ok(num) => Ok(NumberAsString(num)),
-            Err(_) => Err(<D::Error as serde::de::Error>::invalid_value(
-                serde::de::Unexpected::Other("invalid number string"),
-                &"a valid number",
-            )),
-        }
-    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/light-base/src/json_rpc_service/background/transactions.rs
+++ b/light-base/src/json_rpc_service/background/transactions.rs
@@ -221,7 +221,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                                         methods::TransactionWatchEvent::BestChainBlockIncluded {
                                             block: Some(methods::TransactionWatchEventBlock {
                                                 hash: methods::HashHexString(block_hash),
-                                                index: methods::NumberAsString(index),
+                                                index,
                                             }),
                                         },
                                 }).await;
@@ -342,7 +342,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                                 result: methods::TransactionWatchEvent::Finalized {
                                     block: methods::TransactionWatchEventBlock {
                                         hash: methods::HashHexString(block_hash),
-                                        index: methods::NumberAsString(index),
+                                        index,
                                     },
                                 },
                             }).await,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The `index` field of `bestChainBlockIncluded` events of `chainHead_unstable_follow` subscriptions is now a number rather than a string, in accordance with the latest changes in the JSON-RPC API specification. ([#1010](https://github.com/smol-dot/smoldot/pull/1010))
+
 ## 1.0.17 - 2023-08-25
 
 ### Changed


### PR DESCRIPTION
This PR is in preparation for https://github.com/paritytech/json-rpc-interface-spec/pull/84