### PR TITLE
add method to expose storage_changes.trie_diffs

### DIFF
--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -253,6 +253,12 @@ impl StorageChanges {
             .remove(&None)
             .unwrap_or(storage_diff::TrieDiff::empty())
     }
+
+    pub fn trie_diffs(
+        &self,
+    ) -> &hashbrown::HashMap<Option<Vec<u8>>, storage_diff::TrieDiff, fnv::FnvBuildHasher> {
+        &self.inner.trie_diffs
+    }
 }
 
 impl fmt::Debug for StorageChanges {


### PR DESCRIPTION
We need this for chopsticks to get all the storage changes