### PR TITLE
Refactor runtime service to properly isolate the background task

### DIFF
--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -863,7 +863,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         } = self.subscription
                         {
                             self.runtime_service
-                                .unpin_block(subscription_id, hash)
+                                .unpin_block(subscription_id, *hash)
                                 .await;
                         }
                     }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1292,7 +1292,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
 
                 match self
                     .runtime_service
-                    .pinned_block_runtime_access(subscription_id, &hash.0)
+                    .pinned_block_runtime_access(subscription_id, hash.0)
                     .await
                 {
                     Ok(c) => c,

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -994,7 +994,7 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
 
                 let access = if let Some(subscription_id) = subscription_id_with_block {
                     task.runtime_service
-                        .pinned_block_runtime_access(subscription_id, &block_hash)
+                        .pinned_block_runtime_access(subscription_id, block_hash)
                         .await
                         .ok()
                 } else {

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -760,7 +760,7 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 for block_hash in pruned_blocks.into_iter().chain(iter::once(finalized_hash)) {
                     if finalized_and_pruned_lru.len() == finalized_and_pruned_lru.cap().get() {
                         let (hash_to_unpin, _) = finalized_and_pruned_lru.pop_lru().unwrap();
-                        subscription.unpin_block(&hash_to_unpin).await;
+                        subscription.unpin_block(hash_to_unpin).await;
                         pinned_blocks.remove(&hash_to_unpin).unwrap();
                     }
                     finalized_and_pruned_lru.put(block_hash, ());

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1042,11 +1042,10 @@ async fn run_background<TPlat: PlatformRef>(
         to_background: Box::pin(to_background.clone()),
         to_background_tx: to_background_tx.clone(),
         blocks_stream: None,
-        wake_up_new_necessary_download: Box::pin(future::pending()),
+        // Initialized to `ready` so that the downloads immediately start.
+        wake_up_new_necessary_download: Box::pin(future::ready(())),
         runtime_downloads: stream::FuturesUnordered::new(),
     };
-
-    background.start_necessary_downloads(&mut guarded).await;
 
     // Inner loop. Process incoming events.
     loop {

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -761,7 +761,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     let hash = runtime_subscription.async_tree.block_user_data(block);
                     runtime_subscription
                         .relay_chain_subscribe_all
-                        .unpin_block(hash)
+                        .unpin_block(*hash)
                         .await;
                 }
             }
@@ -869,7 +869,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                         if pruned_block_parahead.is_none() {
                             runtime_subscription
                                 .relay_chain_subscribe_all
-                                .unpin_block(&hash)
+                                .unpin_block(hash)
                                 .await;
                         }
                     }

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1222,7 +1222,7 @@ async fn parahead<TPlat: PlatformRef>(
     // For each relay chain block, call `ParachainHost_persisted_validation_data` in
     // order to know where the parachains are.
     let precall = match relay_chain_sync
-        .pinned_block_runtime_access(subscription_id, block_hash)
+        .pinned_block_runtime_access(subscription_id, *block_hash)
         .await
     {
         Ok(p) => p,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1275,7 +1275,7 @@ async fn validate_transaction<TPlat: PlatformRef>(
     source: validate::TransactionSource,
 ) -> Result<validate::ValidTransaction, ValidationError> {
     let runtime_lock = match relay_chain_sync
-        .pinned_block_runtime_access(relay_chain_sync_subscription_id, &block_hash)
+        .pinned_block_runtime_access(relay_chain_sync_subscription_id, block_hash)
         .await
     {
         Ok(l) => l,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -642,10 +642,7 @@ async fn background_task<TPlat: PlatformRef>(mut config: BackgroundTaskConfig<TP
             for block in worker.pending_transactions.prune_finalized_with_body() {
                 // All blocks in `pending_transactions` are pinned within the runtime service.
                 // Unpin them when they're removed.
-                subscribe_all
-                    .new_blocks
-                    .unpin_block(&block.block_hash)
-                    .await;
+                subscribe_all.new_blocks.unpin_block(block.block_hash).await;
 
                 log::debug!(
                     target: &config.log_target,
@@ -742,7 +739,7 @@ async fn background_task<TPlat: PlatformRef>(mut config: BackgroundTaskConfig<TP
                     for pruned in worker.pending_transactions.set_finalized_block(&hash) {
                         // All blocks in `pending_transactions` are pinned within the
                         // runtime service. Unpin them when they're removed.
-                        subscribe_all.new_blocks.unpin_block(&pruned.0).await;
+                        subscribe_all.new_blocks.unpin_block(pruned.0).await;
 
                         // Note that we could in principle interrupt any on-going
                         // download of that block, but it is not worth the effort.


### PR DESCRIPTION
cc #519 

This PR removes the `Arc<Mutex<Guarded>>` that was shared between the frontend and backend, and instead moves everything to the backend.

This will later make it possible to restart the backend task if it happens to crash.

This PR also simplifies the general control flow of the service, as it is now way more straight forward.
