### PR TITLE
Move `is_initiator` to handshake options

### DIFF
--- a/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/fuzz/fuzz_targets/network-connection-raw.rs
@@ -56,9 +56,9 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     let (_id, mut task) = collection.insert_single_stream(
         Duration::new(0, 0),
         smoldot::libp2p::collection::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux {
+            is_initiator,
             noise_key: &smoldot::libp2p::connection::NoiseKey::new(&[0; 32], &[0; 32]),
         },
-        is_initiator,
         (),
     );
 

--- a/lib/src/libp2p/peers.rs
+++ b/lib/src/libp2p/peers.rs
@@ -968,11 +968,11 @@ where
             match handshake_kind {
                 SingleStreamHandshakeKind::MultistreamSelectNoiseYamux => {
                     collection::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux {
+                        is_initiator: false,
                         noise_key: &self.noise_key,
                     }
                 }
             },
-            false,
             Connection {
                 peer_index: None,
                 user_data,
@@ -1006,11 +1006,11 @@ where
             match handshake_kind {
                 SingleStreamHandshakeKind::MultistreamSelectNoiseYamux => {
                     collection::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux {
+                        is_initiator: true,
                         noise_key: &self.noise_key,
                     }
                 }
             },
-            true,
             Connection {
                 peer_index: Some(peer_index),
                 user_data,
@@ -1048,11 +1048,11 @@ where
                     remote_tls_certificate_multihash,
                 } => collection::MultiStreamHandshakeKind::WebRtc {
                     noise_key: &self.noise_key,
+                    is_initiator: false,
                     local_tls_certificate_multihash,
                     remote_tls_certificate_multihash,
                 },
             },
-            false,
             Connection {
                 peer_index: None,
                 user_data,
@@ -1092,11 +1092,11 @@ where
                     remote_tls_certificate_multihash,
                 } => collection::MultiStreamHandshakeKind::WebRtc {
                     noise_key: &self.noise_key,
+                    is_initiator: true,
                     local_tls_certificate_multihash,
                     remote_tls_certificate_multihash,
                 },
             },
-            true,
             Connection {
                 peer_index: Some(peer_index),
                 user_data,


### PR DESCRIPTION
Moves the `is_initiator` option to the handshake configuration, as this value is only ever used for "meta" purposes.