### PR TITLE
Implement `state_getRuntimeVersion` for the full node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "hex",
  "humantime",
+ "lru",
  "mick-jaeger",
  "rand",
  "serde",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -29,6 +29,7 @@ futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 humantime = { version = "2.1.0", default-features = false }
+lru = { version = "0.11.0", default-features = false }
 mick-jaeger = "0.1.8"
 rand = "0.8.5"
 serde = { version = "1.0.183", default-features = false, features = ["derive"] }

--- a/full-node/src/json_rpc_service/runtime_caches_service.rs
+++ b/full-node/src/json_rpc_service/runtime_caches_service.rs
@@ -1,0 +1,185 @@
+// Smoldot
+// Copyright (C) 2023  Pierre Krieger
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{database_thread, LogCallback};
+
+use futures_channel::oneshot;
+use futures_lite::{Future, StreamExt as _};
+use smol::lock::Mutex;
+use smoldot::{database::full_sqlite, executor, trie};
+use std::{iter, num::NonZeroUsize, pin::Pin, sync::Arc};
+
+/// Configuration of the service.
+pub struct Config {
+    /// Closure that spawns background tasks.
+    pub tasks_executor: Arc<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync>,
+
+    /// Function called in order to notify of something.
+    pub log_callback: Arc<dyn LogCallback + Send + Sync>,
+
+    /// Database to access blocks.
+    pub database: Arc<database_thread::DatabaseThread>,
+
+    /// Number of entries in the cache of runtimes.
+    pub num_cache_entries: NonZeroUsize,
+}
+
+/// A running runtime caches service.
+pub struct RuntimeCachesService {
+    to_background: Mutex<async_channel::Sender<Message>>,
+}
+
+/// Message sent from the frontend to the background task.
+enum Message {
+    Get {
+        block_hash: [u8; 32],
+        result_tx: oneshot::Sender<Result<Arc<executor::host::HostVmPrototype>, GetError>>,
+    },
+}
+
+impl RuntimeCachesService {
+    /// Start a new service.
+    pub fn new(config: Config) -> Self {
+        let (to_background, mut from_foreground) = async_channel::bounded(16);
+
+        (config.tasks_executor)(Box::pin(async move {
+            let mut cache =
+                lru::LruCache::<[u8; 32], Result<_, GetError>>::new(config.num_cache_entries);
+
+            loop {
+                match from_foreground.next().await {
+                    Some(Message::Get {
+                        block_hash,
+                        result_tx,
+                    }) => {
+                        // Look in the cache.
+                        if let Some(cache_entry) = cache.get(&block_hash) {
+                            let _ = result_tx.send(cache_entry.clone());
+                            continue;
+                        }
+
+                        let (code, heap_pages) = config
+                            .database
+                            .with_database(move |database| {
+                                let code = database.block_storage_get(
+                                    &block_hash,
+                                    iter::empty::<iter::Empty<_>>(),
+                                    trie::bytes_to_nibbles(b":code".iter().copied()).map(u8::from),
+                                );
+                                let heap_pages = database.block_storage_get(
+                                    &block_hash,
+                                    iter::empty::<iter::Empty<_>>(),
+                                    trie::bytes_to_nibbles(b":heappages".iter().copied())
+                                        .map(u8::from),
+                                );
+                                (code, heap_pages)
+                            })
+                            .await;
+
+                        let runtime = match (code, heap_pages) {
+                            (Ok(Some((code, _))), Ok(heap_pages)) => {
+                                match executor::storage_heap_pages_to_value(
+                                    heap_pages.as_ref().map(|(h, _)| &h[..]),
+                                ) {
+                                    Ok(heap_pages) => executor::host::HostVmPrototype::new(
+                                        executor::host::Config {
+                                            module: &code,
+                                            heap_pages,
+                                            exec_hint: executor::vm::ExecHint::CompileAheadOfTime,
+                                            allow_unresolved_imports: true, // TODO: configurable? or if not, document
+                                        },
+                                    )
+                                    .map_err(GetError::InvalidRuntime),
+                                    Err(_) => Err(GetError::InvalidHeapPages),
+                                }
+                            }
+                            (Ok(None), Ok(_)) => Err(GetError::NoCode),
+                            (Err(full_sqlite::StorageAccessError::UnknownBlock), _)
+                            | (_, Err(full_sqlite::StorageAccessError::UnknownBlock)) => {
+                                // Note that we don't put the `CorruptedError` in the cache, in
+                                // case the database somehow recovers.
+                                let _ = result_tx.send(Err(GetError::UnknownBlock));
+                                continue;
+                            }
+                            (Err(full_sqlite::StorageAccessError::StoragePruned), _)
+                            | (_, Err(full_sqlite::StorageAccessError::StoragePruned)) => {
+                                // Note that we don't put the `CorruptedError` in the cache, in
+                                // case the database somehow recovers.
+                                let _ = result_tx.send(Err(GetError::Pruned));
+                                continue;
+                            }
+                            (Err(full_sqlite::StorageAccessError::Corrupted(_)), _)
+                            | (_, Err(full_sqlite::StorageAccessError::Corrupted(_))) => {
+                                // Note that we don't put the `CorruptedError` in the cache, in
+                                // case the database somehow recovers.
+                                let _ = result_tx.send(Err(GetError::CorruptedDatabase));
+                                continue;
+                            }
+                        };
+
+                        let runtime = runtime.map(Arc::new);
+                        cache.put(block_hash, runtime.clone());
+                        let _ = result_tx.send(runtime);
+                    }
+                    None => {
+                        // Stop the service.
+                        return;
+                    }
+                }
+            }
+        }));
+
+        RuntimeCachesService {
+            to_background: Mutex::new(to_background),
+        }
+    }
+
+    /// Obtains the runtime corresponding to a certain block.
+    pub async fn get(
+        &self,
+        block_hash: [u8; 32],
+    ) -> Result<Arc<executor::host::HostVmPrototype>, GetError> {
+        let (result_tx, result_rx) = oneshot::channel();
+        let _ = self
+            .to_background
+            .lock()
+            .await
+            .send(Message::Get {
+                block_hash,
+                result_tx,
+            })
+            .await;
+        result_rx.await.unwrap()
+    }
+}
+
+/// Error potentially returned by [`RuntimeCachesService::get`].
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum GetError {
+    /// Requested block couldn't be found in the database.
+    UnknownBlock,
+    /// Storage of requested block is no longer in the database.
+    Pruned,
+    /// Block doesn't have any storage entry at the key `:code`.
+    NoCode,
+    /// Invalid storage entry at `:heappages`.
+    InvalidHeapPages,
+    /// Database is corrupted.
+    CorruptedDatabase,
+    /// Impossible to compile the runtime.
+    InvalidRuntime(executor::host::NewErr),
+}

--- a/full-node/tests/json-rpc-general-requests.rs
+++ b/full-node/tests/json-rpc-general-requests.rs
@@ -134,6 +134,30 @@ fn chain_get_block_hash() {
 }
 
 #[test]
+fn state_get_runtime_version() {
+    smol::block_on(async move {
+        let client = start_client().await;
+
+        // Query the runtime of the genesis.
+        client.send_json_rpc_request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"state_getRuntimeVersion","params":["0x6bf30d04495c16ef053de4ac74eac35dfd6473e4907810f450bea1b976ac518f"]}"#.to_owned(),
+        );
+        let response_raw = client.next_json_rpc_response().await;
+        let (_, result_json) = json_rpc::parse::parse_response(&response_raw)
+            .unwrap()
+            .into_success()
+            .unwrap();
+        let decoded =
+            serde_json::from_str::<json_rpc::methods::RuntimeVersion>(result_json).unwrap();
+        assert_eq!(decoded.impl_name, "node-template");
+        assert_eq!(decoded.spec_version, 100);
+        assert_eq!(decoded.apis.len(), 10);
+
+        // TOOD: there are no tests for the corner cases of state_getRuntimeVersion because it's unclear how the function is supposed to behave at all
+    });
+}
+
+#[test]
 fn system_chain() {
     smol::block_on(async move {
         let client = start_client().await;


### PR DESCRIPTION
cc #1006 

Introduces a new "runtimes cache service" that hosts a cache of compiled runtime.

All the legacy JSON-RPC functions and `archive` JSON-RPC functions will make use of this service to obtain runtimes.
