### PR TITLE
Yield pruned blocks from sync state machines and consensus service notifications

### DIFF
--- a/lib/src/chain/fork_tree.rs
+++ b/lib/src/chain/fork_tree.rs
@@ -242,9 +242,9 @@ impl<T> ForkTree<T> {
     /// Returns an iterator containing the removed elements.
     /// All elements are removed from the tree even if the returned iterator is dropped eagerly.
     ///
-    /// Elements are returned in an unspecified order. However, all the elements for which
-    /// [`PrunedNode::is_prune_target_ancestor`] is `true` are guaranteed to be returned from
-    /// child to parent.
+    /// Elements are returned in an unspecified order. However, each element yielded is guaranteed
+    /// to be yielded *before* its parent gets yielded.
+    /// This can be more or less called "reverse hierarchical order".
     ///
     /// In other words, doing `prune_ancestors(...).filter(|n| n.is_prune_target_ancestor)` is
     /// guaranteed to return the elements in the same order as [`ForkTree::node_to_root_path`]

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2697,6 +2697,7 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                         sync,
                         all_forks::FinalityProofVerifyOutcome::NewFinalized {
                             finalized_blocks,
+                            pruned_blocks,
                             updates_best_block,
                         },
                     ) => (
@@ -2710,6 +2711,10 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                                     justifications: Vec::new(), // TODO: wrong
                                     user_data: b.1.unwrap(),
                                 })
+                                .collect(),
+                            pruned_blocks: pruned_blocks
+                                .into_iter()
+                                .map(|b| b.0.hash(self.shared.block_number_bytes))
                                 .collect(),
                             updates_best_block,
                         },
@@ -2753,6 +2758,7 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                                 full: b.full.map(|b| BlockFull { body: b.body }),
                             })
                             .collect(),
+                        pruned_blocks: Vec::new(),
                         updates_best_block: false,
                     },
                 ),
@@ -2775,7 +2781,9 @@ pub enum FinalityProofVerifyOutcome<TBl> {
     NewFinalized {
         /// List of finalized blocks, in decreasing block number.
         finalized_blocks: Vec<Block<TBl>>,
-        // TODO: missing pruned blocks
+        /// List of hashes of blocks that are no longer descendant of the finalized block, in
+        /// an unspecified order.
+        pruned_blocks: Vec<[u8; 32]>,
         /// If `true`, this operation modifies the best block of the non-finalized chain.
         /// This can happen if the previous best block isn't a descendant of the now finalized
         /// block.

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -1104,6 +1104,8 @@ impl<TRq, TSrc, TBl> JustificationVerify<TRq, TSrc, TBl> {
         // complexity to avoid it is probably not worth the speed gain.
         let finalized_blocks = apply
             .apply()
+            .filter(|b| matches!(b.ty, blocks_tree::RemovedBlockType::Finalized))
+            .map(|b| b.user_data)
             .collect::<Vec<_>>()
             .into_iter()
             .rev()


### PR DESCRIPTION
Yield pruned blocks from `NonFinalizedTree` and propagate them through the stack. Will make #1102 easier to do.