### PR TITLE
Increase response nodes cap heuristic a bit

### DIFF
--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -486,7 +486,7 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
         // Number of nodes that are possible in a response before exceeding the response size
         // limit. Because the size of a trie node is unknown, this can only ever be a gross
         // estimate.
-        let mut response_nodes_cap = (1024 * 1024) / 164;
+        let mut response_nodes_cap = (16 * 1024 * 1024) / 164;
 
         let mut randomness = rand_chacha::ChaCha20Rng::from_seed({
             let mut seed = [0; 32];


### PR DESCRIPTION
Amends #1209 by increasing the cap a bit.
This is complete guess work, and it seems that after #1209 requests such as the list of validators take significantly longer than before. This PR increases the cap in order to fix that.