### PR TITLE
Properly parse the JSON-RPC responses in full node tests

### DIFF
--- a/full-node/tests/json-rpc-general-requests.rs
+++ b/full-node/tests/json-rpc-general-requests.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use smoldot::json_rpc;
 use std::sync::Arc;
 
 async fn start_client() -> smoldot_full_node::Client {
@@ -52,8 +53,14 @@ fn chain_spec_v1_chain_name() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("Local Testnet"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "Local Testnet"
+        );
     });
 }
 
@@ -70,9 +77,14 @@ fn chain_spec_v1_genesis_hash() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw
-            .contains("0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"
+        );
     });
 }
 
@@ -89,8 +101,11 @@ fn chain_spec_v1_properties() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("\"result\""));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(result_json, r#"{"tokenDecimals": 15}"#);
     });
 }
 
@@ -105,9 +120,14 @@ fn chain_get_block_hash() {
             )
             .unwrap();
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw
-            .contains("0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"
+        );
 
         client
             .send_json_rpc_request(
@@ -116,8 +136,11 @@ fn chain_get_block_hash() {
             )
             .unwrap();
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("null"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(result_json, "null");
 
         // TODO: test for a non-zero block?
     });
@@ -135,8 +158,14 @@ fn system_chain() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("Local Testnet"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "Local Testnet"
+        );
     });
 }
 
@@ -152,8 +181,14 @@ fn system_local_peer_id() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
+        );
     });
 }
 
@@ -169,8 +204,14 @@ fn system_name() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("smoldot-full-node"));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(result_json).unwrap(),
+            "smoldot-full-node"
+        );
     });
 }
 
@@ -186,8 +227,11 @@ fn system_properties() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("\"result\""));
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        assert_eq!(result_json, r#"{"tokenDecimals": 15}"#);
     });
 }
 
@@ -203,8 +247,11 @@ fn system_version() {
             .unwrap();
 
         let response_raw = client.next_json_rpc_response().await;
-        // TODO: actually parse the response properly
-        assert!(response_raw.contains("\"result\""));
+        // Note: we don't check the actual result, as the version changes pretty often.
+        json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
     });
 }
 

--- a/full-node/tests/substrate-node-template.json
+++ b/full-node/tests/substrate-node-template.json
@@ -6,7 +6,7 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {"tokenDecimals": 15},
   "consensusEngine": null,
   "codeSubstitutes": {},
   "genesis": {

--- a/fuzz/fuzz_targets/json-rpc-call.rs
+++ b/fuzz/fuzz_targets/json-rpc-call.rs
@@ -18,5 +18,5 @@
 #![no_main]
 
 libfuzzer_sys::fuzz_target!(|data: &str| {
-    let _ = smoldot::json_rpc::methods::parse_json_call(data);
+    let _ = smoldot::json_rpc::methods::parse_jsonrpc_client_to_server(data);
 });

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -102,7 +102,7 @@ pub enum ParseNotificationError<'a> {
 /// Panics if the `id_json` isn't valid JSON.
 ///
 pub fn build_json_call_object_parameters(id_json: Option<&str>, method: MethodCall) -> String {
-    method.to_json_call_object_parameters(id_json)
+    method.to_json_request_object_parameters(id_json)
 }
 
 /// See [`ParseClientToServerError::Method`] or [`ParseNotificationError::Method`].
@@ -232,13 +232,13 @@ macro_rules! define_methods {
                 }
             }
 
-            /// Builds a JSON call, to send it to a JSON-RPC server.
+            /// Builds a JSON request, to send it to a JSON-RPC server.
             ///
             /// # Panic
             ///
             /// Panics if the `id_json` isn't valid JSON.
             ///
-            pub fn to_json_call_object_parameters(&self, id_json: Option<&str>) -> String {
+            pub fn to_json_request_object_parameters(&self, id_json: Option<&str>) -> String {
                 parse::build_request(&parse::Request {
                     id_json,
                     method: self.name(),

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -38,7 +38,7 @@ use hashbrown::HashMap;
 pub fn parse_jsonrpc_client_to_server(
     message: &str,
 ) -> Result<(&str, MethodCall), ParseClientToServerError> {
-    let call_def = parse::parse_call(message).map_err(ParseClientToServerError::JsonRpcParse)?;
+    let call_def = parse::parse_request(message).map_err(ParseClientToServerError::JsonRpcParse)?;
 
     // No notification is supported by this server. If the `id` field is missing in the request,
     // assuming that this is a notification and return an appropriate error.
@@ -78,7 +78,7 @@ pub enum ParseClientToServerError<'a> {
 
 /// Parses a JSON notification.
 pub fn parse_notification(message: &str) -> Result<ServerToClient, ParseNotificationError> {
-    let call_def = parse::parse_call(message).map_err(ParseNotificationError::JsonRpcParse)?;
+    let call_def = parse::parse_request(message).map_err(ParseNotificationError::JsonRpcParse)?;
     let call = ServerToClient::from_defs(call_def.method, call_def.params_json)
         .map_err(ParseNotificationError::Method)?;
     Ok(call)
@@ -239,7 +239,7 @@ macro_rules! define_methods {
             /// Panics if the `id_json` isn't valid JSON.
             ///
             pub fn to_json_call_object_parameters(&self, id_json: Option<&str>) -> String {
-                parse::build_call(&parse::Call {
+                parse::build_request(&parse::Request {
                     id_json,
                     method: self.name(),
                     // Note that we never skip the `params` field, even if empty. This is an

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -1300,7 +1300,7 @@ impl Subscription {
     /// >           this function, otherwise it might never return.
     // TODO: with stronger typing we could automatically fill the subscription_id
     pub async fn send_notification(&mut self, notification: methods::ServerToClient<'_>) {
-        let serialized = notification.to_json_call_object_parameters(None);
+        let serialized = notification.to_json_request_object_parameters(None);
 
         // Wait until there is space in the queue or that the subscription is dead.
         // Note that this is intentionally racy.

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -342,30 +342,32 @@ impl ClientMainTask {
                 }
             };
 
-            let (request_id, parsed_request) = match methods::parse_json_call(&new_request) {
-                Ok((request_id, method)) => (request_id, method),
-                Err(methods::ParseCallError::Method { request_id, error }) => {
-                    let response = error.to_json_error(request_id);
-                    let mut responses_queue = self.inner.serialized_io.responses_queue.lock().await;
-                    let pos = responses_queue
-                        .pending_serialized_responses
-                        .insert((response, true));
-                    responses_queue
-                        .pending_serialized_responses_queue
-                        .push_back(pos);
-                    self.inner
-                        .serialized_io
-                        .on_response_pushed_or_task_destroyed
-                        .notify(usize::max_value());
-                    continue;
-                }
-                Err(methods::ParseCallError::UnknownNotification(_)) => continue,
-                Err(methods::ParseCallError::JsonRpcParse(_)) => {
-                    // The `SerializedRequestsIo` makes sure that requests are valid before
-                    // sending them.
-                    unreachable!()
-                }
-            };
+            let (request_id, parsed_request) =
+                match methods::parse_jsonrpc_client_to_server(&new_request) {
+                    Ok((request_id, method)) => (request_id, method),
+                    Err(methods::ParseClientToServerError::Method { request_id, error }) => {
+                        let response = error.to_json_error(request_id);
+                        let mut responses_queue =
+                            self.inner.serialized_io.responses_queue.lock().await;
+                        let pos = responses_queue
+                            .pending_serialized_responses
+                            .insert((response, true));
+                        responses_queue
+                            .pending_serialized_responses_queue
+                            .push_back(pos);
+                        self.inner
+                            .serialized_io
+                            .on_response_pushed_or_task_destroyed
+                            .notify(usize::max_value());
+                        continue;
+                    }
+                    Err(methods::ParseClientToServerError::UnknownNotification(_)) => continue,
+                    Err(methods::ParseClientToServerError::JsonRpcParse(_)) => {
+                        // The `SerializedRequestsIo` makes sure that requests are valid before
+                        // sending them.
+                        unreachable!()
+                    }
+                };
 
             // There exists three types of requests:
             //
@@ -824,7 +826,8 @@ impl SerializedRequestsIo {
     pub async fn send_request(&self, request: String) -> Result<(), SendRequestError> {
         // Try parse the request here. This guarantees that the [`ClientMainTask`] can't receive
         // requests that can't be parsed.
-        if let Err(methods::ParseCallError::JsonRpcParse(err)) = methods::parse_json_call(&request)
+        if let Err(methods::ParseClientToServerError::JsonRpcParse(err)) =
+            methods::parse_jsonrpc_client_to_server(&request)
         {
             return Err(SendRequestError {
                 request,
@@ -879,7 +882,8 @@ impl SerializedRequestsIo {
     pub fn try_send_request(&self, request: String) -> Result<(), TrySendRequestError> {
         // Try parse the request here. This guarantees that the [`ClientMainTask`] can't receive
         // requests that can't be parsed.
-        if let Err(methods::ParseCallError::JsonRpcParse(err)) = methods::parse_json_call(&request)
+        if let Err(methods::ParseClientToServerError::JsonRpcParse(err)) =
+            methods::parse_jsonrpc_client_to_server(&request)
         {
             return Err(TrySendRequestError {
                 request,
@@ -1005,14 +1009,18 @@ impl RequestProcess {
     /// The request is guaranteed to not be related to subscriptions in any way.
     // TODO: with stronger typing users wouldn't have to worry about the type of request
     pub fn request(&self) -> methods::MethodCall {
-        methods::parse_json_call(&self.request).unwrap().1
+        methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .1
     }
 
     /// Indicate the response to the request to the [`ClientMainTask`].
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     pub fn respond(mut self, response: methods::Response<'_>) {
-        let request_id = methods::parse_json_call(&self.request).unwrap().0;
+        let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .0;
         let serialized = response.to_json_response(request_id);
         self.responses_notifications_queue
             .queue
@@ -1028,7 +1036,9 @@ impl RequestProcess {
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     // TODO: the necessity for this function is basically a hack
     pub fn respond_null(mut self) {
-        let request_id = methods::parse_json_call(&self.request).unwrap().0;
+        let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .0;
         let serialized = parse::build_success_response(request_id, "null");
         self.responses_notifications_queue
             .queue
@@ -1043,7 +1053,9 @@ impl RequestProcess {
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     pub fn fail(mut self, error: ErrorResponse) {
-        let request_id = methods::parse_json_call(&self.request).unwrap().0;
+        let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .0;
         let serialized = parse::build_error_response(request_id, error, None);
         self.responses_notifications_queue
             .queue
@@ -1061,7 +1073,9 @@ impl RequestProcess {
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     pub fn fail_with_attached_json(mut self, error: ErrorResponse, json: &str) {
-        let request_id = methods::parse_json_call(&self.request).unwrap().0;
+        let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .0;
         let serialized = parse::build_error_response(request_id, error, Some(json));
         self.responses_notifications_queue
             .queue
@@ -1082,7 +1096,9 @@ impl fmt::Debug for RequestProcess {
 impl Drop for RequestProcess {
     fn drop(&mut self) {
         if !self.has_sent_response {
-            let request_id = methods::parse_json_call(&self.request).unwrap().0;
+            let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+                .unwrap()
+                .0;
             let serialized =
                 parse::build_error_response(request_id, ErrorResponse::InternalError, None);
             self.responses_notifications_queue
@@ -1120,7 +1136,9 @@ impl SubscriptionStartProcess {
     /// The request is guaranteed to be a request that starts a subscription.
     // TODO: with stronger typing users wouldn't have to worry about the type of request
     pub fn request(&self) -> methods::MethodCall {
-        methods::parse_json_call(&self.request).unwrap().1
+        methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .1
     }
 
     /// Indicate to the [`ClientMainTask`] that the subscription is accepted.
@@ -1129,7 +1147,8 @@ impl SubscriptionStartProcess {
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     pub fn accept(mut self) -> Subscription {
-        let (request_id, parsed_request) = methods::parse_json_call(&self.request).unwrap();
+        let (request_id, parsed_request) =
+            methods::parse_jsonrpc_client_to_server(&self.request).unwrap();
 
         let serialized_response = match parsed_request {
             methods::MethodCall::author_submitAndWatchExtrinsic { .. } => {
@@ -1193,7 +1212,9 @@ impl SubscriptionStartProcess {
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
     pub fn fail(mut self, error: ErrorResponse) {
-        let request_id = methods::parse_json_call(&self.request).unwrap().0;
+        let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+            .unwrap()
+            .0;
         let serialized = parse::build_error_response(request_id, error, None);
         self.responses_notifications_queue
             .queue
@@ -1219,7 +1240,9 @@ impl fmt::Debug for SubscriptionStartProcess {
 impl Drop for SubscriptionStartProcess {
     fn drop(&mut self) {
         if !self.has_sent_response {
-            let request_id = methods::parse_json_call(&self.request).unwrap().0;
+            let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
+                .unwrap()
+                .0;
             let serialized =
                 parse::build_error_response(request_id, ErrorResponse::InternalError, None);
             self.responses_notifications_queue

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -307,15 +307,15 @@ impl HandleRpcError {
             HandleRpcError::MalformedJsonRpc(_) => return None,
         };
 
-        match json_rpc::parse::parse_call(&json_rpc_request) {
-            Ok(json_rpc::parse::Call {
+        match json_rpc::parse::parse_request(&json_rpc_request) {
+            Ok(json_rpc::parse::Request {
                 id_json: Some(id), ..
             }) => Some(json_rpc::parse::build_error_response(
                 id,
                 json_rpc::parse::ErrorResponse::ServerError(-32000, "Too busy"),
                 None,
             )),
-            Ok(json_rpc::parse::Call { id_json: None, .. }) | Err(_) => None,
+            Ok(json_rpc::parse::Request { id_json: None, .. }) | Err(_) => None,
         }
     }
 }


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1006

This PR adds the code necessary to parse JSON-RPC responses, does a bunch of renaming, and fixes the full node tests to properly parse the JSON-RPC responses returned by the full node.
