### PR TITLE
No longer panic on Aura consensus epoch change

### DIFF
--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -196,7 +196,7 @@ impl<T> NonFinalizedTree<T> {
                 // No Aura epoch transition. Just a regular block.
                 (
                     verify::header_only::Success::Aura {
-                        authorities_change: false,
+                        authorities_change: None,
                     },
                     Some(BlockConsensus::Aura {
                         authorities_list: parent_authorities,
@@ -214,17 +214,18 @@ impl<T> NonFinalizedTree<T> {
                 // Aura epoch transition.
                 (
                     verify::header_only::Success::Aura {
-                        authorities_change: true,
+                        authorities_change: Some(new_authorities_list),
                     },
                     Some(BlockConsensus::Aura { .. }),
                     FinalizedConsensus::Aura { .. },
                     _,
-                ) => {
-                    todo!() // TODO: fetch from header
-                            /*BlockConsensus::Aura {
-                                authorities_list:
-                            }*/
-                }
+                ) => (
+                    parent_best_score.num_primary_slots + 1,
+                    parent_best_score.num_secondary_slots,
+                    BlockConsensus::Aura {
+                        authorities_list: Arc::new(new_authorities_list),
+                    },
+                ),
 
                 // No Babe epoch transition. Just a regular block.
                 (

--- a/lib/src/verify/aura.rs
+++ b/lib/src/verify/aura.rs
@@ -47,6 +47,7 @@
 
 use crate::header;
 
+use alloc::vec::Vec;
 use core::{num::NonZeroU64, time::Duration};
 
 /// Configuration for [`verify_header`].

--- a/lib/src/verify/header_only.rs
+++ b/lib/src/verify/header_only.rs
@@ -21,6 +21,7 @@ use crate::{
     verify::{aura, babe},
 };
 
+use alloc::vec::Vec;
 use core::{num::NonZeroU64, time::Duration};
 
 /// Configuration for a block verification.

--- a/lib/src/verify/header_only.rs
+++ b/lib/src/verify/header_only.rs
@@ -114,8 +114,9 @@ pub enum ConfigFinality {
 pub enum Success {
     /// Chain is using the Aura consensus engine.
     Aura {
-        /// True if the list of authorities is modified by this block.
-        authorities_change: bool,
+        /// `Some` if the list of authorities is modified by this block. Contains the new list of
+        /// authorities.
+        authorities_change: Option<Vec<header::AuraAuthority>>,
     },
 
     /// Chain is using the Babe consensus engine.


### PR DESCRIPTION
This PR fixes a long-standing `todo!()` in the `NonFinalizedTree` that would trigger on an Aura authorities list change.