### PR TITLE
Implement `chainHead_follow` on the full node

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -133,7 +133,7 @@ enum ToBackground {
     SubscribeAll {
         buffer_size: usize,
         // TODO: unused field
-        _max_pinned_blocks: NonZeroUsize,
+        _max_finalized_pinned_blocks: NonZeroUsize,
         result_tx: oneshot::Sender<SubscribeAll>,
     },
     GetSyncState {
@@ -392,7 +392,7 @@ impl ConsensusService {
     pub async fn subscribe_all(
         &self,
         buffer_size: usize,
-        max_pinned_blocks: NonZeroUsize,
+        max_finalized_pinned_blocks: NonZeroUsize,
     ) -> SubscribeAll {
         let (result_tx, result_rx) = oneshot::channel();
         let _ = self
@@ -401,7 +401,7 @@ impl ConsensusService {
             .await
             .send(ToBackground::SubscribeAll {
                 buffer_size,
-                _max_pinned_blocks: max_pinned_blocks,
+                _max_finalized_pinned_blocks: max_finalized_pinned_blocks,
                 result_tx,
             })
             .await;
@@ -789,7 +789,7 @@ impl SyncBackground {
                 frontend_event = self.to_background_rx.next().fuse() => {
                     // TODO: this isn't processed quickly enough when under load
                     match frontend_event {
-                        Some(ToBackground::SubscribeAll { buffer_size, _max_pinned_blocks: _, result_tx }) => {
+                        Some(ToBackground::SubscribeAll { buffer_size, _max_finalized_pinned_blocks: _, result_tx }) => {
                             let (tx, new_blocks) = async_channel::bounded(buffer_size.saturating_sub(1));
 
                             let non_finalized_blocks_ancestry_order = {

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -16,12 +16,13 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{consensus_service, database_thread, network_service, LogCallback, LogLevel};
+use futures_channel::oneshot;
 use futures_util::FutureExt;
 use smol::{
     future,
     net::{TcpListener, TcpStream},
 };
-use smoldot::json_rpc::service;
+use smoldot::json_rpc::{methods, parse, service};
 use std::{
     future::Future,
     io, mem,
@@ -531,6 +532,12 @@ fn spawn_client_main_task(
 ) {
     let tasks_executor2 = tasks_executor.clone();
     tasks_executor2(Box::pin(async move {
+        let mut chain_head_follow_subscriptions: hashbrown::HashMap<
+            String,
+            async_channel::Sender<chain_head_subscriptions::Message>,
+            _,
+        > = hashbrown::HashMap::with_capacity_and_hasher(2, fnv::FnvBuildHasher::default());
+
         loop {
             match client_main_task.run_until_event().await {
                 service::Event::HandleRequest {
@@ -538,10 +545,54 @@ fn spawn_client_main_task(
                     request_process,
                 } => {
                     client_main_task = task;
-                    to_requests_handlers
-                        .send(requests_handler::Message::Request(request_process))
-                        .await
-                        .unwrap();
+
+                    match request_process.request() {
+                        smoldot::json_rpc::methods::MethodCall::chainHead_unstable_unpin {
+                            follow_subscription,
+                            hash,
+                        } => {
+                            if let Some(follow_subscription) =
+                                chain_head_follow_subscriptions.get_mut(&*follow_subscription)
+                            {
+                                let block_hashes = match hash {
+                                    smoldot::json_rpc::methods::HashHexStringSingleOrArray::Array(list) => {
+                                        list.into_iter().map(|h| h.0).collect::<Vec<_>>()
+                                    },
+                                    smoldot::json_rpc::methods::HashHexStringSingleOrArray::Single(hash) => vec![hash.0]
+                                };
+
+                                let (outcome, outcome_rx) = oneshot::channel();
+                                follow_subscription
+                                    .send(chain_head_subscriptions::Message::Unpin {
+                                        block_hashes,
+                                        outcome,
+                                    })
+                                    .await;
+
+                                match outcome_rx.await {
+                                    Err(_) => {
+                                        request_process.respond(
+                                            methods::Response::chainHead_unstable_unpin(()),
+                                        );
+                                    }
+                                    Ok(Ok(())) => {
+                                        request_process.respond(
+                                            methods::Response::chainHead_unstable_unpin(()),
+                                        );
+                                    }
+                                    Ok(Err(())) => {
+                                        request_process.fail(service::ErrorResponse::InvalidParams);
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            to_requests_handlers
+                                .send(requests_handler::Message::Request(request_process))
+                                .await
+                                .unwrap();
+                        }
+                    }
                 }
                 service::Event::HandleSubscriptionStart {
                     task,
@@ -553,16 +604,23 @@ fn spawn_client_main_task(
                         // TODO: enforce limit to number of subscriptions
                         smoldot::json_rpc::methods::MethodCall::chainHead_unstable_follow {
                             with_runtime,
-                        } => chain_head_subscriptions::spawn_chain_head_subscription_task(
-                            chain_head_subscriptions::Config {
-                                tasks_executor: tasks_executor.clone(),
-                                log_callback: log_callback.clone(),
-                                chain_head_follow_subscription: subscription_start,
-                                with_runtime,
-                                consensus_service: consensus_service.clone(),
-                                database: database.clone(),
-                            },
-                        ),
+                        } => {
+                            let (tx, rx) = async_channel::bounded(16);
+                            let subscription_id =
+                                chain_head_subscriptions::spawn_chain_head_subscription_task(
+                                    chain_head_subscriptions::Config {
+                                        tasks_executor: tasks_executor.clone(),
+                                        log_callback: log_callback.clone(),
+                                        receiver: rx,
+                                        chain_head_follow_subscription: subscription_start,
+                                        with_runtime,
+                                        consensus_service: consensus_service.clone(),
+                                        database: database.clone(),
+                                    },
+                                )
+                                .await;
+                            chain_head_follow_subscriptions.insert(subscription_id, tx);
+                        }
                         _ => {
                             to_requests_handlers
                                 .send(requests_handler::Message::SubscriptionStart(
@@ -573,7 +631,12 @@ fn spawn_client_main_task(
                         }
                     }
                 }
-                service::Event::SubscriptionDestroyed { task, .. } => {
+                service::Event::SubscriptionDestroyed {
+                    task,
+                    subscription_id,
+                    ..
+                } => {
+                    let _ = chain_head_follow_subscriptions.remove(&subscription_id);
                     client_main_task = task;
                 }
                 service::Event::SerializedRequestsIoClosed => {

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -562,7 +562,7 @@ fn spawn_client_main_task(
                                 };
 
                                 let (outcome, outcome_rx) = oneshot::channel();
-                                follow_subscription
+                                let _ = follow_subscription
                                     .send(chain_head_subscriptions::Message::Unpin {
                                         block_hashes,
                                         outcome,

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -22,7 +22,7 @@ use smol::{
     future,
     net::{TcpListener, TcpStream},
 };
-use smoldot::json_rpc::{methods, parse, service};
+use smoldot::json_rpc::{methods, service};
 use std::{
     future::Future,
     io, mem,

--- a/full-node/src/json_rpc_service/chain_head_subscriptions.rs
+++ b/full-node/src/json_rpc_service/chain_head_subscriptions.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// TODO: document
+
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
 use smol::stream::StreamExt as _;

--- a/full-node/src/json_rpc_service/chain_head_subscriptions.rs
+++ b/full-node/src/json_rpc_service/chain_head_subscriptions.rs
@@ -1,0 +1,88 @@
+// Smoldot
+// Copyright (C) 2019-2022  Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use smol::stream::StreamExt as _;
+use smoldot::json_rpc::{methods, parse, service};
+use std::{
+    future::Future,
+    num::{NonZeroU32, NonZeroUsize},
+    pin::Pin,
+    sync::Arc,
+};
+
+use crate::{
+    consensus_service, database_thread, json_rpc_service::legacy_api_subscriptions,
+    network_service, LogCallback, LogLevel,
+};
+
+pub struct Config {
+    /// Function that can be used to spawn background tasks.
+    ///
+    /// The tasks passed as parameter must be executed until they shut down.
+    pub tasks_executor: Arc<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync>,
+
+    /// Function called in order to notify of something.
+    pub log_callback: Arc<dyn LogCallback + Send + Sync>,
+
+    /// `chainHead_unstable_follow` subscription start handle.
+    pub chain_head_follow_subscription: service::SubscriptionStartProcess,
+
+    /// Parameter that was passed by the user when requesting `chainHead_unstable_follow`.
+    pub with_runtime: bool,
+
+    /// Consensus service of the chain.
+    pub consensus_service: Arc<consensus_service::ConsensusService>,
+
+    /// Database to access blocks.
+    pub database: Arc<database_thread::DatabaseThread>,
+}
+
+/// Spawns a new tasks dedicated to handling a `chainHead_unstable_follow` subscription.
+pub fn spawn_chain_head_subscription_task(mut config: Config) {
+    let tasks_executor = config.tasks_executor.clone();
+    tasks_executor(Box::pin(async move {
+        let mut json_rpc_subscription = config.chain_head_follow_subscription.accept();
+        let json_rpc_subscription_id = json_rpc_subscription.subscription_id().to_owned();
+
+        let consensus_service_subscription = config
+            .consensus_service
+            .subscribe_all(32, NonZeroUsize::new(32).unwrap())
+            .await;
+
+        json_rpc_subscription
+            .send_notification(methods::ServerToClient::chainHead_unstable_followEvent {
+                subscription: (&json_rpc_subscription_id).into(),
+                result: methods::FollowEvent::Initialized {
+                    finalized_block_hash: methods::HashHexString(
+                        consensus_service_subscription.finalized_block_hash,
+                    ),
+                    finalized_block_runtime: if config.with_runtime {
+                        Some(todo!()) // TODO:
+                    } else {
+                        None
+                    },
+                },
+            })
+            .await;
+
+        for block in consensus_service_subscription.non_finalized_blocks_ancestry_order {}
+
+        loop {
+            match consensus_service_subscription.new_blocks.next().await {}
+        }
+    }));
+}


### PR DESCRIPTION
Only implements following blocks, and not runtime calls or storage retrievals or header/body retrievals.

~~Before proceeding, we must figure out how to access the runtime from the JSON-RPC service.~~

~~Implementing the legacy API first might actually be a better idea, as it's easier.~~
