### PR TITLE
Fix storage items being silently discarded from requests

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix storage items requested through JSON-RPC functions not being sent to the JSON-RPC client when the full node doesn't send it back in the Merkle proof.
+
 ## 2.0.4 - 2023-10-11
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix storage items requested through JSON-RPC functions not being sent to the JSON-RPC client when the full node doesn't send it back in the Merkle proof.
+- Fix storage items requested through JSON-RPC functions not being sent to the JSON-RPC client when the full node doesn't send it back in the Merkle proof. ([#1216](https://github.com/smol-dot/smoldot/pull/1216))
 
 ## 2.0.4 - 2023-10-11
 


### PR DESCRIPTION
The algorithm here was completely wrong in the way it handles Merkle proofs that are missing entries.
Before #1209 this situation could only happen if full nodes were malicious, while afterwards this happens even in normal situations.
