### PR TITLE
Don't reexport `PeerId` from lib.rs

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -93,7 +93,6 @@ mod util;
 pub mod platform;
 
 pub use json_rpc_service::HandleRpcError;
-pub use peer_id::PeerId;
 
 /// See [`Client::add_chain`].
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Not sure why this re-export is there.