### PR TITLE
Make initializing a chain's services synchronous

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -136,7 +136,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
     /// Returns the networking service, plus a list of receivers on which events are pushed.
     /// All of these receivers must be polled regularly to prevent the networking service from
     /// slowing down.
-    pub async fn new(
+    pub fn new(
         config: Config<TPlat>,
     ) -> (
         Arc<Self>,

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -150,7 +150,7 @@ pub struct SyncService<TPlat: PlatformRef> {
 }
 
 impl<TPlat: PlatformRef> SyncService<TPlat> {
-    pub async fn new(config: Config<TPlat>) -> Self {
+    pub fn new(config: Config<TPlat>) -> Self {
         let (to_background, from_foreground) = async_channel::bounded(16);
         let from_foreground = Box::pin(from_foreground);
 

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -145,7 +145,7 @@ pub struct TransactionsService<TPlat> {
 
 impl<TPlat: PlatformRef> TransactionsService<TPlat> {
     /// Builds a new service.
-    pub async fn new(config: Config<TPlat>) -> Self {
+    pub fn new(config: Config<TPlat>) -> Self {
         let log_target = format!("tx-service-{}", config.log_name);
         let (to_background, from_foreground) = async_channel::bounded(8);
 


### PR DESCRIPTION
cc #133 

While the chain's services continue initializing in the background, there's no reason for the service frontends to take a long time to initialize. This PR makes them all synchronous.

While this PR is a good change in isolation, it also moves towards #133 by removing some std-only futures primitives.
