### PR TITLE
Remove rejection of large JSON-RPC requests

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Transactions submitted through the JSON-RPC server before the warp syncing process is finished will now immediately be dropped. ([#1110](https://github.com/smol-dot/smoldot/pull/1110))
+- JSON-RPC requests that are too large are no longer rejected.
 
 ### Fixed
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Transactions submitted through the JSON-RPC server before the warp syncing process is finished will now immediately be dropped. ([#1110](https://github.com/smol-dot/smoldot/pull/1110))
-- JSON-RPC requests that are too large are no longer rejected.
+- JSON-RPC requests that are too large are no longer rejected. In case where the JSON-RPC client is trusted, then there is nothing to do, and the potential lack of memory space will become a non-issue once the `Memory64` WebAssembly proposal becomes widely available. In case where the JSON-RPC client is not trusted, the API user is encouraged to manually implement a limit to the size of JSON-RPC requests. ([#1115](https://github.com/smol-dot/smoldot/pull/1115))
 
 ### Fixed
 

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -534,9 +534,6 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                         throw new AlreadyDestroyedError();
                     if (options.disableJsonRpc)
                         throw new JsonRpcDisabledError();
-                    if (request.length >= 64 * 1024 * 1024) {
-                        throw new MalformedJsonRpcError();
-                    };
 
                     const retVal = state.instance.instance.request(request, chainId);
                     switch (retVal) {

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -145,8 +145,7 @@ export interface Chain {
      * as the responses.
      *
      * A {@link MalformedJsonRpcError} is thrown if the request isn't a valid JSON-RPC request
-     * (for example if it is not valid JSON) or if the request is unreasonably large (64 MiB at the
-     * time of writing of this comment).
+     * (for example if it is not valid JSON).
      * If, however, the request is a valid JSON-RPC request but that concerns an unknown method, or
      * if for example some parameters are missing, an error response is properly generated and
      * yielded through the JSON-RPC callback.

--- a/wasm-node/javascript/test/misc.mjs
+++ b/wasm-node/javascript/test/misc.mjs
@@ -36,29 +36,6 @@ test('malformed json-rpc requests rejected', async t => {
     .then(() => client.terminate());
 });
 
-test('too large json-rpc requests rejected', async t => {
-  // Generate a very long string. We start with a length of 1 and double for every iteration.
-  // Thus the final length of the string is `2^i` where `i` is the number of iterations.
-  let veryLongString = 'a';
-  for (let i = 0; i < 27; ++i) {
-    veryLongString += veryLongString;
-  }
-
-  const client = start({ logCallback: () => { } });
-  await client
-    .addChain({ chainSpec: westendSpec })
-    .then((chain) => {
-      try {
-        // We use `JSON.stringify` in order to be certain that the request is valid JSON.
-        chain.sendJsonRpc(JSON.stringify({ "jsonrpc": "2.0", "id": 1, "method": "foo", "params": [veryLongString] }));
-      } catch(error) {
-        t.assert(error instanceof MalformedJsonRpcError);
-        t.pass();
-      }
-    })
-    .then(() => client.terminate());
-});
-
 test('disableJsonRpc option forbids sendJsonRpc', async t => {
   const client = start({ logCallback: () => { } });
   await client


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1098

After thinking about it, I've decided to go ahead and remove the limit of 64 MiB for JSON-RPC requests.

The presence of a limit is bad by itself due to the "additional thing to think about".

The existence of this limit was meant to limit the capacity for JSON-RPC clients to DoS the server by sending large requests. After all, the server can only allocate 4 GiB of memory in total due to compiling for `wasm32`.
However, the current limit at 64 MiB is too large to be efficient. A client can simply send as many 64 MiB requests as possible and will reach the memory cap nonetheless.
Reducing the limit runs of the risk of actually running accidentally into said limit with legitimate requests.

If the JSON-RPC client is trusted, then there's nothing to do as the JSON-RPC client isn't going to DoS the server. There's still a risk of running out of memory space, but it will be solved by #88, and to me returning an error if requests are too large is no better than crashing.

If the JSON-RPC client isn't trusted, then it's good to have a limit to the size of requests (even with #88). When writing this PR, I initially added an option to `addChain` that allows specifying a limit. However, the code that wraps around smoldot also needs to enforce a limit for itself anyway, and as such a smoldot-specific solution isn't a good idea.
