### PR TITLE
Rename `hash` to `hashOrHashes`

### DIFF
--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -590,7 +590,7 @@ fn spawn_client_main_task(
                         }
                         methods::MethodCall::chainHead_unstable_unpin {
                             follow_subscription,
-                            hash,
+                            hash_or_hashes: hash,
                         } => {
                             if let Some(follow_subscription) =
                                 chain_head_follow_subscriptions.get_mut(&*follow_subscription)

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -590,12 +590,12 @@ fn spawn_client_main_task(
                         }
                         methods::MethodCall::chainHead_unstable_unpin {
                             follow_subscription,
-                            hash_or_hashes: hash,
+                            hash_or_hashes,
                         } => {
                             if let Some(follow_subscription) =
                                 chain_head_follow_subscriptions.get_mut(&*follow_subscription)
                             {
-                                let block_hashes = match hash {
+                                let block_hashes = match hash_or_hashes {
                                     methods::HashHexStringSingleOrArray::Array(list) => {
                                         list.into_iter().map(|h| h.0).collect::<Vec<_>>()
                                     }

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -488,7 +488,7 @@ define_methods! {
     ) -> (),
     chainHead_unstable_unpin(
         #[rename = "followSubscription"] follow_subscription: Cow<'a, str>,
-        hash: HashHexStringSingleOrArray
+        #[rename = "hashOrHashes"] hash_or_hashes: HashHexStringSingleOrArray
     ) -> (),
 
     chainSpec_v1_chainName() -> Cow<'a, str>,

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -840,9 +840,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             }
             methods::MethodCall::chainHead_unstable_unpin {
                 follow_subscription: _,
-                hash_or_hashes: hash,
+                hash_or_hashes,
             } => {
-                let all_hashes = match &hash {
+                let all_hashes = match &hash_or_hashes {
                     methods::HashHexStringSingleOrArray::Single(hash) => {
                         either::Left(iter::once(&hash.0))
                     }

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -840,7 +840,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
             }
             methods::MethodCall::chainHead_unstable_unpin {
                 follow_subscription: _,
-                hash,
+                hash_or_hashes: hash,
             } => {
                 let all_hashes = match &hash {
                     methods::HashHexStringSingleOrArray::Single(hash) => {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The `hash` parameter of `chainHead_unstable_unpin` has been renamed to `hashOrHashes`, in accordance with the latest changes in the JSON-RPC API specification. ([#1097](https://github.com/smol-dot/smoldot/pull/1097))
+
 ### Fixed
 
 - Fix panic when requesting a block with a specific hash from the peer-to-peer network and none of the peers has the block. ([#1303](https://github.com/smol-dot/smoldot/pull/1303))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- The `hash` parameter of `chainHead_unstable_unpin` has been renamed to `hashOrHashes`, in accordance with the latest changes in the JSON-RPC API specification. ([#1097](https://github.com/smol-dot/smoldot/pull/1097))
+- The `hash` parameter of `chainHead_unstable_unpin` has been renamed to `hashOrHashes`, in accordance with the latest changes in the JSON-RPC API specification. ([#1329](https://github.com/smol-dot/smoldot/pull/1329))
 
 ### Fixed
 


### PR DESCRIPTION
cc https://github.com/paritytech/json-rpc-interface-spec/pull/111

Assuming that another PR will be opened to fix the naming