### PR TITLE
Unify the ordering when multiple blocks are finalized at once

### DIFF
--- a/full-node/src/json_rpc_service/chain_head_subscriptions.rs
+++ b/full-node/src/json_rpc_service/chain_head_subscriptions.rs
@@ -255,7 +255,7 @@ pub async fn spawn_chain_head_subscription_task(mut config: Config) -> String {
                 }
                 WhatHappened::ConsensusNotification(
                     consensus_service::Notification::Finalized {
-                        finalized_blocks_hashes,
+                        finalized_blocks_newest_to_oldest,
                         pruned_blocks_hashes,
                         best_block_hash,
                     },
@@ -265,9 +265,13 @@ pub async fn spawn_chain_head_subscription_task(mut config: Config) -> String {
                             methods::ServerToClient::chainHead_unstable_followEvent {
                                 subscription: (&json_rpc_subscription_id).into(),
                                 result: methods::FollowEvent::Finalized {
-                                    finalized_blocks_hashes: finalized_blocks_hashes
+                                    // As specified in the JSON-RPC spec, the list must be ordered
+                                    // in increasing block number. Consequently we have to reverse
+                                    // the list.
+                                    finalized_blocks_hashes: finalized_blocks_newest_to_oldest
                                         .into_iter()
                                         .map(methods::HashHexString)
+                                        .rev()
                                         .collect(),
                                     pruned_blocks_hashes: pruned_blocks_hashes
                                         .into_iter()

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -2696,14 +2696,14 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                     (
                         sync,
                         all_forks::FinalityProofVerifyOutcome::NewFinalized {
-                            finalized_blocks,
+                            finalized_blocks_newest_to_oldest,
                             pruned_blocks,
                             updates_best_block,
                         },
                     ) => (
                         sync,
                         FinalityProofVerifyOutcome::NewFinalized {
-                            finalized_blocks: finalized_blocks
+                            finalized_blocks_newest_to_oldest: finalized_blocks_newest_to_oldest
                                 .into_iter()
                                 .map(|b| Block {
                                     full: None, // TODO: wrong
@@ -2742,14 +2742,19 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                 )
             }
             FinalityProofVerifyInner::Optimistic(verify) => match verify.perform(randomness_seed) {
-                (inner, optimistic::JustificationVerification::Finalized { finalized_blocks }) => (
+                (
+                    inner,
+                    optimistic::JustificationVerification::Finalized {
+                        finalized_blocks_newest_to_oldest: finalized_blocks,
+                    },
+                ) => (
                     // TODO: transition to all_forks
                     AllSync {
                         inner: AllSyncInner::Optimistic { inner },
                         shared: self.shared,
                     },
                     FinalityProofVerifyOutcome::NewFinalized {
-                        finalized_blocks: finalized_blocks
+                        finalized_blocks_newest_to_oldest: finalized_blocks
                             .into_iter()
                             .map(|b| Block {
                                 header: b.header,
@@ -2780,7 +2785,7 @@ pub enum FinalityProofVerifyOutcome<TBl> {
     /// Proof verification successful. The block and all its ancestors is now finalized.
     NewFinalized {
         /// List of finalized blocks, in decreasing block number.
-        finalized_blocks: Vec<Block<TBl>>,
+        finalized_blocks_newest_to_oldest: Vec<Block<TBl>>,
         /// List of hashes of blocks that are no longer descendant of the finalized block, in
         /// an unspecified order.
         pruned_blocks: Vec<[u8; 32]>,

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -2180,7 +2180,7 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
                                 finalized_blocks.last().unwrap().0.number,
                             );
                         FinalityProofVerifyOutcome::NewFinalized {
-                            finalized_blocks,
+                            finalized_blocks_newest_to_oldest: finalized_blocks,
                             pruned_blocks,
                             updates_best_block,
                         }
@@ -2244,7 +2244,7 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
                                 finalized_blocks.last().unwrap().0.number,
                             );
                         FinalityProofVerifyOutcome::NewFinalized {
-                            finalized_blocks,
+                            finalized_blocks_newest_to_oldest: finalized_blocks,
                             pruned_blocks,
                             updates_best_block,
                         }
@@ -2337,7 +2337,7 @@ pub enum FinalityProofVerifyOutcome<TBl> {
     NewFinalized {
         /// List of finalized blocks, in decreasing block number.
         // TODO: use `Vec<u8>` instead of `Header`?
-        finalized_blocks: Vec<(header::Header, TBl)>,
+        finalized_blocks_newest_to_oldest: Vec<(header::Header, TBl)>,
         /// List of blocks that aren't descendant of the latest finalized block, in an unspecified order.
         pruned_blocks: Vec<(header::Header, TBl)>,
         /// If `true`, this operation modifies the best block of the non-finalized chain.

--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -1097,18 +1097,10 @@ impl<TRq, TSrc, TBl> JustificationVerify<TRq, TSrc, TBl> {
             .push((consensus_engine_id, justification));
 
         // Applying the finalization and iterating over the now-finalized block.
-        // Since `apply()` returns the blocks in decreasing block number, we have
-        // to revert the list in order to get them in increasing block number
-        // instead.
-        // While this intermediary buffering is an overhead, the increased code
-        // complexity to avoid it is probably not worth the speed gain.
-        let finalized_blocks = apply
+        let finalized_blocks_newest_to_oldest = apply
             .apply()
             .filter(|b| matches!(b.ty, blocks_tree::RemovedBlockType::Finalized))
             .map(|b| b.user_data)
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
             .collect();
 
         // Since the best block is now the finalized block, reset the storage
@@ -1123,7 +1115,9 @@ impl<TRq, TSrc, TBl> JustificationVerify<TRq, TSrc, TBl> {
                 chain: self.chain,
                 inner: self.inner,
             },
-            JustificationVerification::Finalized { finalized_blocks },
+            JustificationVerification::Finalized {
+                finalized_blocks_newest_to_oldest,
+            },
         )
     }
 }
@@ -1144,8 +1138,8 @@ pub enum JustificationVerification<TBl> {
     ///
     /// There might be more blocks remaining. Call [`OptimisticSync::process_one`] again.
     Finalized {
-        /// Blocks that have been finalized.
-        finalized_blocks: Vec<Block<TBl>>,
+        /// Blocks that have been finalized, in decreasing block number.
+        finalized_blocks_newest_to_oldest: Vec<Block<TBl>>,
     },
 }
 

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -928,7 +928,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         sync,
                         all::FinalityProofVerifyOutcome::NewFinalized {
                             updates_best_block,
-                            finalized_blocks,
+                            finalized_blocks_newest_to_oldest,
                             ..
                         },
                     ) => {
@@ -937,7 +937,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         log::debug!(
                             target: &self.log_target,
                             "Sync => FinalityProofVerified(finalized_blocks={})",
-                            finalized_blocks.len(),
+                            finalized_blocks_newest_to_oldest.len(),
                         );
 
                         if updates_best_block {
@@ -946,7 +946,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         self.network_up_to_date_finalized = false;
                         // Invalidate the cache of the runtime of the finalized blocks if any
                         // of the finalized blocks indicates that a runtime update happened.
-                        if finalized_blocks
+                        if finalized_blocks_newest_to_oldest
                             .iter()
                             .any(|b| b.header.digest.has_runtime_environment_updated())
                         {


### PR DESCRIPTION
Fixes a discrepancy between optimistic and all forks syncing strategies where the finalized blocks were reported in a different order.

This has no consequence for the light client, because the code of `chainHead` maintains its own tree of blocks.

For the full node, however, this fixes some panics in the JSON-RPC functions.
