### PR TITLE
Remove the `channel` feature from `futures-util`

### DIFF
--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -23,7 +23,7 @@ event-listener = { version = "3.0.0", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
 futures-channel = { version = "0.3.27", default-features = false, features = ["alloc"] }
 futures-lite = { version = "2.0.0", default-features = false, features = ["alloc"] }
-futures-util = { version = "0.3.27", default-features = false, features = ["alloc", "channel", "sink"] }  # TODO: slim down these features and consider removing this dependency altogether
+futures-util = { version = "0.3.27", default-features = false, features = ["alloc", "sink"] }  # TODO: slim down these features and consider removing this dependency altogether
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }


### PR DESCRIPTION
cc #133 

This should be the last step to making it `no_std`.
