### PR TITLE
Don't use `futures_util` in `jit.rs` anymore

### DIFF
--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -23,10 +23,7 @@ use super::{
 };
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{
-    fmt, future, mem, pin, ptr, slice,
-    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
-};
+use core::{fmt, future, mem, pin, ptr, slice, task};
 // TODO: we use std::sync::Mutex rather than parking_lot::Mutex due to issues with Cargo features, see <https://github.com/paritytech/smoldot/issues/2732>
 use std::sync::Mutex;
 
@@ -221,7 +218,7 @@ impl JitPrototype {
                                             ..
                                         } => {
                                             *in_interrupted_waker = Some(cx.waker().clone());
-                                            Poll::Pending
+                                            task::Poll::Pending
                                         }
                                         Shared::MemoryGrowRequired {
                                             ref memory,
@@ -238,7 +235,7 @@ impl JitPrototype {
                                                 ),
                                                 expected_return_ty,
                                             };
-                                            Poll::Pending
+                                            task::Poll::Pending
                                         }
                                         Shared::Return {
                                             ref mut return_value,
@@ -252,7 +249,7 @@ impl JitPrototype {
                                             }
 
                                             *shared_lock = Shared::OutsideFunctionCall { memory };
-                                            Poll::Ready(Ok(()))
+                                            task::Poll::Ready(Ok(()))
                                         }
                                         _ => unreachable!(),
                                     }
@@ -298,11 +295,11 @@ impl JitPrototype {
                 &base_components.module,
                 &imports
             )),
-            &mut Context::from_waker(&noop_waker()),
+            &mut task::Context::from_waker(&noop_waker()),
         ) {
-            Poll::Pending => return Err(NewErr::StartFunctionNotSupported), // TODO: hacky error value, as the error could also be different
-            Poll::Ready(Ok(i)) => i,
-            Poll::Ready(Err(err)) => return Err(NewErr::Instantiation(err.to_string())),
+            task::Poll::Pending => return Err(NewErr::StartFunctionNotSupported), // TODO: hacky error value, as the error could also be different
+            task::Poll::Ready(Ok(i)) => i,
+            task::Poll::Ready(Err(err)) => return Err(NewErr::Instantiation(err.to_string())),
         };
 
         // Now that we are passed the `start` stage, update the state of execution.
@@ -547,7 +544,7 @@ enum Shared {
         /// See [`Shared::WithinFunctionCall::expected_return_ty`].
         expected_return_ty: Option<ValueType>,
         /// See [`Shared::WithinFunctionCall::in_interrupted_waker`].
-        in_interrupted_waker: Option<Waker>,
+        in_interrupted_waker: Option<task::Waker>,
     },
     WithinFunctionCall {
         /// Pointer and size of the location where the virtual machine memory is located in the
@@ -565,7 +562,7 @@ enum Shared {
         /// `waker` that it has passed (the one stored here) wasn't waken up.
         /// This field therefore exists in order to future-proof against this possible optimization
         /// that `wasmtime` might perform in the future.
-        in_interrupted_waker: Option<Waker>,
+        in_interrupted_waker: Option<task::Waker>,
     },
     MemoryGrowRequired {
         memory: wasmtime::Memory,
@@ -732,9 +729,9 @@ impl Jit {
         // execution might be able to progress, hence the lack of need for a waker.
         match future::Future::poll(
             function_call.as_mut(),
-            &mut Context::from_waker(&noop_waker()),
+            &mut task::Context::from_waker(&noop_waker()),
         ) {
-            Poll::Ready((store, Ok(val))) => {
+            task::Poll::Ready((store, Ok(val))) => {
                 self.inner = JitInner::Done(store);
                 Ok(ExecOutcome::Finished {
                     // Since we verify at initialization that the signature of the function to
@@ -743,13 +740,13 @@ impl Jit {
                     return_value: Ok(val),
                 })
             }
-            Poll::Ready((store, Err(err))) => {
+            task::Poll::Ready((store, Err(err))) => {
                 self.inner = JitInner::Done(store);
                 Ok(ExecOutcome::Finished {
                     return_value: Err(Trap(err.to_string())),
                 })
             }
-            Poll::Pending => {
+            task::Poll::Pending => {
                 let mut shared_lock = self.shared.try_lock().unwrap();
                 match mem::replace(&mut *shared_lock, Shared::Poisoned) {
                     Shared::EnteredFunctionCall {
@@ -925,10 +922,10 @@ impl Jit {
                 // execution might be able to progress, hence the lack of need for a waker.
                 match future::Future::poll(
                     function_call.as_mut(),
-                    &mut Context::from_waker(&noop_waker()),
+                    &mut task::Context::from_waker(&noop_waker()),
                 ) {
-                    Poll::Ready(_) => unreachable!(),
-                    Poll::Pending => {
+                    task::Poll::Ready(_) => unreachable!(),
+                    task::Poll::Pending => {
                         debug_assert!(matches!(
                             *self.shared.try_lock().unwrap(),
                             Shared::WithinFunctionCall { .. }
@@ -954,15 +951,15 @@ impl fmt::Debug for Jit {
     }
 }
 
-fn noop_waker() -> Waker {
+fn noop_waker() -> task::Waker {
     // Safety: all the requirements in the documentation of wakers (e.g. thread safety) is
     // irrelevant here due to the implementation being trivial.
     unsafe {
-        fn clone(_: *const ()) -> RawWaker {
-            RawWaker::new(ptr::null(), &VTABLE)
+        fn clone(_: *const ()) -> task::RawWaker {
+            task::RawWaker::new(ptr::null(), &VTABLE)
         }
         fn noop(_: *const ()) {}
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
-        Waker::from_raw(RawWaker::new(ptr::null(), &VTABLE))
+        static VTABLE: task::RawWakerVTable = task::RawWakerVTable::new(clone, noop, noop, noop);
+        task::Waker::from_raw(task::RawWaker::new(ptr::null(), &VTABLE))
     }
 }


### PR DESCRIPTION
Continuing to phase out `futures_util`.

cc https://github.com/smol-dot/smoldot/issues/133