### PR TITLE
Some tweaks to the connection start time parameters

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -172,7 +172,7 @@ enum ToBackground {
     IncomingConnection {
         socket: TcpStream,
         multiaddr: Multiaddr,
-        when_connected: Instant,
+        when_accepted: Instant,
     },
     StartKademliaDiscoveries {
         when_done: oneshot::Sender<()>,
@@ -421,6 +421,8 @@ impl NetworkService {
                             break;
                         };
 
+                        let when_accepted = Instant::now();
+
                         let (socket, addr) = match accept_result {
                             Ok(v) => v,
                             Err(_) => {
@@ -461,7 +463,7 @@ impl NetworkService {
                             .send(ToBackground::IncomingConnection {
                                 socket,
                                 multiaddr,
-                                when_connected: Instant::now(),
+                                when_accepted,
                             })
                             .await;
                     }
@@ -1281,11 +1283,11 @@ async fn background_task(mut inner: Inner) {
             ToBackground::IncomingConnection {
                 socket,
                 multiaddr,
-                when_connected,
+                when_accepted,
             } => {
                 let (connection_id, connection_task) =
                     inner.network.add_single_stream_incoming_connection(
-                        when_connected,
+                        when_accepted,
                         service::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux,
                         multiaddr.clone(),
                     );

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -378,14 +378,14 @@ where
 
     /// Adds a new single-stream connection to the collection.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     ///
     /// `is_initiator` must be `true` if the connection has been initiated locally, or `false` if
     /// it has been initiated by the remote.
     pub fn insert_single_stream(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: SingleStreamHandshakeKind,
         is_initiator: bool,
         user_data: TConn,
@@ -432,7 +432,7 @@ where
                     is_initiator,
                 )
             },
-            handshake_timeout: when_connected + self.handshake_timeout,
+            handshake_timeout: when_connection_start + self.handshake_timeout,
             max_inbound_substreams: self.max_inbound_substreams,
             substreams_capacity,
             max_protocol_name_len,
@@ -453,11 +453,11 @@ where
 
     /// Adds a new multi-stream connection to the collection.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     pub fn insert_multi_stream<TSubId>(
         &mut self,
-        now: TNow,
+        when_connection_start: TNow,
         handshake_kind: MultiStreamHandshakeKind,
         is_initiator: bool,
         user_data: TConn,
@@ -533,7 +533,7 @@ where
                 self.randomness_seeds.fill_bytes(&mut seed);
                 seed
             },
-            now,
+            when_connection_start,
             handshake,
             self.max_inbound_substreams,
             substreams_capacity,

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -386,9 +386,6 @@ where
     ///
     /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
     /// order to determine when the handshake timeout expires.
-    ///
-    /// `is_initiator` must be `true` if the connection has been initiated locally, or `false` if
-    /// it has been initiated by the remote.
     pub fn insert_single_stream(
         &mut self,
         when_connection_start: TNow,

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -144,7 +144,7 @@ where
     // a function only called from the parent module.
     pub(super) fn new(
         randomness_seed: [u8; 32],
-        now: TNow,
+        when_connection_start: TNow,
         handshake: noise::HandshakeInProgress,
         max_inbound_substreams: usize,
         substreams_capacity: usize,
@@ -153,6 +153,7 @@ where
     ) -> Self {
         MultiStreamConnectionTask {
             connection: MultiStreamConnectionTaskInner::Handshake {
+                // TODO: the handshake doesn't have a timeout
                 handshake: Some(handshake),
                 opened_substream: None,
                 handshake_read_buffer: Vec::new(),
@@ -168,7 +169,7 @@ where
                     ping_protocol: ping_protocol.to_string(), // TODO: cloning :-/
                     ping_interval: Duration::from_secs(20),   // TODO: hardcoded
                     ping_timeout: Duration::from_secs(10),    // TODO: hardcoded
-                    first_out_ping: now + Duration::from_secs(2), // TODO: hardcoded
+                    first_out_ping: when_connection_start, // TODO: only start the ping after the Noise handshake has ended
                 })),
             },
         }

--- a/lib/src/libp2p/peers.rs
+++ b/lib/src/libp2p/peers.rs
@@ -955,16 +955,16 @@ where
     /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
     /// yet.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     pub fn add_single_stream_incoming_connection(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: SingleStreamHandshakeKind,
         user_data: TConn,
     ) -> (ConnectionId, SingleStreamConnectionTask<TNow>) {
         self.inner.insert_single_stream(
-            when_connected,
+            when_connection_start,
             match handshake_kind {
                 SingleStreamHandshakeKind::MultistreamSelectNoiseYamux => {
                     collection::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux {
@@ -988,11 +988,11 @@ where
     /// called, the provided `expected_peer_id` will no longer be part of the return value of
     /// [`Peers::unfulfilled_desired_peers`].
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     pub fn add_single_stream_outgoing_connection(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: SingleStreamHandshakeKind,
         expected_peer_id: &PeerId,
         user_data: TConn,
@@ -1002,7 +1002,7 @@ where
         self.unfulfilled_desired_peers.remove(&peer_index);
 
         let (connection_id, connection_task) = self.inner.insert_single_stream(
-            when_connected,
+            when_connection_start,
             match handshake_kind {
                 SingleStreamHandshakeKind::MultistreamSelectNoiseYamux => {
                     collection::SingleStreamHandshakeKind::MultistreamSelectNoiseYamux {
@@ -1029,11 +1029,11 @@ where
     /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
     /// yet.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     pub fn add_multi_stream_incoming_connection<TSubId>(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: MultiStreamHandshakeKind,
         user_data: TConn,
     ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
@@ -1041,7 +1041,7 @@ where
         TSubId: Clone + PartialEq + Eq + Hash,
     {
         self.inner.insert_multi_stream(
-            when_connected,
+            when_connection_start,
             match handshake_kind {
                 MultiStreamHandshakeKind::WebRtc {
                     local_tls_certificate_multihash,
@@ -1068,11 +1068,11 @@ where
     /// called, the provided `expected_peer_id` will no longer be part of the return value of
     /// [`Peers::unfulfilled_desired_peers`].
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection process has been started, in
+    /// order to determine when the handshake timeout expires.
     pub fn add_multi_stream_outgoing_connection<TSubId>(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: MultiStreamHandshakeKind,
         expected_peer_id: &PeerId,
         user_data: TConn,
@@ -1085,7 +1085,7 @@ where
         self.unfulfilled_desired_peers.remove(&peer_index);
 
         let (connection_id, connection_task) = self.inner.insert_multi_stream(
-            when_connected,
+            when_connection_start,
             match handshake_kind {
                 MultiStreamHandshakeKind::WebRtc {
                     local_tls_certificate_multihash,

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -410,20 +410,20 @@ where
     /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
     /// yet.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection has first been opened, in
+    /// order to determine when the handshake timeout expires.
     ///
     /// The `remote_addr` is the address used to reach back the remote. In the case of TCP, it
     /// contains the TCP dialing port of the remote. The remote can ask, through the `identify`
     /// libp2p protocol, its own address, in which case we send it.
     pub fn add_single_stream_incoming_connection(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: SingleStreamHandshakeKind,
         remote_addr: multiaddr::Multiaddr,
     ) -> (ConnectionId, SingleStreamConnectionTask<TNow>) {
         self.inner.add_single_stream_incoming_connection(
-            when_connected,
+            when_connection_start,
             handshake_kind,
             remote_addr,
         )
@@ -434,23 +434,26 @@ where
     /// This connection hasn't finished handshaking and the [`PeerId`] of the remote isn't known
     /// yet.
     ///
-    /// Must be passed the moment (as a `TNow`) when the connection as been established, in order
-    /// to determine when the handshake timeout expires.
+    /// Must be passed the moment (as a `TNow`) when the connection has first been opened, in
+    /// order to determine when the handshake timeout expires.
     ///
     /// The `remote_addr` is the address used to reach back the remote. In the case of TCP, it
     /// contains the TCP dialing port of the remote. The remote can ask, through the `identify`
     /// libp2p protocol, its own address, in which case we send it.
     pub fn add_multi_stream_incoming_connection<TSubId>(
         &mut self,
-        when_connected: TNow,
+        when_connection_start: TNow,
         handshake_kind: MultiStreamHandshakeKind,
         remote_addr: multiaddr::Multiaddr,
     ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
     where
         TSubId: Clone + PartialEq + Eq + Hash,
     {
-        self.inner
-            .add_multi_stream_incoming_connection(when_connected, handshake_kind, remote_addr)
+        self.inner.add_multi_stream_incoming_connection(
+            when_connection_start,
+            handshake_kind,
+            remote_addr,
+        )
     }
 
     pub fn pull_message_to_connection(
@@ -504,10 +507,10 @@ where
         id: PendingId,
         handshake_kind: SingleStreamHandshakeKind,
     ) -> (ConnectionId, SingleStreamConnectionTask<TNow>) {
-        let (expected_peer_id, multiaddr, when_connected) = self.pending_ids.remove(id.0);
+        let (expected_peer_id, multiaddr, when_connection_start) = self.pending_ids.remove(id.0);
 
         let (connection_id, connection_task) = self.inner.add_single_stream_outgoing_connection(
-            when_connected,
+            when_connection_start,
             handshake_kind,
             &expected_peer_id,
             multiaddr,
@@ -546,10 +549,10 @@ where
     where
         TSubId: Clone + PartialEq + Eq + Hash,
     {
-        let (expected_peer_id, multiaddr, when_connected) = self.pending_ids.remove(id.0);
+        let (expected_peer_id, multiaddr, when_connection_start) = self.pending_ids.remove(id.0);
 
         let (connection_id, connection_task) = self.inner.add_multi_stream_outgoing_connection(
-            when_connected,
+            when_connection_start,
             handshake_kind,
             &expected_peer_id,
             multiaddr,


### PR DESCRIPTION
This unifies the parameters passed to "insert single stream" and "insert multi stream".

Also clarifies that this must be when the connection has first started being opened. For outgoing connections, this is when we call `TcpStream::connect` rather than when `connect` returns. For incoming connections, we use the moment when `accept` returns as there's no better indication.
