### PR TITLE
Move list of protocols to `peers.rs`

### DIFF
--- a/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/fuzz/fuzz_targets/network-connection-raw.rs
@@ -35,8 +35,6 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             randomness_seed: [0; 32],
             capacity: 0,
             max_inbound_substreams: 10,
-            notification_protocols: Vec::new(),
-            request_response_protocols: Vec::new(),
             // This timeout doesn't matter as we pass dummy time values.
             handshake_timeout: Duration::from_secs(5),
             ping_protocol: "ping".into(),
@@ -59,6 +57,8 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             is_initiator,
             noise_key: &smoldot::libp2p::connection::NoiseKey::new(&[0; 32], &[0; 32]),
         },
+        0,
+        128,
         (),
     );
 

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -718,7 +718,6 @@ where
     ///
     /// # Panic
     ///
-    /// Panics if `overlay_network_index` isn't a valid index in [`Config::notification_protocols`].
     /// Panics if the [`ConnectionId`] is invalid or is a connection that hasn't finished its
     /// handshake or is shutting down.
     ///

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -133,50 +133,6 @@ pub struct Config {
     pub ping_protocol: String,
 }
 
-/// Configuration for a request-response protocol.
-#[derive(Debug, Clone)]
-pub struct ConfigRequestResponse {
-    /// Name of the protocol transferred on the wire.
-    pub name: String,
-
-    /// Configuration related to sending out requests through this protocol.
-    ///
-    /// > **Note**: This is used even if `inbound_allowed` is `false` when performing outgoing
-    /// >           requests.
-    pub inbound_config: ConfigRequestResponseIn,
-
-    pub max_response_size: usize,
-
-    /// If true, incoming substreams are allowed to negotiate this protocol.
-    pub inbound_allowed: bool,
-}
-
-/// See [`ConfigRequestResponse::inbound_config`].
-#[derive(Debug, Clone)]
-pub enum ConfigRequestResponseIn {
-    /// Request must be completely empty, not even a length prefix.
-    Empty,
-    /// Request must contain a length prefix plus a potentially empty payload.
-    Payload {
-        /// Maximum allowed size for the payload in bytes.
-        max_size: usize,
-    },
-}
-
-/// Configuration for a specific overlay network.
-///
-/// See [`Config::notification_protocols`].
-pub struct NotificationProtocolConfig {
-    /// Name of the protocol negotiated on the wire.
-    pub protocol_name: String,
-
-    /// Maximum size, in bytes, of the handshake that can be received.
-    pub max_handshake_size: usize,
-
-    /// Maximum size, in bytes, of a notification that can be received.
-    pub max_notification_size: usize,
-}
-
 /// Identifier of a connection spawned by the [`Network`].
 //
 // Identifiers are never reused.

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -660,6 +660,10 @@ where
                 Some(s) => s,
                 None => panic!(),
             };
+        let _was_in = self
+            .ingoing_negotiated_substreams_by_connection
+            .remove(&(connection_id, inner_substream_id));
+        debug_assert!(_was_in.is_some());
         assert!(!already_accepted);
 
         self.messages_to_connections.push_back((

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -21,7 +21,7 @@ use super::{
         read_write::ReadWrite,
     },
     ConnectionToCoordinator, ConnectionToCoordinatorInner, CoordinatorToConnection,
-    CoordinatorToConnectionInner, InboundTy, NotificationsOutErr, ShutdownCause, SubstreamId,
+    CoordinatorToConnectionInner, NotificationsOutErr, ShutdownCause, SubstreamId,
 };
 
 use alloc::{collections::VecDeque, string::ToString as _, sync::Arc};
@@ -82,7 +82,7 @@ enum SingleStreamConnectionTaskInner<TNow> {
 
     /// Connection has been fully established.
     Established {
-        established: established::SingleStream<TNow, either::Either<SubstreamId, usize>>,
+        established: established::SingleStream<TNow, Option<SubstreamId>>,
 
         /// Because outgoing substream ids are assigned by the coordinator, we maintain a mapping
         /// of the "outer ids" to "inner ids".
@@ -229,33 +229,11 @@ where
                     ..
                 },
             ) => {
-                let (inbound_ty, protocol_index) = match inbound_ty {
-                    InboundTy::Notifications {
-                        protocol_index,
-                        max_handshake_size,
-                    } => (
-                        established::InboundTy::Notifications { max_handshake_size },
-                        protocol_index,
-                    ),
-                    InboundTy::Request {
-                        protocol_index,
-                        request_max_size,
-                    } => (
-                        established::InboundTy::Request { request_max_size },
-                        protocol_index,
-                    ),
-                    InboundTy::Ping => (established::InboundTy::Ping, 0),
-                };
-
                 if !inbound_negotiated_cancel_acknowledgments.remove(&substream_id) {
-                    established.accept_inbound(
-                        substream_id,
-                        inbound_ty,
-                        either::Right(protocol_index),
-                    );
+                    established.accept_inbound(substream_id, inbound_ty, None);
                 } else {
                     self.pending_messages.push_back(
-                        ConnectionToCoordinatorInner::InboundAcceptedCancel { _id: substream_id },
+                        ConnectionToCoordinatorInner::InboundAcceptedCancel { id: substream_id },
                     )
                 }
             }
@@ -290,7 +268,7 @@ where
                     request_data,
                     timeout,
                     max_response_size,
-                    either::Left(substream_id),
+                    Some(substream_id),
                 );
 
                 let _prev_value = outbound_substreams_map.insert(substream_id, inner_substream_id);
@@ -315,7 +293,7 @@ where
                     handshake,
                     max_handshake_size,
                     now + Duration::from_secs(20), // TODO: make configurable
-                    either::Left(outer_substream_id),
+                    Some(outer_substream_id),
                 );
 
                 let _prev_value =
@@ -620,27 +598,19 @@ where
                         }
                         Some(established::Event::InboundAcceptedCancel { id, .. }) => {
                             self.pending_messages.push_back(
-                                ConnectionToCoordinatorInner::InboundAcceptedCancel { _id: id },
+                                ConnectionToCoordinatorInner::InboundAcceptedCancel { id },
                             );
                         }
                         Some(established::Event::RequestIn { id, request, .. }) => {
-                            let either::Right(protocol_index) = connection[id] else {
-                                panic!()
-                            };
-                            self.pending_messages.push_back(
-                                ConnectionToCoordinatorInner::RequestIn {
-                                    id,
-                                    protocol_index,
-                                    request,
-                                },
-                            );
+                            self.pending_messages
+                                .push_back(ConnectionToCoordinatorInner::RequestIn { id, request });
                         }
                         Some(established::Event::Response {
                             response,
                             user_data,
                             ..
                         }) => {
-                            let either::Left(outer_substream_id) = user_data else {
+                            let Some(outer_substream_id) = user_data else {
                                 panic!()
                             };
                             outbound_substreams_map.remove(&outer_substream_id).unwrap();
@@ -652,15 +622,8 @@ where
                             );
                         }
                         Some(established::Event::NotificationsInOpen { id, handshake, .. }) => {
-                            let either::Right(protocol_index) = connection[id] else {
-                                panic!()
-                            };
                             self.pending_messages.push_back(
-                                ConnectionToCoordinatorInner::NotificationsInOpen {
-                                    id,
-                                    protocol_index,
-                                    handshake,
-                                },
+                                ConnectionToCoordinatorInner::NotificationsInOpen { id, handshake },
                             );
                         }
                         Some(established::Event::NotificationsInOpenCancel { id, .. }) => {
@@ -682,13 +645,13 @@ where
                         Some(established::Event::NotificationsOutResult { id, result }) => {
                             let (outer_substream_id, result) = match result {
                                 Ok(r) => {
-                                    let either::Left(outer_substream_id) = connection[id] else {
+                                    let Some(outer_substream_id) = connection[id] else {
                                         panic!()
                                     };
                                     (outer_substream_id, Ok(r))
                                 }
                                 Err((err, ud)) => {
-                                    let either::Left(outer_substream_id) = ud else {
+                                    let Some(outer_substream_id) = ud else {
                                         panic!()
                                     };
                                     outbound_substreams_map.remove(&outer_substream_id);
@@ -704,7 +667,7 @@ where
                             );
                         }
                         Some(established::Event::NotificationsOutCloseDemanded { id }) => {
-                            let either::Left(outer_substream_id) = connection[id] else {
+                            let Some(outer_substream_id) = connection[id] else {
                                 panic!()
                             };
                             self.pending_messages.push_back(
@@ -714,7 +677,7 @@ where
                             );
                         }
                         Some(established::Event::NotificationsOutReset { user_data, .. }) => {
-                            let either::Left(outer_substream_id) = user_data else {
+                            let Some(outer_substream_id) = user_data else {
                                 panic!()
                             };
                             outbound_substreams_map.remove(&outer_substream_id);

--- a/lib/src/libp2p/peers.rs
+++ b/lib/src/libp2p/peers.rs
@@ -58,8 +58,7 @@ use core::{
 use rand_chacha::rand_core::{RngCore as _, SeedableRng as _};
 
 pub use collection::{
-    ConfigRequestResponse, ConfigRequestResponseIn, ConnectionId, ConnectionToCoordinator,
-    CoordinatorToConnection, MultiStreamConnectionTask, NotificationProtocolConfig,
+    ConnectionId, ConnectionToCoordinator, CoordinatorToConnection, MultiStreamConnectionTask,
     NotificationsInClosedErr, NotificationsOutErr, ReadWrite, RequestError,
     SingleStreamConnectionTask, SubstreamId,
 };
@@ -100,6 +99,50 @@ pub struct Config {
     /// This is a Noise static key, according to the Noise specification.
     /// Signed using the actual libp2p key.
     pub noise_key: libp2p::connection::NoiseKey,
+}
+
+/// Configuration for a request-response protocol.
+#[derive(Debug, Clone)]
+pub struct ConfigRequestResponse {
+    /// Name of the protocol transferred on the wire.
+    pub name: String,
+
+    /// Configuration related to sending out requests through this protocol.
+    ///
+    /// > **Note**: This is used even if `inbound_allowed` is `false` when performing outgoing
+    /// >           requests.
+    pub inbound_config: ConfigRequestResponseIn,
+
+    pub max_response_size: usize,
+
+    /// If true, incoming substreams are allowed to negotiate this protocol.
+    pub inbound_allowed: bool,
+}
+
+/// See [`ConfigRequestResponse::inbound_config`].
+#[derive(Debug, Clone)]
+pub enum ConfigRequestResponseIn {
+    /// Request must be completely empty, not even a length prefix.
+    Empty,
+    /// Request must contain a length prefix plus a potentially empty payload.
+    Payload {
+        /// Maximum allowed size for the payload in bytes.
+        max_size: usize,
+    },
+}
+
+/// Configuration for a specific overlay network.
+///
+/// See [`Config::notification_protocols`].
+pub struct NotificationProtocolConfig {
+    /// Name of the protocol negotiated on the wire.
+    pub protocol_name: String,
+
+    /// Maximum size, in bytes, of the handshake that can be received.
+    pub max_handshake_size: usize,
+
+    /// Maximum size, in bytes, of a notification that can be received.
+    pub max_notification_size: usize,
 }
 
 pub struct Peers<TConn, TNow> {


### PR DESCRIPTION
This PR is the continuation of https://github.com/smol-dot/smoldot/pull/462, and moves towards https://github.com/smol-dot/smoldot/issues/111

Instead of having the list of protocols in `collection.rs`, it is now found in `peers.rs`.
`collection.rs` now emits events about protocol negotiations that `peers.rs` must answer.

As always with the networking code, I'm not very happy about how it is, but I'm trying to define precise boundaries between the various modules before cleaning them up.

