### PR TITLE
Properly implement the `BasicPeeringStrategy`

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -861,7 +861,7 @@ async fn background_task(mut inner: Inner) {
                                 .remove_address(expected_peer_id, remote_addr.as_ref());
                             match inner
                                 .peering_strategy
-                                .insert_connected_address(&peer_id, remote_addr.clone().into_vec(), 10) // TODO: constant
+                                .insert_or_set_connected_address(&peer_id, remote_addr.clone().into_vec(), 10) // TODO: constant
                             {
                                 basic_peering_strategy::InsertAddressResult::Inserted { address_removed: Some(addr_rm) } => {
                                     let addr_rm = Multiaddr::try_from(addr_rm).unwrap();

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -304,7 +304,11 @@ impl NetworkService {
         });
 
         let mut peering_strategy =
-            basic_peering_strategy::BasicPeeringStrategy::new(rand::random());
+            basic_peering_strategy::BasicPeeringStrategy::new(basic_peering_strategy::Config {
+                randomness_seed: rand::random(),
+                peers_capacity: 200, // TODO: ?
+                chains_capacity: config.chains.len(),
+            });
 
         let mut chain_names =
             hashbrown::HashMap::with_capacity_and_hasher(config.chains.len(), Default::default());

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -727,34 +727,52 @@ where
     }
 }
 
+/// See [`BasicPeeringStrategy::disconnect_addr`].
 #[derive(Debug, derive_more::Display)]
 pub enum DisconnectAddrError {
+    /// Address isn't known to the collection.
     UnknownAddress,
+    /// The address was not in the "connected" state.
     NotConnected,
 }
 
+/// See [`BasicPeeringStrategy::pick_assignable_peer`].
 pub enum AssignablePeer<'a, TInstant> {
+    /// An assignal peer was found. Note that the peer wasn't assigned yet.
     Assignable(&'a PeerId),
-    AllPeersBanned { next_unban: &'a TInstant },
+    /// No peer was found as all known un-assigned peers are currently in the "banned" state.
+    AllPeersBanned {
+        /// Instant when the first peer will be unbanned.
+        next_unban: &'a TInstant,
+    },
+    /// No un-assigned peer was found.
     NoPeer,
 }
 
+/// See [`BasicPeeringStrategy::insert_chain_peer`].
 pub enum InsertChainPeerResult {
+    /// Peer-chain association has been successfully inserted.
     Inserted {
         /// If the maximum number of peers is reached, an old peer might have been removed. If so,
         /// this contains the peer.
         peer_removed: Option<PeerId>,
     },
+    /// Peer-chain association was already inserted.
     Duplicate,
 }
 
+/// See [`BasicPeeringStrategy::insert_address`] and
+/// [`BasicPeeringStrategy::insert_or_set_connected_address`].
 pub enum InsertAddressResult {
+    /// Address has been successfully inserted.
     Inserted {
         /// If the maximum number of addresses is reached, an old address might have been
         /// removed. If so, this contains the address.
         address_removed: Option<Vec<u8>>,
     },
+    /// Address was already inserted.
     Duplicate,
+    /// The peer isn't associated to any chain, and as such the address was not inserted.
     UnknownPeer,
 }
 

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -43,7 +43,7 @@ pub struct BasicPeeringStrategy<TChainId, TInstant> {
     /// Contains all the `PeerId`s used throughout the collection.
     peer_ids: slab::Slab<PeerId>,
 
-    /// Contains all the keys of [`BasicPeeringStragtegy::peer_ids`] indexed differently.
+    /// Contains all the keys of [`BasicPeeringStrategy::peer_ids`] indexed differently.
     peer_ids_indices: hashbrown::HashMap<PeerId, usize, util::SipHasherBuild>,
 
     addresses: BTreeMap<(usize, Vec<u8>), AddressState>,
@@ -56,7 +56,7 @@ pub struct BasicPeeringStrategy<TChainId, TInstant> {
     /// >           `TChainId`s are instead refered to as a `usize`.
     chains: slab::Slab<TChainId>,
 
-    /// Contains all the keys of [`BasicPeeringStragtegy::chains`] indexed differently.
+    /// Contains all the keys of [`BasicPeeringStrategy::chains`] indexed differently.
     /// While a dumber hasher is in principle enough, we use a `SipHasherBuild` "just in case"
     /// as we don't know the properties of `TChainId`.
     chains_indices: hashbrown::HashMap<TChainId, usize, util::SipHasherBuild>,
@@ -585,7 +585,7 @@ where
         Ok(())
     }
 
-    /// Finds the index of the given [`TChainId`] in [`BasicPeeringStrategy::chains`], or inserts
+    /// Finds the index of the given `TChainId` in [`BasicPeeringStrategy::chains`], or inserts
     /// one if there is none.
     fn get_or_insert_chain_index(&mut self, chain: &TChainId) -> usize {
         debug_assert_eq!(self.chains.len(), self.chains_indices.len());
@@ -600,7 +600,7 @@ where
         }
     }
 
-    /// Check if the given [`TChainId`] is still used within the collection. If no, removes it from
+    /// Check if the given `TChainId` is still used within the collection. If no, removes it from
     /// [`BasicPeeringStrategy::chains`].
     fn try_clean_up_chain(&mut self, chain_index: usize) {
         if self

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -571,15 +571,13 @@ where
             return None;
         };
 
-        // TODO: could be optimized further
-        for ((_, address), state) in self
+        // TODO: could be optimized further by removing filter() and adjusting the set
+        if let Some(((_, address), state)) = self
             .addresses
             .range_mut((peer_id_index, Vec::new())..(peer_id_index + 1, Vec::new()))
+            .filter(|(_, state)| matches!(state, AddressState::Disconnected))
+            .choose(&mut self.randomness)
         {
-            if matches!(state, AddressState::Connected) {
-                continue;
-            }
-
             *state = AddressState::Connected;
             return Some(address);
         }

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -123,6 +123,7 @@ where
         }
     }
 
+    // TODO: must purge an old peer
     pub fn insert_chain_peer(&mut self, chain: TChainId, peer_id: PeerId) {
         let peer_id_index = self.get_or_insert_peer_index(&peer_id);
         let chain_index = self.get_or_insert_chain_index(&chain);
@@ -232,6 +233,7 @@ where
                     .count();
 
                 if num_addresses >= max_addresses {
+                    // TODO: is it a good idea to choose the address randomly to remove? maybe there should be a sorting system with best addresses first?
                     self.addresses
                         .range((peer_id_index, Vec::new())..=(peer_id_index + 1, Vec::new()))
                         .filter(|((_, a), s)| {

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -466,7 +466,7 @@ where
     }
 
     /// Returns the list of all the chains that have been added.
-    pub fn chains(&'_ self) -> impl Iterator<Item = ChainId> + '_ {
+    pub fn chains(&'_ self) -> impl ExactSizeIterator<Item = ChainId> + '_ {
         self.chains.iter().map(|(idx, _)| ChainId(idx))
     }
 

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1241,8 +1241,9 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     }
 
                     for addr in addrs {
-                        task.peering_strategy
-                            .insert_address(&peer_id, addr.into_vec());
+                        let _ = task
+                            .peering_strategy
+                            .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
                     }
 
                     task.peering_strategy.insert_chain_peer(chain_id, peer_id);
@@ -1336,8 +1337,11 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                     task.peering_strategy
                         .remove_address(expected_peer_id, remote_addr.as_ref());
-                    task.peering_strategy
-                        .insert_connected_address(&peer_id, remote_addr.clone().into_vec());
+                    let _ = task.peering_strategy.insert_connected_address(
+                        &peer_id,
+                        remote_addr.clone().into_vec(),
+                        10,
+                    );
                 } else {
                     log::debug!(target: "network", "Connections({}, {}) => HandshakeFinished", peer_id, remote_addr);
                 }
@@ -1560,7 +1564,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                     for addr in valid_addrs {
                         task.peering_strategy
-                            .insert_address(&peer_id, addr.into_vec());
+                            .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
                     }
                 }
 

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -237,11 +237,17 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                 }),
                 identify_agent_version: config.identify_agent_version,
                 messages_tx: messages_tx.clone(),
-                peering_strategy: basic_peering_strategy::BasicPeeringStrategy::new({
-                    let mut seed = [0; 32];
-                    config.platform.fill_random_bytes(&mut seed);
-                    seed
-                }),
+                peering_strategy: basic_peering_strategy::BasicPeeringStrategy::new(
+                    basic_peering_strategy::Config {
+                        randomness_seed: {
+                            let mut seed = [0; 32];
+                            config.platform.fill_random_bytes(&mut seed);
+                            seed
+                        },
+                        peers_capacity: 50, // TODO: ?
+                        chains_capacity: network.chains().count(),
+                    },
+                ),
                 network,
                 platform: config.platform.clone(),
                 event_senders: either::Left(event_senders),

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1240,13 +1240,16 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                         task.important_nodes.insert(peer_id.clone());
                     }
 
+                    // Note that we must call this function before `insert_address`, as documented
+                    // in `basic_peering_strategy`.
+                    task.peering_strategy
+                        .insert_chain_peer(chain_id, peer_id.clone(), 30); // TODO: constant
+
                     for addr in addrs {
                         let _ = task
                             .peering_strategy
                             .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
                     }
-
-                    task.peering_strategy.insert_chain_peer(chain_id, peer_id);
                 }
 
                 continue;
@@ -1558,13 +1561,20 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     }
 
                     if !valid_addrs.is_empty() {
+                        // Note that we must call this function before `insert_address`,
+                        // as documented in `basic_peering_strategy`.
                         task.peering_strategy
-                            .insert_chain_peer(chain_id, peer_id.clone());
+                            .insert_chain_peer(chain_id, peer_id.clone(), 30); // TODO: constant
                     }
 
                     for addr in valid_addrs {
-                        task.peering_strategy
-                            .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
+                        let _insert_result =
+                            task.peering_strategy
+                                .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
+                        debug_assert!(!matches!(
+                            _insert_result,
+                            basic_peering_strategy::InsertAddressResult::UnknownPeer
+                        ));
                     }
                 }
 

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1346,7 +1346,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                     task.peering_strategy
                         .remove_address(expected_peer_id, remote_addr.as_ref());
-                    let _ = task.peering_strategy.insert_connected_address(
+                    let _ = task.peering_strategy.insert_or_set_connected_address(
                         &peer_id,
                         remote_addr.clone().into_vec(),
                         10,


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1247

This PR properly implements the `BasicPeeringStrategy`.
The first commit optimizes it to remove all the `O(n)` operations, while the others finish implementing various aspects of it.

(work in progress at the time of opening)
