### PR TITLE
feat: add crashCallback

### DIFF
--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -281,6 +281,8 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                     error: new CrashError(event.message),
                 }
 
+                options.crashCallback?.(state.instance.error)
+
                 state.connections.forEach((connec) => connec.reset());
                 state.connections.clear();
 

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -321,6 +321,13 @@ export interface ClientOptions {
      * supported anyway.
      */
     forbidWebRtc?: boolean;
+
+    /**
+     * Callback that the client will invoke when the client crashes.
+     * 
+     * @param error the crash error
+     */
+    crashCallback?: (error: CrashError) => void
 }
 
 /**


### PR DESCRIPTION
Add a `crashCallback` that will enable to detect a `smoldot` client crash more easily.

Currently, the `CrashError` can be detected by invoking the following methods
- `client.addChain`
- `chain.sendJsonRpc`
- `chain.nextJsonRpcResponse`
- `chain.remove`
- `client.terminate`

Detecting a crash on these methods is not very convenient.

I'm currently using a single `smoldot` instante in a browser extension that add many chains.
When there is a crash, some of these chains need to be recreated with a new `smoldot` client instance.
This API will facilitate this scenario.

cc @josepot 