### PR TITLE
Implement `chain_subscribeNewHeads` for the full node

### DIFF
--- a/full-node/tests/json-rpc-general-requests.rs
+++ b/full-node/tests/json-rpc-general-requests.rs
@@ -301,3 +301,4 @@ fn system_version() {
 }
 
 // TODO: add tests for `chain_subscribeAllHeads`
+// TODO: add tests for `chain_subscribeNewHeads`


### PR DESCRIPTION
cc #1006 

PolkadotJS no longer "crashes" when connecting to the full node after that.