### PR TITLE
Print a log entry when services shut down

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -166,11 +166,18 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
             let sync_service = config.sync_service.clone();
             let guarded = guarded.clone();
             let platform = config.platform.clone();
-            let (abortable, abort) = future::abortable(async move {
-                run_background(log_target, platform, sync_service, guarded).await;
-            });
+            let (abortable, abort) = future::abortable(run_background(
+                log_target.clone(),
+                platform,
+                sync_service,
+                guarded,
+            ));
             background_task_abort = abort;
-            abortable.map(|_| ()).boxed()
+            abortable
+                .map(move |_| {
+                    log::debug!(target: &log_target, "Shutdown");
+                })
+                .boxed()
         });
 
         RuntimeService {

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -29,7 +29,7 @@
 use crate::{network_service, platform::PlatformRef, runtime_service};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
-use core::{fmt, mem, num::NonZeroU32, pin::Pin, time::Duration};
+use core::{fmt, future::Future, mem, num::NonZeroU32, pin::Pin, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::stream;
 use rand::seq::IteratorRandom as _;
@@ -152,42 +152,41 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
 
         let log_target = format!("sync-service-{}", config.log_name);
 
-        match config.chain_type {
-            ConfigChainType::Parachain(config_parachain) => {
-                config.platform.spawn_task(
-                    log_target.clone().into(),
-                    Box::pin(parachain::start_parachain(
-                        log_target,
-                        config.platform.clone(),
-                        config_parachain.finalized_block_header,
-                        config.block_number_bytes,
-                        config_parachain.relay_chain_sync.clone(),
-                        config_parachain.relay_chain_block_number_bytes,
-                        config_parachain.para_id,
-                        from_foreground,
-                        config.network_service.0.clone(),
-                        config.network_service.1,
-                        config.network_events_receiver,
-                    )),
-                );
-            }
+        let task: Pin<Box<dyn Future<Output = ()> + Send>> = match config.chain_type {
+            ConfigChainType::Parachain(config_parachain) => Box::pin(parachain::start_parachain(
+                log_target.clone(),
+                config.platform.clone(),
+                config_parachain.finalized_block_header,
+                config.block_number_bytes,
+                config_parachain.relay_chain_sync.clone(),
+                config_parachain.relay_chain_block_number_bytes,
+                config_parachain.para_id,
+                from_foreground,
+                config.network_service.0.clone(),
+                config.network_service.1,
+                config.network_events_receiver,
+            )),
             ConfigChainType::RelayChain(config_relay_chain) => {
-                config.platform.spawn_task(
-                    log_target.clone().into(),
-                    Box::pin(standalone::start_standalone_chain(
-                        log_target,
-                        config.platform.clone(),
-                        config_relay_chain.chain_information,
-                        config.block_number_bytes,
-                        config_relay_chain.runtime_code_hint,
-                        from_foreground,
-                        config.network_service.0.clone(),
-                        config.network_service.1,
-                        config.network_events_receiver,
-                    )),
-                );
+                Box::pin(standalone::start_standalone_chain(
+                    log_target.clone(),
+                    config.platform.clone(),
+                    config_relay_chain.chain_information,
+                    config.block_number_bytes,
+                    config_relay_chain.runtime_code_hint,
+                    from_foreground,
+                    config.network_service.0.clone(),
+                    config.network_service.1,
+                    config.network_events_receiver,
+                ))
             }
-        }
+        };
+
+        config
+            .platform
+            .spawn_task(log_target.clone().into(), async move {
+                task.await;
+                log::debug!(target: &log_target, "Shutdown");
+            });
 
         SyncService {
             to_background,


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1093

I haven't done it for the JSON-RPC service due to the many several tasks that are being spawned, and because the fact that it doesn't use reference counting makes it easier to figure out that it does indeed get destroyed.
