### PR TITLE
Add a deps.rs badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This repository contains the following components:
     - 📚 <https://docs.rs/smoldot-full-node> (latest published version)
     - 📚 <https://smol-dot.github.io/smoldot/doc-rust/smoldot_full_node/index.html> (latest commit)
 
+[![dependency status](https://deps.rs/repo/github/smol-dot/smoldot/status.svg)](https://deps.rs/repo/github/smol-dot/smoldot)
+
 # Frequently asked questions
 
 ## Does smoldot support &lt;blockchain&gt;?


### PR DESCRIPTION
Since dependabot is broken again and seems to break all the time, having this badge is useful in order to know when something isn't up-to-date.