### PR TITLE
Update light-base to async-channel v2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336d835910fab747186c56586562cb46f42809c2843ef3a84f47509009522838"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 3.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +384,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c36a4d0d48574b3dd360b4b7d95cc651d2b6557b6402848a27d4b228a473e2a"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-lock 2.8.0",
  "async-task",
  "fastrand 2.0.1",
@@ -2327,7 +2340,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-executor",
  "async-fs",
  "async-io",
@@ -2401,7 +2414,7 @@ dependencies = [
 name = "smoldot-full-node"
 version = "0.3.0"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "blake2-rfc",
  "clap",
  "ctrlc",
@@ -2433,7 +2446,7 @@ dependencies = [
 name = "smoldot-light"
 version = "0.10.0"
 dependencies = [
- "async-channel",
+ "async-channel 2.0.0",
  "async-lock 3.0.0",
  "base64 0.21.5",
  "blake2-rfc",

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -13,7 +13,7 @@ name = "basic"
 required-features = ["std"]
 
 [dependencies]
-async-channel = { version = "1.9.0", default-features = false }  # TODO: no-std-ize; this is has been done and is just waiting for a release: https://github.com/smol-rs/event-listener/pull/34
+async-channel = { version = "2.0.0", default-features = false }
 async-lock = { version = "3.0.0", default-features = false }
 base64 = { version = "0.21.2", default-features = false, features = ["alloc"] }
 blake2-rfc = { version = "0.2.18", default-features = false }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -22,8 +22,8 @@ use super::Background;
 use crate::{platform::PlatformRef, runtime_service, sync_service};
 
 use alloc::{
-    boxed::Box,
     borrow::ToOwned as _,
+    boxed::Box,
     format,
     string::{String, ToString as _},
     sync::Arc,

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -22,6 +22,7 @@ use super::Background;
 use crate::{platform::PlatformRef, runtime_service, sync_service};
 
 use alloc::{
+    boxed::Box,
     borrow::ToOwned as _,
     format,
     string::{String, ToString as _},
@@ -31,6 +32,7 @@ use alloc::{
 use core::{
     iter,
     num::{NonZeroU32, NonZeroUsize},
+    pin,
     time::Duration,
 };
 use futures_lite::FutureExt as _;
@@ -289,6 +291,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 let sync_service = self.sync_service.clone();
                 let platform = self.platform.clone();
                 let (to_operation_handlers, from_operation_handlers) = async_channel::bounded(8);
+                let from_operation_handlers = Box::pin(from_operation_handlers);
 
                 ChainHeadFollowTask {
                     platform,
@@ -299,7 +302,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                             notifications: sub.new_blocks,
                             subscription_id: id,
                         },
-                        either::Right(sub) => Subscription::WithoutRuntime(sub.new_blocks),
+                        either::Right(sub) => {
+                            Subscription::WithoutRuntime(Box::pin(sub.new_blocks))
+                        }
                     },
                     log_target,
                     runtime_service,
@@ -510,7 +515,7 @@ struct ChainHeadFollowTask<TPlat: PlatformRef> {
 
     to_main_task: async_channel::Sender<OperationEvent>,
 
-    from_operation_handlers: async_channel::Receiver<OperationEvent>,
+    from_operation_handlers: pin::Pin<Box<async_channel::Receiver<OperationEvent>>>,
 
     /// Identifier to assign to the next body/call/storage operation.
     next_operation_id: u128,
@@ -538,7 +543,7 @@ enum Subscription<TPlat: PlatformRef> {
         subscription_id: runtime_service::SubscriptionId,
     },
     // TODO: better typing?
-    WithoutRuntime(async_channel::Receiver<sync_service::Notification>),
+    WithoutRuntime(pin::Pin<Box<async_channel::Receiver<sync_service::Notification>>>),
 }
 
 impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -132,6 +132,7 @@ pub(super) fn start_task<TPlat: PlatformRef>(
     config: Config<TPlat>,
 ) -> async_channel::Sender<Message<TPlat>> {
     let (requests_tx, requests_rx) = async_channel::bounded(8);
+    let requests_rx = Box::pin(requests_rx);
 
     config.platform.clone().spawn_task(
         format!("{}-legacy-state-subscriptions", config.log_target).into(),
@@ -206,7 +207,7 @@ struct Task<TPlat: PlatformRef> {
     /// Sending side of [`Task::requests_rx`].
     requests_tx: async_channel::WeakSender<Message<TPlat>>,
     /// How to receive messages from the API user.
-    requests_rx: async_channel::Receiver<Message<TPlat>>,
+    requests_rx: Pin<Box<async_channel::Receiver<Message<TPlat>>>>,
 
     /// List of all active `chain_subscribeAllHeads` subscriptions, indexed by the subscription ID.
     // TODO: shrink_to_fit?

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -202,6 +202,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
         let on_service_killed = event_listener::Event::new();
 
         let (messages_tx, messages_rx) = async_channel::bounded(32);
+        let messages_rx = Box::pin(messages_rx);
 
         // Spawn task starts a discovery request at a periodic interval.
         // This is done through a separate task due to ease of implementation.
@@ -880,7 +881,7 @@ struct BackgroundTask<TPlat: PlatformRef> {
         Pin<Box<dyn future::Future<Output = Vec<async_channel::Sender<Event>>> + Send>>,
     >,
 
-    messages_rx: async_channel::Receiver<ToBackground>,
+    messages_rx: Pin<Box<async_channel::Receiver<ToBackground>>>,
 
     active_connections: HashMap<
         service::ConnectionId,

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -152,6 +152,7 @@ pub struct SyncService<TPlat: PlatformRef> {
 impl<TPlat: PlatformRef> SyncService<TPlat> {
     pub async fn new(config: Config<TPlat>) -> Self {
         let (to_background, from_foreground) = async_channel::bounded(16);
+        let from_foreground = Box::pin(from_foreground);
 
         let log_target = format!("sync-service-{}", config.log_name);
 

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -48,7 +48,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
     relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
     relay_chain_block_number_bytes: usize,
     parachain_id: u32,
-    from_foreground: async_channel::Receiver<ToBackground>,
+    from_foreground: Pin<Box<async_channel::Receiver<ToBackground>>>,
     network_service: Arc<network_service::NetworkService<TPlat>>,
     network_chain_id: network_service::ChainId,
     from_network_service: stream::BoxStream<'static, network_service::Event>,
@@ -108,7 +108,7 @@ struct ParachainBackgroundTask<TPlat: PlatformRef> {
     platform: TPlat,
 
     /// Channel receiving message from the sync service frontend.
-    from_foreground: async_channel::Receiver<ToBackground>,
+    from_foreground: Pin<Box<async_channel::Receiver<ToBackground>>>,
 
     /// Number of bytes to use to encode the parachain block numbers in headers.
     block_number_bytes: usize,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -52,7 +52,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
     chain_information: chain::chain_information::ValidChainInformation,
     block_number_bytes: usize,
     runtime_code_hint: Option<ConfigRelayChainRuntimeCodeHint>,
-    mut from_foreground: async_channel::Receiver<ToBackground>,
+    mut from_foreground: Pin<Box<async_channel::Receiver<ToBackground>>>,
     network_service: Arc<network_service::NetworkService<TPlat>>,
     network_chain_id: network_service::ChainId,
     mut from_network_service: stream::BoxStream<'static, network_service::Event>,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -81,6 +81,7 @@ use core::{
     cmp, iter,
     marker::PhantomData,
     num::{NonZeroU32, NonZeroUsize},
+    pin,
     time::Duration,
 };
 use futures_lite::FutureExt as _;
@@ -155,7 +156,7 @@ impl<TPlat: PlatformRef> TransactionsService<TPlat> {
             runtime_service: config.runtime_service,
             network_service: config.network_service.0,
             network_chain_id: config.network_service.1,
-            from_foreground,
+            from_foreground: Box::pin(from_foreground),
             max_concurrent_downloads: usize::try_from(config.max_concurrent_downloads.get())
                 .unwrap_or(usize::max_value()),
             max_pending_transactions: usize::try_from(config.max_pending_transactions.get())
@@ -314,7 +315,7 @@ struct BackgroundTaskConfig<TPlat: PlatformRef> {
     runtime_service: Arc<runtime_service::RuntimeService<TPlat>>,
     network_service: Arc<network_service::NetworkService<TPlat>>,
     network_chain_id: network_service::ChainId,
-    from_foreground: async_channel::Receiver<ToBackground>,
+    from_foreground: pin::Pin<Box<async_channel::Receiver<ToBackground>>>,
     max_concurrent_downloads: usize,
     max_pending_transactions: usize,
     max_concurrent_validations: usize,


### PR DESCRIPTION
cc #133 

Note that the full node doesn't get updated to `async-channel` v2 as it's actually more complicated than the light client, and because it uses `smol`.

Given that a no-std full node isn't an objective, it's fine to delay this.
