### PR TITLE
Increase threshold for truncating JSON-RPC requests/responses in logs

### DIFF
--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -134,7 +134,7 @@ impl Frontend {
     /// isn't called often enough.
     pub fn queue_rpc_request(&self, json_rpc_request: String) -> Result<(), HandleRpcError> {
         let log_friendly_request =
-            crate::util::truncated_str(json_rpc_request.chars().filter(|c| !c.is_control()), 100)
+            crate::util::truncated_str(json_rpc_request.chars().filter(|c| !c.is_control()), 250)
                 .to_string();
 
         match self
@@ -177,7 +177,7 @@ impl Frontend {
             "JSON-RPC <= {}",
             crate::util::truncated_str(
                 message.chars().filter(|c| !c.is_control()),
-                100,
+                250,
             )
         );
 


### PR DESCRIPTION
JSON-RPC requests and responses are truncated in logs if they are too long.
However "too long" is arbitrary and often requests/responses are truncated when it would have been useful to know what they're saying. This PR increases the threshold.