### PR TITLE
Add `Network::start_close_in_notifications`

### DIFF
--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -849,18 +849,17 @@ where
     }
 
     /// Closes a notifications substream opened after a successful
-    /// [`Event::NotificationsOutResult`] or that was accepted using
-    /// [`MultiStream::accept_in_notifications_substream`].
+    /// [`Event::NotificationsOutResult`].
     ///
-    /// In the case of an outbound substream, this can be done even when in the negotiation phase,
-    /// in other words before the remote has accepted/refused the substream.
+    /// This can be done even when in the negotiation phase, in other words before the remote has
+    /// accepted/refused the substream.
     ///
     /// # Panic
     ///
     /// Panics if the [`SubstreamId`] doesn't correspond to a notifications substream, or if the
     /// notifications substream isn't in the appropriate state.
     ///
-    pub fn close_notifications_substream(&mut self, substream_id: SubstreamId) {
+    pub fn close_out_notifications_substream(&mut self, substream_id: SubstreamId) {
         let substream_id = match substream_id.0 {
             SubstreamIdInner::MultiStream(id) => id,
             _ => panic!(),
@@ -874,7 +873,32 @@ where
             .inner
             .as_mut()
             .unwrap()
-            .close_notifications_substream();
+            .close_out_notifications_substream();
+    }
+
+    /// Closes a notifications substream that was accepted using
+    /// [`MultiStream::accept_in_notifications_substream`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SubstreamId`] doesn't correspond to a notifications substream, or if the
+    /// notifications substream isn't in the appropriate state.
+    ///
+    pub fn close_in_notifications_substream(&mut self, substream_id: SubstreamId, timeout: TNow) {
+        let substream_id = match substream_id.0 {
+            SubstreamIdInner::MultiStream(id) => id,
+            _ => panic!(),
+        };
+
+        let inner_substream_id = self.out_in_substreams_map.get(&substream_id).unwrap();
+
+        self.in_substreams
+            .get_mut(inner_substream_id)
+            .unwrap()
+            .inner
+            .as_mut()
+            .unwrap()
+            .close_in_notifications_substream(timeout);
     }
 
     /// Responds to an incoming request. Must be called in response to a [`Event::RequestIn`].

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -671,18 +671,17 @@ where
     }
 
     /// Closes a notifications substream opened after a successful
-    /// [`Event::NotificationsOutResult`] or that was accepted using
-    /// [`SingleStream::accept_in_notifications_substream`].
+    /// [`Event::NotificationsOutResult`].
     ///
-    /// In the case of an outbound substream, this can be done even when in the negotiation phase,
-    /// in other words before the remote has accepted/refused the substream.
+    /// This can be done even when in the negotiation phase, in other words before the remote has
+    /// accepted/refused the substream.
     ///
     /// # Panic
     ///
     /// Panics if the [`SubstreamId`] doesn't correspond to a notifications substream, or if the
     /// notifications substream isn't in the appropriate state.
     ///
-    pub fn close_notifications_substream(&mut self, substream_id: SubstreamId) {
+    pub fn close_out_notifications_substream(&mut self, substream_id: SubstreamId) {
         let substream_id = match substream_id.0 {
             SubstreamIdInner::SingleStream(id) => id,
             _ => panic!(),
@@ -696,7 +695,33 @@ where
             .as_mut()
             .unwrap()
             .0
-            .close_notifications_substream();
+            .close_out_notifications_substream();
+        self.inner.yamux.mark_substream_write_ready(substream_id);
+    }
+
+    /// Closes a notifications substream that was accepted using
+    /// [`SingleStream::accept_in_notifications_substream`].
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SubstreamId`] doesn't correspond to a notifications substream, or if the
+    /// notifications substream isn't in the appropriate state.
+    ///
+    pub fn close_in_notifications_substream(&mut self, substream_id: SubstreamId, timeout: TNow) {
+        let substream_id = match substream_id.0 {
+            SubstreamIdInner::SingleStream(id) => id,
+            _ => panic!(),
+        };
+
+        if !self.inner.yamux.has_substream(substream_id) {
+            panic!()
+        }
+
+        self.inner.yamux[substream_id]
+            .as_mut()
+            .unwrap()
+            .0
+            .close_in_notifications_substream(timeout);
         self.inner.yamux.mark_substream_write_ready(substream_id);
     }
 

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -219,7 +219,7 @@ where
     ///
     /// If this event contains an `Ok`, then [`Substream::write_notification_unbounded`],
     /// [`Substream::notification_substream_queued_bytes`] and
-    /// [`Substream::close_notifications_substream`] can be used, and
+    /// [`Substream::close_out_notifications_substream`] can be used, and
     /// [`Event::NotificationsOutCloseDemanded`] and [`Event::NotificationsOutReset`] can be
     /// generated.
     pub fn notifications_out(

--- a/lib/src/libp2p/connection/established/tests.rs
+++ b/lib/src/libp2p/connection/established/tests.rs
@@ -804,7 +804,9 @@ fn outbound_substream_close_demanded() {
     match event {
         either::Right(Event::NotificationIn { id, notification }) => {
             assert_eq!(notification, b"notif");
-            connections.bob.close_notifications_substream(id)
+            connections
+                .bob
+                .close_in_notifications_substream(id, Duration::from_secs(100))
         }
         _ev => unreachable!("{:?}", _ev),
     }
@@ -813,7 +815,7 @@ fn outbound_substream_close_demanded() {
     connections = connections_update;
     match event {
         either::Left(Event::NotificationsOutCloseDemanded { id }) => {
-            connections.alice.close_notifications_substream(id);
+            connections.alice.close_out_notifications_substream(id);
         }
         _ev => unreachable!("{:?}", _ev),
     }


### PR DESCRIPTION
cc #1248

I believe that this is almost the last complication added to `collection.rs`, apart from shutdowns.

Before this PR, it isn't possible to ask the remote to go away and they do it on their own goodwill. This PR is the first step to making this happen properly.
