### PR TITLE
Update `wat` and `wast`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.32.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba64e81215916eaeb48fee292f29401d69235d62d8b8fd92a7b2844ec5ae5f7"
+checksum = "b39de0723a53d3c8f54bed106cfbc0d06b3e4d945c5c5022115a61e3b29183ae"
 dependencies = [
  "leb128",
 ]
@@ -3171,21 +3171,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "64.0.0"
+version = "65.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a259b226fd6910225aa7baeba82f9d9933b6d00f2ce1b49b80fa4214328237cc"
+checksum = "5fd8c1cbadf94a0b0d1071c581d3cfea1b7ed5192c79808dd15406e508dd0afb"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.32.0",
+ "wasm-encoder 0.33.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53253d920ab413fca1c7dc2161d601c79b4fdf631d0ba51dd4343bf9b556c3f6"
+checksum = "3209e35eeaf483714f4c6be93f4a03e69aad5f304e3fa66afa7cb90fe1c8051f"
 dependencies = [
  "wast",
 ]

--- a/lib/src/executor/vm/tests.rs
+++ b/lib/src/executor/vm/tests.rs
@@ -1191,15 +1191,15 @@ fn feature_disabled_tail_call() {
     (module
         (import "env" "memory" (memory $mem 0 4096))
         (func $fac (param $x i64) (result i64)
-            (return_call $fac-aux (get_local $x) (i64.const 1))
+            (return_call $fac-aux (local.get $x) (i64.const 1))
         )
         (func $fac-aux (param $x i64) (param $r i64) (result i64)
-          (if (i64.eqz (get_local $x))
-            (then (return (get_local $r)))
+          (if (i64.eqz (local.get $x))
+            (then (return (local.get $r)))
             (else
               (return_call $fac-aux
-                (i64.sub (get_local $x) (i64.const 1))
-                (i64.mul (get_local $x) (get_local $r))
+                (i64.sub (local.get $x) (i64.const 1))
+                (i64.mul (local.get $x) (local.get $r))
               )
             )
           )


### PR DESCRIPTION
Investigating the CI failure of https://github.com/smol-dot/smoldot/pull/1159, it turns out that `wast` removed support for some deprecated syntax we were accidentally using: https://github.com/bytecodealliance/wasm-tools/pull/1184