### PR TITLE
Tweak when requests/notif handshakes timeouts start

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -243,7 +243,7 @@ struct Inner {
 
     active_connections: HashMap<
         service::ConnectionId,
-        channel::Sender<service::CoordinatorToConnection<Instant>>,
+        channel::Sender<service::CoordinatorToConnection>,
         fnv::FnvBuildHasher,
     >,
 
@@ -1314,9 +1314,7 @@ async fn background_task(mut inner: Inner) {
 
             ToBackground::StartKademliaDiscoveries { when_done } => {
                 for chain_index in 0..inner.databases.len() {
-                    let operation_id = inner
-                        .network
-                        .start_kademlia_discovery_round(Instant::now(), chain_index);
+                    let operation_id = inner.network.start_kademlia_discovery_round(chain_index);
                     let _prev_val = inner
                         .kademlia_discovery_operations
                         .insert(operation_id, chain_index);
@@ -1370,7 +1368,6 @@ async fn background_task(mut inner: Inner) {
                 // The call to `start_blocks_request` below panics if we have no active connection.
                 if inner.network.can_start_requests(&target) {
                     let request_id = inner.network.start_blocks_request(
-                        Instant::now(),
                         &target,
                         chain_index,
                         config,

--- a/full-node/src/network_service/tasks.rs
+++ b/full-node/src/network_service/tasks.rs
@@ -78,7 +78,7 @@ pub(super) async fn established_connection_task(
     socket: impl AsyncReadWrite,
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<Instant>,
-    mut coordinator_to_connection: channel::Receiver<service::CoordinatorToConnection<Instant>>,
+    mut coordinator_to_connection: channel::Receiver<service::CoordinatorToConnection>,
     connection_to_coordinator: channel::Sender<super::ToBackground>,
 ) {
     // The socket is wrapped around an object containing a read buffer and a write buffer and
@@ -163,7 +163,7 @@ pub(super) async fn established_connection_task(
         // Now wait for something interesting to happen before looping again.
 
         enum WhatHappened {
-            CoordinatorMessage(CoordinatorToConnection<Instant>),
+            CoordinatorMessage(CoordinatorToConnection),
             CoordinatorDead,
             SocketEvent,
             MessageSent,
@@ -218,7 +218,7 @@ pub(super) async fn established_connection_task(
 
         match what_happened {
             WhatHappened::CoordinatorMessage(message) => {
-                connection_task.inject_coordinator_message(message);
+                connection_task.inject_coordinator_message(&Instant::now(), message);
             }
             WhatHappened::CoordinatorDead => return,
             WhatHappened::SocketEvent => {}

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -380,7 +380,7 @@ where
     /// Calling this function might generate data to send to the connection. You should call
     /// [`MultiStreamConnectionTask::desired_outbound_substreams`] and
     /// [`MultiStreamConnectionTask::substream_read_write`] after this function has returned.
-    pub fn inject_coordinator_message(&mut self, message: CoordinatorToConnection<TNow>) {
+    pub fn inject_coordinator_message(&mut self, now: &TNow, message: CoordinatorToConnection) {
         match (message.inner, &mut self.connection) {
             (
                 CoordinatorToConnectionInner::AcceptInbound {
@@ -429,7 +429,7 @@ where
                 let inner_substream_id = established.add_request(
                     protocol_name,
                     request_data,
-                    timeout,
+                    now.clone() + timeout,
                     max_response_size,
                     Some(substream_id),
                 );
@@ -454,7 +454,7 @@ where
                     protocol_name,
                     max_handshake_size,
                     handshake,
-                    handshake_timeout,
+                    now.clone() + handshake_timeout,
                     Some(outer_substream_id),
                 );
 

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -216,7 +216,7 @@ where
     /// Calling this function might generate data to send to the connection. You should call
     /// [`SingleStreamConnectionTask::read_write`] after this function has returned (unless you
     /// have called [`SingleStreamConnectionTask::reset`] in the past).
-    pub fn inject_coordinator_message(&mut self, message: CoordinatorToConnection<TNow>) {
+    pub fn inject_coordinator_message(&mut self, now: &TNow, message: CoordinatorToConnection) {
         match (message.inner, &mut self.connection) {
             (
                 CoordinatorToConnectionInner::AcceptInbound {
@@ -266,7 +266,7 @@ where
                 let inner_substream_id = established.add_request(
                     protocol_name,
                     request_data,
-                    timeout,
+                    now.clone() + timeout,
                     max_response_size,
                     Some(substream_id),
                 );
@@ -292,7 +292,7 @@ where
                     protocol_name,
                     handshake,
                     max_handshake_size,
-                    handshake_timeout,
+                    now.clone() + handshake_timeout,
                     Some(outer_substream_id),
                 );
 

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -458,7 +458,7 @@ where
 
     pub fn pull_message_to_connection(
         &mut self,
-    ) -> Option<(ConnectionId, CoordinatorToConnection<TNow>)> {
+    ) -> Option<(ConnectionId, CoordinatorToConnection)> {
         self.inner.pull_message_to_connection()
     }
 
@@ -989,12 +989,8 @@ where
                 unreachable!()
             };
 
-            self.inner.open_out_notification(
-                &peer_id,
-                notifications_protocol_index,
-                now.clone(),
-                handshake,
-            );
+            self.inner
+                .open_out_notification(&peer_id, notifications_protocol_index, handshake);
         }
 
         event_to_return

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -900,7 +900,7 @@ struct BackgroundTask<TPlat: PlatformRef> {
 
     active_connections: HashMap<
         service::ConnectionId,
-        async_channel::Sender<service::CoordinatorToConnection<TPlat::Instant>>,
+        async_channel::Sender<service::CoordinatorToConnection>,
         fnv::FnvBuildHasher,
     >,
 
@@ -976,7 +976,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             StartConnect(service::StartConnect<TPlat::Instant>),
             MessageToConnection {
                 connection_id: service::ConnectionId,
-                message: service::CoordinatorToConnection<TPlat::Instant>,
+                message: service::CoordinatorToConnection,
             },
             EventSendersReady,
         }
@@ -1165,13 +1165,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     }
                 }
 
-                let request_id = task.network.start_blocks_request(
-                    task.platform.now(),
-                    &target,
-                    chain_index,
-                    config,
-                    timeout,
-                );
+                let request_id =
+                    task.network
+                        .start_blocks_request(&target, chain_index, config, timeout);
 
                 task.blocks_requests.insert(request_id, result);
                 continue;
@@ -1196,7 +1192,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 );
 
                 let request_id = task.network.start_grandpa_warp_sync_request(
-                    task.platform.now(),
                     &target,
                     chain_index,
                     begin_hash,
@@ -1229,7 +1224,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 );
 
                 let request_id = match task.network.start_storage_proof_request(
-                    task.platform.now(),
                     &target,
                     chain_index,
                     config,
@@ -1269,7 +1263,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 );
 
                 let request_id = match task.network.start_call_proof_request(
-                    task.platform.now(),
                     &target,
                     chain_index,
                     config,
@@ -1398,9 +1391,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }
             WhatHappened::Message(ToBackground::StartDiscovery) => {
                 for chain_index in 0..task.log_chain_names.len() {
-                    let operation_id = task
-                        .network
-                        .start_kademlia_discovery_round(task.platform.now(), chain_index);
+                    let operation_id = task.network.start_kademlia_discovery_round(chain_index);
 
                     let _prev_value = task
                         .kademlia_discovery_operations

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -184,9 +184,7 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
     platform: TPlat,
     connection_id: service::ConnectionId,
     mut connection_task: service::SingleStreamConnectionTask<TPlat::Instant>,
-    mut coordinator_to_connection: async_channel::Receiver<
-        service::CoordinatorToConnection<TPlat::Instant>,
-    >,
+    mut coordinator_to_connection: async_channel::Receiver<service::CoordinatorToConnection>,
     connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
     let mut socket = pin::pin!(socket);
@@ -258,14 +256,14 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
 
         // Now wait for something interesting to happen before looping again.
 
-        enum WhatHappened<TPlat: PlatformRef> {
-            CoordinatorMessage(service::CoordinatorToConnection<TPlat::Instant>),
+        enum WhatHappened {
+            CoordinatorMessage(service::CoordinatorToConnection),
             CoordinatorDead,
             SocketEvent,
             MessageSent,
         }
 
-        let what_happened: WhatHappened<TPlat> = {
+        let what_happened: WhatHappened = {
             let coordinator_message = async {
                 match coordinator_to_connection.next().await {
                     Some(msg) => WhatHappened::CoordinatorMessage(msg),
@@ -312,7 +310,7 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
 
         match what_happened {
             WhatHappened::CoordinatorMessage(message) => {
-                connection_task.inject_coordinator_message(message);
+                connection_task.inject_coordinator_message(&platform.now(), message);
             }
             WhatHappened::CoordinatorDead => return,
             WhatHappened::SocketEvent => {}
@@ -333,9 +331,7 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     platform: TPlat,
     connection_id: service::ConnectionId,
     mut connection_task: service::MultiStreamConnectionTask<TPlat::Instant, usize>,
-    mut coordinator_to_connection: async_channel::Receiver<
-        service::CoordinatorToConnection<TPlat::Instant>,
-    >,
+    mut coordinator_to_connection: async_channel::Receiver<service::CoordinatorToConnection>,
     connection_to_coordinator: async_channel::Sender<ToBackground<TPlat>>,
 ) {
     // Future that sends a message to the coordinator. Only one message is sent to the coordinator
@@ -365,7 +361,7 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
         // Now wait for something interesting to happen before looping again.
 
         enum WhatHappened<TPlat: PlatformRef> {
-            CoordinatorMessage(service::CoordinatorToConnection<TPlat::Instant>),
+            CoordinatorMessage(service::CoordinatorToConnection),
             CoordinatorDead,
             SocketEvent(pin::Pin<Box<TPlat::Stream>>, usize),
             MessageSent,
@@ -437,7 +433,7 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
 
         match what_happened {
             WhatHappened::CoordinatorMessage(message) => {
-                connection_task.inject_coordinator_message(message);
+                connection_task.inject_coordinator_message(&platform.now(), message);
             }
             WhatHappened::CoordinatorDead => return,
             WhatHappened::SocketEvent(mut socket, substream_id) => {


### PR DESCRIPTION
While working on https://github.com/smol-dot/smoldot/pull/1200, I noticed that we calculate the timeout of requests and notification substream handshakes when the request/notif is created in "the frontend" of the networking.

This means that this timeout includes the time it takes to send the message from the frontend to the connection task. This isn't great.

This PR changes this by calculating the timeout when the message is received by the connection task.

~~Note that calculating this timeout in `Substream::read_write` would be wrong, because a malicious peer might be able to delay a call to `Substream::read_write` for a long time, and timeouts are designed specifically to prevent that.~~
EDIT: calculating the timeout in `Substream::read_write` would actually work, because Yamux always processes new substreams even when it can't read/write to them, however it's a bit complicated to implement and I don't see the harm in passing a `TNow` when receiving a message.
