### PR TITLE
Fix `TypeError` when calling `client.terminate()` after `Finalized block runtime ready...`

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix JavaScript error being thrown when `Client.terminate` is called while the client is not idle.
+- Fix JavaScript error being thrown when `Client.terminate` is called while the client is not idle. ([#1197](https://github.com/smol-dot/smoldot/pull/1197))
 
 ## 2.0.2 - 2023-09-25
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix JavaScript error being thrown when `Client.terminate` is called while the client is not idle.
+
 ## 2.0.2 - 2023-09-25
 
 ### Changed


### PR DESCRIPTION
Fix #1192