### PR TITLE
Fix panic when subscribing to consensus service notifications

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -807,12 +807,7 @@ impl SyncBackground {
                                 .sync
                                 .finalized_block_header()
                                 .scale_encoding_vec(self.sync.block_number_bytes());
-                            let finalized_block_height = header::decode(&finalized_block_scale_encoded_header, self.sync.block_number_bytes()).unwrap().number;
                             let finalized_block_hash = header::hash_from_scale_encoded_header(&finalized_block_scale_encoded_header);
-                            let finalized_block_runtime = match &self.sync[(finalized_block_height, &finalized_block_hash)] {
-                                NonFinalizedBlock::Verified { runtime } => runtime.clone(),
-                                _ => unreachable!()
-                            };
 
                             let non_finalized_blocks_ancestry_order = {
                                 let best_hash = self.sync.best_block_hash();
@@ -825,7 +820,7 @@ impl SyncBackground {
                                         NonFinalizedBlock::Verified { runtime } => runtime.clone(),
                                         _ => unreachable!()
                                     };
-                                    let runtime_update = if Arc::ptr_eq(&finalized_block_runtime, &runtime) {
+                                    let runtime_update = if Arc::ptr_eq(&self.finalized_runtime, &runtime) {
                                         None
                                     } else {
                                         Some(Arc::new(runtime.lock().await.clone().unwrap()))
@@ -848,7 +843,7 @@ impl SyncBackground {
                                 id: SubscriptionId(0), // TODO:
                                 finalized_block_hash,
                                 finalized_block_scale_encoded_header,
-                                finalized_block_runtime: Arc::new(finalized_block_runtime.lock().await.clone().unwrap()),
+                                finalized_block_runtime: Arc::new(self.finalized_runtime.lock().await.clone().unwrap()),
                                 non_finalized_blocks_ancestry_order,
                                 new_blocks,
                             });


### PR DESCRIPTION
The syncing state machine has no user data for the finalized block, by design.