### PR TITLE
No longer pass back remote TLS certificate

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1916,11 +1916,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             .into_iter()
                             .chain(connection.local_tls_certificate_sha256.into_iter())
                             .collect();
-                        debug_assert_eq!(
-                            // TODO: check is a bit stupid given that the remote certificate is just passed through
-                            remote_certificate_sha256,
-                            connection.remote_tls_certificate_sha256
-                        );
                         let remote_tls_certificate_multihash = [12u8, 32]
                             .into_iter()
                             .chain(remote_certificate_sha256.into_iter())

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -214,9 +214,6 @@ pub struct MultiStreamWebRtcConnection<TConnection> {
     pub connection: TConnection,
     /// SHA256 hash of the TLS certificate used by the local node at the DTLS layer.
     pub local_tls_certificate_sha256: [u8; 32],
-    /// SHA256 hash of the TLS certificate used by the remote node at the DTLS layer.
-    // TODO: consider caching the information that was passed in the address instead of passing it back
-    pub remote_tls_certificate_sha256: [u8; 32],
 }
 
 /// Direction in which a substream has been opened. See [`PlatformRef::next_substream`].

--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -148,7 +148,6 @@ export interface ConnectionConfig {
         {
             handshake: 'webrtc',
             localTlsCertificateSha256: Uint8Array,
-            remoteTlsCertificateSha256: Uint8Array,
         }
     ) => void;
 

--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -91,7 +91,7 @@ export interface Instance {
      * all connections.
      */
     shutdownExecutor: () => void,
-    connectionMultiStreamSetHandshakeInfo: (connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array, remoteTlsCertificateSha256: Uint8Array }) => void,
+    connectionMultiStreamSetHandshakeInfo: (connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array }) => void,
     connectionReset: (connectionId: number, message: string) => void,
     streamWritableBytes: (connectionId: number, numExtra: number, streamId?: number) => void,
     streamMessage: (connectionId: number, message: Uint8Array, streamId?: number) => void,
@@ -546,14 +546,13 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             cb();
         },
 
-        connectionMultiStreamSetHandshakeInfo: (connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array, remoteTlsCertificateSha256: Uint8Array }) => {
+        connectionMultiStreamSetHandshakeInfo: (connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array }) => {
             if (!state.instance)
                 return;
 
-            const handshakeTy = new Uint8Array(1 + info.localTlsCertificateSha256.length + info.remoteTlsCertificateSha256.length);
+            const handshakeTy = new Uint8Array(1 + info.localTlsCertificateSha256.length);
             buffer.writeUInt8(handshakeTy, 0, 0);
             handshakeTy.set(info.localTlsCertificateSha256, 1)
-            handshakeTy.set(info.remoteTlsCertificateSha256, 1 + info.localTlsCertificateSha256.length)
             state.bufferIndices[0] = handshakeTy;
             state.instance.exports.connection_multi_stream_set_handshake_info(connectionId, 0);
             delete state.bufferIndices[0]

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -449,7 +449,7 @@ type ClientToServer =
     { ty: "accept-more-json-rpc-answers", chainId: number } |
     { ty: "shutdown" } |
     { ty: "connection-reset", connectionId: number, message: string } |
-    { ty: "connection-multistream-set-info", connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array, remoteTlsCertificateSha256: Uint8Array } } |
+    { ty: "connection-multistream-set-info", connectionId: number, info: { handshake: 'webrtc', localTlsCertificateSha256: Uint8Array } } |
     { ty: "stream-message", connectionId: number, streamId?: number, message: Uint8Array } |
     { ty: "stream-opened", connectionId: number, streamId: number, direction: "inbound" | "outbound" } |
     { ty: "stream-writable-bytes", connectionId: number, streamId?: number, numExtra: number } |

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -424,7 +424,6 @@ function connect(config: ConnectionConfig): Connection {
             config.onMultistreamHandshakeInfo({
                 handshake: 'webrtc',
                 localTlsCertificateSha256,
-                remoteTlsCertificateSha256,
             });
         });
 

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -497,8 +497,7 @@ pub extern "C" fn timer_finished() {
 /// de-assigned and buffer destroyed once this function returns.
 ///
 /// The buffer must contain a single 0 byte (indicating WebRTC), followed with the SHA-256 hash of
-/// the local node's TLS certificate, followed with the SHA-256 hash of the remote node's TLS
-/// certificate.
+/// the local node's TLS certificate.
 #[no_mangle]
 pub extern "C" fn connection_multi_stream_set_handshake_info(
     connection_id: u32,


### PR DESCRIPTION
When a connection (WebRTC or other) is opened, the JS code was originally meant to parse the multiaddress then indicate to smoldot the type of connection.

This design has been changed over time, and now smoldot does the parsing and indicates all the information to the JS code.

As a result, in case of a WebRTC connection, the JS code was originally sending back the remote TLS certificate (which is necessary for the Noise handshake later). Given that smoldot now does the parsing, this is no longer necessary.
