### PR TITLE
Remove `MalformedJsonRpcError`

### DIFF
--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -42,8 +42,6 @@ mod json_rpc_service;
 mod network_service;
 mod util;
 
-pub use json_rpc_service::RequestParseError as JsonRpcRequestParseError;
-
 pub struct Config<'a> {
     /// Chain to connect to.
     pub chain: ChainConfig<'a>,
@@ -170,9 +168,7 @@ impl Client {
     /// Adds a JSON-RPC request to the queue of requests of the virtual endpoint of the chain.
     ///
     /// The virtual endpoint doesn't have any limit.
-    ///
-    /// Returns an error if the JSON-RPC request is malformed.
-    pub fn send_json_rpc_request(&self, request: String) -> Result<(), JsonRpcRequestParseError> {
+    pub fn send_json_rpc_request(&self, request: String) {
         self.json_rpc_service.send_request(request)
     }
 

--- a/full-node/tests/json-rpc-general-requests.rs
+++ b/full-node/tests/json-rpc-general-requests.rs
@@ -45,12 +45,9 @@ fn chain_spec_v1_chain_name() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_chainName","params":[]}"#
-                    .to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_chainName","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -69,12 +66,10 @@ fn chain_spec_v1_genesis_hash() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_genesisHash","params":[]}"#
-                    .to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_genesisHash","params":[]}"#
+                .to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -93,12 +88,9 @@ fn chain_spec_v1_properties() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_properties","params":[]}"#
-                    .to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"chainSpec_v1_properties","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -114,11 +106,9 @@ fn chain_get_block_hash() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chain_getBlockHash","params":[0]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"chain_getBlockHash","params":[0]}"#.to_owned(),
+        );
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
             .unwrap()
@@ -129,12 +119,9 @@ fn chain_get_block_hash() {
             "0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"
         );
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"chain_getBlockHash","params":[10000]}"#
-                    .to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"chain_getBlockHash","params":[10000]}"#.to_owned(),
+        );
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
             .unwrap()
@@ -151,11 +138,9 @@ fn system_chain() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"system_chain","params":[]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"system_chain","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -174,11 +159,9 @@ fn system_local_peer_id() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"system_localPeerId","params":[]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"system_localPeerId","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -197,11 +180,9 @@ fn system_name() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"system_name","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -220,11 +201,9 @@ fn system_properties() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"system_properties","params":[]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"system_properties","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
@@ -240,11 +219,9 @@ fn system_version() {
     smol::block_on(async move {
         let client = start_client().await;
 
-        client
-            .send_json_rpc_request(
-                r#"{"jsonrpc":"2.0","id":1,"method":"system_version","params":[]}"#.to_owned(),
-            )
-            .unwrap();
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"system_version","params":[]}"#.to_owned(),
+        );
 
         let response_raw = client.next_json_rpc_response().await;
         // Note: we don't check the actual result, as the version changes pretty often.

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -49,11 +49,7 @@ use alloc::{
     sync::Arc,
 };
 use core::num::NonZeroU32;
-use smoldot::{
-    chain_spec,
-    json_rpc::{self, service},
-    libp2p::PeerId,
-};
+use smoldot::{chain_spec, json_rpc::service, libp2p::PeerId};
 
 /// Configuration for [`service()`].
 pub struct Config {

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -135,8 +135,7 @@ impl Frontend {
     ///
     /// An error is returned if [`Config::max_pending_requests`] is exceeded, which can happen
     /// if the requests take a long time to process or if [`Frontend::next_json_rpc_response`]
-    /// isn't called often enough. Use [`HandleRpcError::into_json_rpc_error`] to build the
-    /// JSON-RPC response to immediately send back to the user.
+    /// isn't called often enough.
     pub fn queue_rpc_request(&self, json_rpc_request: String) -> Result<(), HandleRpcError> {
         let log_friendly_request =
             crate::util::truncated_str(json_rpc_request.chars().filter(|c| !c.is_control()), 100)
@@ -160,18 +159,6 @@ impl Frontend {
             }) => Err(HandleRpcError::TooManyPendingRequests {
                 json_rpc_request: request,
             }),
-            Err(service::TrySendRequestError {
-                cause: service::TrySendRequestErrorCause::MalformedJson(error),
-                ..
-            }) => {
-                // If the request isn't even a valid JSON-RPC request, we can't even send back a
-                // response. We have no choice but to immediately refuse the request.
-                log::warn!(
-                    target: &self.log_target,
-                    "Refused malformed JSON-RPC request: {}", error
-                );
-                Err(HandleRpcError::MalformedJsonRpc(error))
-            }
             Err(service::TrySendRequestError {
                 cause: service::TrySendRequestErrorCause::ClientMainTaskDestroyed,
                 ..
@@ -291,31 +278,4 @@ pub enum HandleRpcError {
         /// Request that was being queued.
         json_rpc_request: String,
     },
-    /// The request isn't a valid JSON-RPC request.
-    #[display(fmt = "The request isn't a valid JSON-RPC request: {_0}")]
-    MalformedJsonRpc(json_rpc::parse::ParseError),
-}
-
-impl HandleRpcError {
-    /// Builds the JSON-RPC error string corresponding to this error.
-    ///
-    /// Returns `None` if the JSON-RPC requests isn't valid JSON-RPC or if the call was a
-    /// notification.
-    pub fn into_json_rpc_error(self) -> Option<String> {
-        let json_rpc_request = match self {
-            HandleRpcError::TooManyPendingRequests { json_rpc_request } => json_rpc_request,
-            HandleRpcError::MalformedJsonRpc(_) => return None,
-        };
-
-        match json_rpc::parse::parse_request(&json_rpc_request) {
-            Ok(json_rpc::parse::Request {
-                id_json: Some(id), ..
-            }) => Some(json_rpc::parse::build_error_response(
-                id,
-                json_rpc::parse::ErrorResponse::ServerError(-32000, "Too busy"),
-                None,
-            )),
-            Ok(json_rpc::parse::Request { id_json: None, .. }) | Err(_) => None,
-        }
-    }
 }

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1048,8 +1048,8 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
     /// a good way to avoid errors here, but this should only be done if the JSON-RPC client is
     /// trusted.
     ///
-    /// Also returns an error if the request could not be parsed as a valid JSON-RPC request, as
-    /// in that situation smoldot is unable to send back a corresponding JSON-RPC error message.
+    /// If the JSON-RPC request is not a valid JSON-RPC request, a JSON-RPC error response with
+    /// an `id` equal to `null` is later generated, in accordance with the JSON-RPC specification.
     ///
     /// # Panic
     ///

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Remove
+
+- Removed `MalformedJsonRpcError`. Malformed JSON-RPC requests now generate an error JSON-RPC response where the `id` field is equal to `null`, in accordance with the JSON-RPC 2.0 specification.
+
 ### Changed
 
 - Transactions submitted through the JSON-RPC server before the warp syncing process is finished will now immediately be dropped. ([#1110](https://github.com/smol-dot/smoldot/pull/1110))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Remove
 
-- Removed `MalformedJsonRpcError`. Malformed JSON-RPC requests now generate an error JSON-RPC response where the `id` field is equal to `null`, in accordance with the JSON-RPC 2.0 specification.
+- Removed `MalformedJsonRpcError`. Malformed JSON-RPC requests now generate an error JSON-RPC response where the `id` field is equal to `null`, in accordance with the JSON-RPC 2.0 specification. ([#1116](https://github.com/smol-dot/smoldot/pull/1116))
 
 ### Changed
 

--- a/wasm-node/javascript/src/index-browser.ts
+++ b/wasm-node/javascript/src/index-browser.ts
@@ -32,7 +32,6 @@ export {
     SmoldotBytecode,
     CrashError,
     JsonRpcDisabledError,
-    MalformedJsonRpcError,
     QueueFullError,
     LogCallback
 } from './public-types.js';

--- a/wasm-node/javascript/src/index-deno.ts
+++ b/wasm-node/javascript/src/index-deno.ts
@@ -29,7 +29,6 @@ export {
     ClientOptionsWithBytecode,
     SmoldotBytecode,
     CrashError,
-    MalformedJsonRpcError,
     QueueFullError,
     JsonRpcDisabledError,
     LogCallback

--- a/wasm-node/javascript/src/index-nodejs.ts
+++ b/wasm-node/javascript/src/index-nodejs.ts
@@ -33,7 +33,6 @@ export {
     ClientOptionsWithBytecode,
     SmoldotBytecode,
     CrashError,
-    MalformedJsonRpcError,
     QueueFullError,
     JsonRpcDisabledError,
     LogCallback

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { Client, ClientOptions, QueueFullError, AlreadyDestroyedError, AddChainError, AddChainOptions, Chain, JsonRpcDisabledError, MalformedJsonRpcError, CrashError, SmoldotBytecode } from '../public-types.js';
+import { Client, ClientOptions, QueueFullError, AlreadyDestroyedError, AddChainError, AddChainOptions, Chain, JsonRpcDisabledError, CrashError, SmoldotBytecode } from '../public-types.js';
 import * as instance from './local-instance.js';
 import * as remote from './remote-instance.js';
 
@@ -538,8 +538,7 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                     const retVal = state.instance.instance.request(request, chainId);
                     switch (retVal) {
                         case 0: break;
-                        case 1: throw new MalformedJsonRpcError();
-                        case 2: throw new QueueFullError();
+                        case 1: throw new QueueFullError();
                         default: throw new Error("Internal error: unknown json_rpc_send error code: " + retVal)
                     }
                 },

--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -627,7 +627,7 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
     return {
         request: (request: string, chainId: number) => {
             if (!state.instance)
-                return 2;  // TODO: return a different error code? should be documented
+                return 1;  // TODO: return a different error code? should be documented
             state.bufferIndices[0] = new TextEncoder().encode(request);
             return state.instance.exports.json_rpc_send(0, chainId) >>> 0;
         },

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -31,7 +31,6 @@ export {
     SmoldotBytecode,
     CrashError,
     JsonRpcDisabledError,
-    MalformedJsonRpcError,
     QueueFullError,
     LogCallback
 } from './public-types.js';

--- a/wasm-node/javascript/src/no-auto-bytecode-deno.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-deno.ts
@@ -28,7 +28,6 @@ export {
     ClientOptionsWithBytecode,
     SmoldotBytecode,
     CrashError,
-    MalformedJsonRpcError,
     QueueFullError,
     JsonRpcDisabledError,
     LogCallback

--- a/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
@@ -38,7 +38,6 @@ export {
     ClientOptionsWithBytecode,
     SmoldotBytecode,
     CrashError,
-    MalformedJsonRpcError,
     QueueFullError,
     JsonRpcDisabledError,
     LogCallback

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -58,15 +58,6 @@ export class CrashError extends Error {
 }
 
 /**
- * Thrown in case a malformed JSON-RPC request is sent.
- */
-export class MalformedJsonRpcError extends Error {
-    constructor() {
-        super("JSON-RPC request is malformed");
-    }
-}
-
-/**
  * Thrown in case the buffer of JSON-RPC requests is full and cannot accept any more request.
  */
 export class QueueFullError extends Error {
@@ -144,14 +135,12 @@ export interface Chain {
      * Be aware that some requests will cause notifications to be sent back using the same callback
      * as the responses.
      *
-     * A {@link MalformedJsonRpcError} is thrown if the request isn't a valid JSON-RPC request
-     * (for example if it is not valid JSON).
+     * If the request is not a valid JSON-RPC request, then a JSON-RPC error response is later
+     * generated with an `id` equal to `null`, in accordance with the JSON-RPC 2.0 specification.
+     *
      * If, however, the request is a valid JSON-RPC request but that concerns an unknown method, or
      * if for example some parameters are missing, an error response is properly generated and
      * yielded through the JSON-RPC callback.
-     * In other words, a {@link MalformedJsonRpcError} is thrown in situations where something
-     * is *so wrong* with the request that it is not possible for smoldot to send back an error
-     * through the JSON-RPC callback.
      *
      * Two JSON-RPC APIs are supported by smoldot:
      *
@@ -160,7 +149,6 @@ export interface Chain {
      *
      * @param rpc JSON-encoded RPC request.
      *
-     * @throws {@link MalformedJsonRpcError} If the payload isn't valid JSON-RPC.
      * @throws {@link QueueFullError} If the queue of JSON-RPC requests of the chain is full.
      * @throws {@link AlreadyDestroyedError} If the chain has been removed or the client has been terminated.
      * @throws {@link JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.

--- a/wasm-node/javascript/test/misc.mjs
+++ b/wasm-node/javascript/test/misc.mjs
@@ -21,6 +21,25 @@ import { start, JsonRpcDisabledError } from "../dist/mjs/index-nodejs.js";
 
 const westendSpec = fs.readFileSync('./test/westend.json', 'utf8');
 
+test('malformed JSON-RPC request generates an error', async t => {
+  const client = start({ logCallback: () => { } });
+  await client
+    .addChain({ chainSpec: westendSpec })
+    .then((chain) => {
+      chain.sendJsonRpc('this is an invalid request');
+      return chain;
+    })
+    .then(async (chain) => {
+      const response = await chain.nextJsonRpcResponse();
+      const parsed = JSON.parse(response);
+      if (parsed.id === null && parsed.error)
+        t.pass();
+      else
+        t.fail(response);
+    })
+    .then(() => client.terminate());
+});
+
 test('disableJsonRpc option forbids sendJsonRpc', async t => {
   const client = start({ logCallback: () => { } });
   await client

--- a/wasm-node/javascript/test/misc.mjs
+++ b/wasm-node/javascript/test/misc.mjs
@@ -17,24 +17,9 @@
 
 import test from 'ava';
 import * as fs from 'node:fs';
-import { start, JsonRpcDisabledError, MalformedJsonRpcError } from "../dist/mjs/index-nodejs.js";
+import { start, JsonRpcDisabledError } from "../dist/mjs/index-nodejs.js";
 
 const westendSpec = fs.readFileSync('./test/westend.json', 'utf8');
-
-test('malformed json-rpc requests rejected', async t => {
-  const client = start({ logCallback: () => { } });
-  await client
-    .addChain({ chainSpec: westendSpec })
-    .then((chain) => {
-      try {
-        chain.sendJsonRpc("this is not a valid JSON-RPC request");
-      } catch(error) {
-        t.assert(error instanceof MalformedJsonRpcError);
-        t.pass();
-      }
-    })
-    .then(() => client.terminate());
-});
 
 test('disableJsonRpc option forbids sendJsonRpc', async t => {
   const client = start({ logCallback: () => { } });

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -409,6 +409,9 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 /// format of the JSON-RPC requests and notifications is described in
 /// [the standard JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification).
 ///
+/// If the buffer isn't a valid JSON-RPC request, then an error JSON-RPC response with an `id`
+/// equal to `null` is generated, in accordance with the JSON-RPC 2.0 specification.
+///
 /// Assign a so-called "buffer index" (a `u32`) representing the buffer containing the UTF-8
 /// request, then provide this buffer index to the function. The Rust code will call
 /// [`buffer_size`] and [`buffer_copy`] in order to obtain the content of this buffer. The buffer
@@ -422,8 +425,7 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 ///
 /// This function returns:
 /// - 0 on success.
-/// - 1 if the request couldn't be parsed as a valid JSON-RPC request.
-/// - 2 if the chain has too many pending JSON-RPC requests and refuses to queue another one.
+/// - 1 if the chain has too many pending JSON-RPC requests and refuses to queue another one.
 ///
 #[no_mangle]
 pub extern "C" fn json_rpc_send(text_buffer_index: u32, chain_id: u32) -> u32 {

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -245,8 +245,7 @@ fn json_rpc_send(json_rpc_request: Vec<u8>, chain_id: u32) -> u32 {
         .json_rpc_request(json_rpc_request, client_chain_id)
     {
         Ok(()) => 0,
-        Err(HandleRpcError::MalformedJsonRpc(_)) => 1,
-        Err(HandleRpcError::TooManyPendingRequests { .. }) => 2,
+        Err(HandleRpcError::TooManyPendingRequests { .. }) => 1,
     }
 }
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1098

Removing this makes smoldot "more conforming" to the specification. It removes possible confusion due to the fact that smoldot didn't do exactly what the JSON-RPC specification says should happen.

It also makes it easier in general to plug an actual TCP/IP JSON-RPC server on top of a light client if needed, without having to understand the JSON-RPC specification.

The drawback of this PR is that it removes feedback about which request exactly has an issue. However this is very much a "never supposed to happen" problem, and this feedback is pretty useless.
