### PR TITLE
Call wake_up_asap when generating an event

### DIFF
--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -574,7 +574,7 @@ where
                 mut inbound_negotiated_cancel_acknowledgments,
             } => match established.read_write(read_write) {
                 Ok((connection, event)) => {
-                    if read_write.is_dead() && event.is_none() {
+                    if read_write.is_dead() && read_write.wake_up_after.is_none() {
                         self.pending_messages.push_back(
                             ConnectionToCoordinatorInner::StartShutdown(Some(
                                 ShutdownCause::CleanShutdown,

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -942,6 +942,7 @@ where
                                 substream.state = SubstreamState::Reset;
                             }
 
+                            outer_read_write.wake_up_asap();
                             return Ok(ReadWriteOutcome::GoAway {
                                 yamux: self,
                                 code: error_code,
@@ -1024,6 +1025,7 @@ where
 
                             substream.state = SubstreamState::Reset;
 
+                            outer_read_write.wake_up_asap();
                             return Ok(ReadWriteOutcome::StreamReset {
                                 yamux: self,
                                 substream_id: SubstreamId(stream_id),


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1113

This removes an ambiguity in the `ReadWrite` system.
Whether `read_write` should be called again is now decided by the `wake_up_after` field, and is no longer mandatory after an event is generated.
