### PR TITLE
Disable `std` feature from `futures-util`

### DIFF
--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -23,7 +23,7 @@ event-listener = { version = "3.0.0", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 futures-channel = { version = "0.3.27", default-features = false, features = ["alloc"] }
 futures-lite = { version = "1.13.0", default-features = false, features = ["alloc"] }
-futures-util = { version = "0.3.27", default-features = false, features = ["std", "async-await", "async-await-macro", "channel", "sink"] }  # TODO: slim down these features
+futures-util = { version = "0.3.27", default-features = false, features = ["alloc", "async-await", "async-await-macro", "channel", "sink"] }  # TODO: slim down these features
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = "0.11.0"


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/133

It seems that this feature was enabled by mistake.
I'm a bit skeptical that this actually helps no-std compatibility, but it doesn't hurt to remove it.
