### PR TITLE
Make `PlatformRef::connect_*` instantaneously return

### DIFF
--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -128,7 +128,7 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     ///
     /// This function returns a `Future`. This `Future` **must** return as soon as possible, and
     /// must **not** wait for the connection to be established.
-    /// In the most scenarios, the `Future` returned by this function should immediately produce
+    /// In most scenarios, the `Future` returned by this function should immediately produce
     /// an output.
     ///
     /// # Panic
@@ -142,7 +142,7 @@ pub trait PlatformRef: Clone + Send + Sync + 'static {
     ///
     /// This function returns a `Future`. This `Future` **must** return as soon as possible, and
     /// must **not** wait for the connection to be established.
-    /// In the most scenarios, the `Future` returned by this function should immediately produce
+    /// In most scenarios, the `Future` returned by this function should immediately produce
     /// an output.
     ///
     /// # Panic

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -19,8 +19,8 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use super::{
-    with_buffers, Address, ConnectionType, IpAddr, MultiStreamAddress,
-    MultiStreamWebRtcConnection, PlatformRef, SubstreamDirection,
+    with_buffers, Address, ConnectionType, IpAddr, MultiStreamAddress, MultiStreamWebRtcConnection,
+    PlatformRef, SubstreamDirection,
 };
 
 use alloc::{borrow::Cow, sync::Arc};

--- a/wasm-node/javascript/src/no-auto-bytecode-deno.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-deno.ts
@@ -94,7 +94,7 @@ function connect(config: ConnectionConfig): Connection {
         };
 
         socket.onopen = () => {
-            config.onOpen({ type: 'single-stream', handshake: 'multistream-select-noise-yamux', initialWritableBytes: 1024 * 1024 });
+            config.onWritableBytes(1024 * 1024);
         };
         socket.onclose = (event) => {
             const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
@@ -151,7 +151,7 @@ function connect(config: ConnectionConfig): Connection {
                 return established;
 
             established?.setNoDelay();
-            config.onOpen({ type: 'single-stream', handshake: 'multistream-select-noise-yamux', initialWritableBytes: 1024 * 1024 });
+            config.onWritableBytes(1024 * 1024);
 
             // Spawns an asynchronous task that continuously reads from the socket.
             // Every time data is read, the task re-executes itself in order to continue reading.

--- a/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
@@ -105,7 +105,7 @@ function connect(config: ConnectionConfig): Connection {
         };
 
         socket.onopen = () => {
-            config.onOpen({ type: 'single-stream', handshake: 'multistream-select-noise-yamux', initialWritableBytes: 1024 * 1024 });
+            config.onWritableBytes(1024 * 1024);
         };
         socket.onclose = (event) => {
             const message = "Error code " + event.code + (!!event.reason ? (": " + event.reason) : "");
@@ -161,10 +161,7 @@ function connect(config: ConnectionConfig): Connection {
 
         socket.on('connect', () => {
             if (socket.destroyed) return;
-            config.onOpen({
-                type: 'single-stream', handshake: 'multistream-select-noise-yamux',
-                initialWritableBytes: socket.writableHighWaterMark
-            });
+            config.onWritableBytes(socket.writableHighWaterMark);
         });
         socket.on('close', (hasError) => {
             if (socket.destroyed) return;

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -522,7 +522,7 @@ pub extern "C" fn connection_multi_stream_set_handshake_info(
 /// If `connection_id` is a multi-stream connection, then `stream_id` corresponds to the stream
 /// on which the data was received, as was provided to [`connection_stream_opened`].
 ///
-/// See also [`connection_open_single_stream`] and [`connection_open_multi_stream`].
+/// See also [`connection_new`].
 #[no_mangle]
 pub extern "C" fn stream_message(connection_id: u32, stream_id: u32, buffer_index: u32) {
     crate::platform::stream_message(connection_id, stream_id, get_buffer(buffer_index));
@@ -585,7 +585,7 @@ pub extern "C" fn connection_reset(connection_id: u32, buffer_index: u32) {
 ///
 /// It is illegal to call this function on a single-stream connections.
 ///
-/// See also [`connection_open_multi_stream`].
+/// See also [`connection_new`].
 #[no_mangle]
 pub extern "C" fn stream_reset(connection_id: u32, stream_id: u32) {
     crate::platform::stream_reset(connection_id, stream_id);

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -196,20 +196,15 @@ extern "C" {
     /// The `id` parameter is an identifier for this connection, as chosen by the Rust code. It
     /// must be passed on every interaction with this connection.
     ///
-    /// At any time, a connection can be in one of the three following states:
+    /// At any time, a connection can be in either the `Open` (the initial state) or the `Reset`
+    /// state.
+    /// When in the `Open` state, the connection can transition to the `Reset` state if the remote
+    /// closes the connection or refuses the connection altogether. When that happens,
+    /// [`connection_reset`] must be called. Once in the `Reset` state, the connection cannot
+    /// transition back to the `Open` state.
     ///
-    /// - `Opening` (initial state)
-    /// - `Open`
-    /// - `Reset`
-    ///
-    /// When in the `Opening` or `Open` state, the connection can transition to the `Reset` state
-    /// if the remote closes the connection or refuses the connection altogether. When that
-    /// happens, [`connection_reset`] must be called. Once in the `Reset` state, the connection
-    /// cannot transition back to another state.
-    ///
-    /// Initially in the `Opening` state, the connection can transition to the `Open` state if the
-    /// remote accepts the connection. When that happens, [`connection_open_single_stream`] or
-    /// [`connection_open_multi_stream`] must be called depending on the type of connection.
+    /// If the connection is a multistream connection, then
+    /// [`connection_multi_stream_set_handshake_info`] must later be called as soon as possible.
     ///
     /// There exists two kind of connections: single-stream and multi-stream. Single-stream
     /// connections are assumed to have a single stream open at all time and the encryption and
@@ -490,22 +485,7 @@ pub extern "C" fn timer_finished() {
     crate::timers::timer_finished();
 }
 
-/// Called by the JavaScript code if the connection switches to the `Open` state. The connection
-/// must be in the `Opening` state.
-///
-/// Must be called at most once per connection object.
-///
-/// See also [`connection_new`].
-///
-/// When in the `Open` state, the connection can receive messages. Use [`stream_message`] in order
-/// to provide to the Rust code the messages received by the connection.
-#[no_mangle]
-pub extern "C" fn connection_open_single_stream(connection_id: u32, initial_writable_bytes: u32) {
-    crate::platform::connection_open_single_stream(connection_id, initial_writable_bytes);
-}
-
-/// Called by the JavaScript code if the connection switches to the `Open` state. The connection
-/// must be in the `Opening` state.
+/// Called by the JavaScript code in order to provide information about a multistream connection.
 ///
 /// Must be called at most once per connection object.
 ///
@@ -520,8 +500,11 @@ pub extern "C" fn connection_open_single_stream(connection_id: u32, initial_writ
 /// the local node's TLS certificate, followed with the SHA-256 hash of the remote node's TLS
 /// certificate.
 #[no_mangle]
-pub extern "C" fn connection_open_multi_stream(connection_id: u32, handshake_ty_buffer_index: u32) {
-    crate::platform::connection_open_multi_stream(
+pub extern "C" fn connection_multi_stream_set_handshake_info(
+    connection_id: u32,
+    handshake_ty_buffer_index: u32,
+) {
+    crate::platform::connection_multi_stream_set_handshake_info(
         connection_id,
         get_buffer(handshake_ty_buffer_index),
     );
@@ -549,13 +532,8 @@ pub extern "C" fn stream_message(connection_id: u32, stream_id: u32, buffer_inde
 /// stream (and, in the case of a multi-stream connection, the stream itself) must be in the
 /// `Open` state.
 ///
-/// `total_sent - total_reported_writable_bytes` must always be `>= 0`, where `total_sent` is the
-/// total number of bytes sent on the stream using [`stream_send`] and
-/// `total_reported_writable_bytes` is the total number of bytes reported using
-/// [`stream_writable_bytes`].
-/// In other words, this function is meant to notify that data sent using [`stream_send`̀] has
-/// effectively been sent out. It is not possible to exceed the `initial_writable_bytes` provided
-/// when the stream was created.
+/// The total of writable bytes must not go beyond reasonable values (e.g. a few megabytes). It
+/// is not legal to provide a dummy implementation that simply passes an exceedingly large value.
 ///
 /// If `connection_id` is a single-stream connection, then the value of `stream_id` is ignored.
 /// If `connection_id` is a multi-stream connection, then `stream_id` corresponds to the stream
@@ -576,18 +554,8 @@ pub extern "C" fn stream_writable_bytes(connection_id: u32, stream_id: u32, num_
 /// value other than `0` if the substream has been opened in response to a call to
 /// [`connection_stream_open`].
 #[no_mangle]
-pub extern "C" fn connection_stream_opened(
-    connection_id: u32,
-    stream_id: u32,
-    outbound: u32,
-    initial_writable_bytes: u32,
-) {
-    crate::platform::connection_stream_opened(
-        connection_id,
-        stream_id,
-        outbound,
-        initial_writable_bytes,
-    );
+pub extern "C" fn connection_stream_opened(connection_id: u32, stream_id: u32, outbound: u32) {
+    crate::platform::connection_stream_opened(connection_id, stream_id, outbound);
 }
 
 /// Can be called at any point by the JavaScript code if the connection switches to the `Reset`


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1249

When it comes to TCP connections, the connection process follows the three way handshake. Once finished, we are now "connected" to the remote and can exchange messages. The same exists for WebSocket, where the server sends back an HTTP response signalling that we're now "connected".

However, when it comes to connections such as QUIC or WebRTC, it's less clear what "connected" means. QUIC supports 0-RTT connections, meaning that you're "instantaneously" connected. Similarly, WebRTC only actually does things once you try opening a channel, and it's not clear when you're actually "connected" or not.

Because of this, the word "connected" is a bit blurry.
In #1200, I've realized that we don't actually care whether we're "connected". Libp2p requires an extra handshake (Noise and maybe Yamux) anyway, and I don't see any advantage in differentiating the moment when the TCP handshake has finished and when the libp2p handshake has finished.
For this reason, in #1200, the concept of "pending connections" is gone. Instead, connections are instantaneously "connected", or, more precisely, there's no concept of "connected" anymore. There are only connections before their (libp2p) handshake and connections after their (libp2p) handshake.

#1200, however, introduced two issues:

- In case of WebRTC connections, it's not possible to know the local TLS certificate synchronously. The browser's function that generates a certificate is asynchronous (why? no idea, and at this point my main hypothesis is that people who design these things try to be as annoying as possible)
- Timeouts for pending connections (the TCP handshake) weren't working anymore.

While the second point could be solved with more code in the `light-base` library, I've instead decided to solve both by propagating the removal of the concept of "connected" to the `PlatformRef` trait.

---
cc @lexnv @skunert 

What that means, pragmatically speaking, is:

- `PlatformRef::connect_stream` and `connect_multistream` must now return as soon as possible. They're still returning futures, but it's done for API reasons. These futures must **not** wait for the connection to be established or something.
- `WithBuffers` (the helper to help implement `PlatformRef`) now stores a `Future<Output = Socket>` instead of just a `Socket`.

So in order to update after this change, you should now return a `WithBuffer<Future<Output = Socket>>` from `PlatformRef::connect_*`, instead of a `Future<Output = WithBuffer<Socket>>`.
See the changes to `default.rs` for an illustration.

This change made it possible to significantly simplify the WebRTC browser implementation, as at the moment we open a hacky preliminary substream just to detect when we reach the remote.
