### PR TITLE
Move notifications handshake timeout config to peers.rs

### DIFF
--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -726,7 +726,7 @@ where
         &mut self,
         connection_id: ConnectionId,
         protocol_name: String,
-        now: TNow,
+        handshake_timeout: TNow,
         handshake: impl Into<Vec<u8>>,
         max_handshake_size: usize,
     ) -> SubstreamId {
@@ -756,7 +756,7 @@ where
             CoordinatorToConnectionInner::OpenOutNotifications {
                 protocol_name,
                 handshake: handshake.into(),
-                now,
+                handshake_timeout,
                 max_handshake_size,
                 substream_id,
             },
@@ -1804,7 +1804,7 @@ enum CoordinatorToConnectionInner<TNow> {
         substream_id: SubstreamId,
         protocol_name: String,
         max_handshake_size: usize,
-        now: TNow,
+        handshake_timeout: TNow,
         handshake: Vec<u8>,
     },
     CloseOutNotifications {

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -441,7 +441,7 @@ where
                     max_handshake_size,
                     protocol_name,
                     handshake,
-                    now,
+                    handshake_timeout,
                     substream_id: outer_substream_id,
                 },
                 MultiStreamConnectionTaskInner::Established {
@@ -454,7 +454,7 @@ where
                     protocol_name,
                     max_handshake_size,
                     handshake,
-                    now + Duration::from_secs(20), // TODO: make configurable
+                    handshake_timeout,
                     Some(outer_substream_id),
                 );
 

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -279,7 +279,7 @@ where
                     protocol_name,
                     max_handshake_size,
                     handshake,
-                    now,
+                    handshake_timeout,
                     substream_id: outer_substream_id,
                 },
                 SingleStreamConnectionTaskInner::Established {
@@ -292,7 +292,7 @@ where
                     protocol_name,
                     handshake,
                     max_handshake_size,
-                    now + Duration::from_secs(20), // TODO: make configurable
+                    handshake_timeout,
                     Some(outer_substream_id),
                 );
 

--- a/lib/src/libp2p/peers.rs
+++ b/lib/src/libp2p/peers.rs
@@ -1735,7 +1735,7 @@ where
         let substream_id = self.inner.open_out_notifications(
             connection_id,
             protocol_name,
-            now,
+            now + Duration::from_secs(20), // TODO: make configurable
             handshake,
             max_handshake_size,
         );


### PR DESCRIPTION
Instead of passing "now" to the connection then calculating the timeout there, we directly pass the timeout to the connection.