### PR TITLE
Check block requests response in higher level code instead

### DIFF
--- a/lib/src/sync/optimistic.rs
+++ b/lib/src/sync/optimistic.rs
@@ -602,6 +602,8 @@ impl<TRq, TSrc, TBl> OptimisticSync<TRq, TSrc, TBl> {
             return (user_data, FinishRequestOutcome::Obsolete);
         }
 
+        // TODO: important /!\ should check whether the block bodies match the extrinsics root in the headers, in order to differentiate invalid blocks from malicious peers
+
         let ((_, user_data), source_id) = self
             .inner
             .verification_queue

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -123,8 +123,8 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             rx.await.unwrap()
         };
 
-        // Block bodies and justifications aren't stored locally. Ask the network.
-        let result = if let Some(block_number) = block_number {
+        // Block bodies and headers aren't stored locally. Ask the network.
+        let mut result = if let Some(block_number) = block_number {
             self.sync_service
                 .clone()
                 .block_query(
@@ -133,7 +133,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     protocol::BlocksRequestFields {
                         header: true,
                         body: true,
-                        justifications: true,
+                        justifications: false,
                     },
                     3,
                     Duration::from_secs(8),
@@ -148,7 +148,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     protocol::BlocksRequestFields {
                         header: true,
                         body: true,
-                        justifications: true,
+                        justifications: false,
                     },
                     3,
                     Duration::from_secs(8),
@@ -157,9 +157,32 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 .await
         };
 
-        // The `block_query` function guarantees that the header and body are present and
-        // are correct.
+        // Check whether the header and body are present and valid.
+        // TODO: try the request again with a different peerin case the response is invalid, instead of returning null
+        if let Ok(block) = &result {
+            if let (Some(header), Some(body)) = (&block.header, &block.body) {
+                if header::hash_from_scale_encoded_header(header) == hash {
+                    if let Ok(decoded) =
+                        header::decode(header, self.sync_service.block_number_bytes())
+                    {
+                        if header::extrinsics_root(&body) != *decoded.extrinsics_root {
+                            result = Err(());
+                        }
+                    } else {
+                        // Note that if the header is undecodable it doesn't necessarily mean
+                        // that the header and/or body is bad, but given that we have no way to
+                        // check this we return an error.
+                        result = Err(());
+                    }
+                } else {
+                    result = Err(());
+                }
+            } else {
+                result = Err(());
+            }
+        }
 
+        // Return the response.
         if let Ok(block) = result {
             request.respond(methods::Response::chain_getBlock(methods::Block {
                 extrinsics: block
@@ -173,11 +196,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     self.sync_service.block_number_bytes(),
                 )
                 .unwrap(),
-                justifications: block.justifications.map(|list| {
-                    list.into_iter()
-                        .map(|j| (j.engine_id, j.justification))
-                        .collect()
-                }),
+                // There's no way to verify the correctness of the justifications, consequently
+                // we always return an empty list.
+                justifications: None,
             }))
         } else {
             request.respond_null()

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- The `chain_getBlock` JSON-RPC function now always returns an empty list of justifications, because there is no (reasonable) way for smoldot to verify whether the justifications sent by full nodes are valid.
+- The `chain_getBlock` JSON-RPC function now always returns an empty list of justifications, because there is no (reasonable) way for smoldot to verify whether the justifications sent by full nodes are valid. ([#1238](https://github.com/smol-dot/smoldot/pull/1238))
 
 ## 2.0.6 - 2023-10-13
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The `chain_getBlock` JSON-RPC function now always returns an empty list of justifications, because there is no (reasonable) way for smoldot to verify whether the justifications sent by full nodes are valid.
+
 ## 2.0.6 - 2023-10-13
 
 ### Fixed


### PR DESCRIPTION
Right now, the `SyncService::blocks_query` function downloads the block from a peer then verifies whether the body matches the header.

This has two issues:

- In order for this to work, one need to also download the header, which is often necessary. There are several TODOs in the code where we download the header when unnecessary.
- Inconsistency. None of the other networking requests have this verification. Block requests are the only requests that have this, because it's actually possible to perform some verification, whereas for other requests it's not.

In https://github.com/smol-dot/smoldot/pull/1200 I'm planning to remove this check.
This PR is a preliminary change to make the high-level code verify the block headers and bodies, instead of the low-level code.

Note that the syncing code already verifies whether headers in responses match the expected hash. As for bodies, I've added a TODO in the optimistic syncing. Since this doesn't concern the light client it isn't critical.

A side change is that I realize that `chain_getBlock` directly returns the justifications downloaded from the network without verifying them. I've removed this and mentioned it in the CHANGELOG.
