### PR TITLE
Change the way the networking service reports events

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1175,7 +1175,6 @@ fn start_services<TPlat: platform::PlatformRef>(
                 log_name: log_name.clone(),
                 block_number_bytes,
                 network_service: (network_service.clone(), network_service_chain_id),
-                network_events_receiver: network_event_receivers.pop().unwrap(),
                 chain_type: sync_service::ConfigChainType::Parachain(
                     sync_service::ConfigParachain {
                         finalized_block_header,
@@ -1212,7 +1211,6 @@ fn start_services<TPlat: platform::PlatformRef>(
                 block_number_bytes,
                 platform: platform.clone(),
                 network_service: (network_service.clone(), network_service_chain_id),
-                network_events_receiver: network_event_receivers.pop().unwrap(),
                 chain_type: sync_service::ConfigChainType::RelayChain(
                     sync_service::ConfigRelayChain {
                         chain_information: chain_information.clone(),

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1093,10 +1093,9 @@ fn start_services<TPlat: platform::PlatformRef>(
     network_identify_agent_version: String,
 ) -> ChainServices<TPlat> {
     // The network service is responsible for connecting to the peer-to-peer network.
-    let (network_service, network_service_chain_ids, mut network_event_receivers) =
+    let (network_service, network_service_chain_ids) =
         network_service::NetworkService::new(network_service::Config {
             platform: platform.clone(),
-            num_events_receivers: 1, // Configures the length of `network_event_receivers`
             identify_agent_version: network_identify_agent_version,
             connections_open_pool_size: 5,
             connections_open_pool_restore_delay: Duration::from_secs(1),

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -65,6 +65,7 @@ use smoldot::{
 };
 
 pub use service::{ChainId, EncodedMerkleProof, QueueNotificationError};
+pub use codec::Role;
 
 mod tasks;
 
@@ -193,7 +194,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                     best_hash: chain.best_block.1,
                     best_number: chain.best_block.0,
                     genesis_hash: chain.genesis_block_hash,
-                    role: codec::Role::Light,
+                    role: Role::Light,
                     allow_inbound_block_requests: false,
                     user_data: Chain {
                         log_name: chain.log_name.clone(),
@@ -715,7 +716,7 @@ pub enum Event {
     Connected {
         peer_id: PeerId,
         chain_id: ChainId,
-        role: codec::Role,
+        role: Role,
         best_block_number: u64,
         best_block_hash: [u8; 32],
     },

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -66,10 +66,6 @@ pub struct Config<TPlat: PlatformRef> {
         network_service::ChainId,
     ),
 
-    /// Receiver for events coming from the network, as returned by
-    /// [`network_service::NetworkService::new`].
-    pub network_events_receiver: Pin<Box<dyn stream::Stream<Item = network_service::Event> + Send>>,
-
     /// Extra fields depending on whether the chain is a relay chain or a parachain.
     pub chain_type: ConfigChainType<TPlat>,
 }
@@ -168,7 +164,6 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                 from_foreground,
                 config.network_service.0.clone(),
                 config.network_service.1,
-                config.network_events_receiver,
             )),
             ConfigChainType::RelayChain(config_relay_chain) => {
                 Box::pin(standalone::start_standalone_chain(
@@ -180,7 +175,6 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                     from_foreground,
                     config.network_service.0.clone(),
                     config.network_service.1,
-                    config.network_events_receiver,
                 ))
             }
         };

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -31,7 +31,6 @@ use crate::{network_service, platform::PlatformRef, runtime_service};
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{cmp, fmt, future::Future, mem, num::NonZeroU32, pin::Pin, time::Duration};
 use futures_channel::oneshot;
-use futures_lite::stream;
 use rand::seq::IteratorRandom as _;
 use rand_chacha::rand_core::SeedableRng as _;
 use smoldot::{

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -619,10 +619,9 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
             network_service::Event::Connected {
                 peer_id,
                 role,
-                chain_id,
                 best_block_number,
                 best_block_hash,
-            } if chain_id == self.network_chain_id => {
+            } => {
                 let local_id = self.sync_sources.add_source(
                     best_block_number,
                     best_block_hash,
@@ -630,18 +629,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                 );
                 self.sync_sources_map.insert(peer_id, local_id);
             }
-            network_service::Event::Disconnected { peer_id, chain_id }
-                if chain_id == self.network_chain_id =>
-            {
+            network_service::Event::Disconnected { peer_id } => {
                 let local_id = self.sync_sources_map.remove(&peer_id).unwrap();
                 let (_peer_id, _role) = self.sync_sources.remove(local_id);
                 debug_assert_eq!(peer_id, _peer_id);
             }
-            network_service::Event::BlockAnnounce {
-                chain_id,
-                peer_id,
-                announce,
-            } if chain_id == self.network_chain_id => {
+            network_service::Event::BlockAnnounce { peer_id, announce } => {
                 let local_id = *self.sync_sources_map.get(&peer_id).unwrap();
                 let decoded = announce.decode();
                 if let Ok(decoded_header) =
@@ -664,7 +657,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                 }
             }
             _ => {
-                // Uninteresting message or irrelevant chain index.
+                // Uninteresting message.
             }
         }
     }

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1136,10 +1136,9 @@ impl<TPlat: PlatformRef> Task<TPlat> {
             network_service::Event::Connected {
                 peer_id,
                 role,
-                chain_id,
                 best_block_number,
                 best_block_hash,
-            } if chain_id == self.network_chain_id => {
+            } => {
                 self.peers_source_id_map.insert(
                     peer_id.clone(),
                     self.sync
@@ -1147,9 +1146,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 );
             }
 
-            network_service::Event::Disconnected { peer_id, chain_id }
-                if chain_id == self.network_chain_id =>
-            {
+            network_service::Event::Disconnected { peer_id } => {
                 let sync_source_id = self.peers_source_id_map.remove(&peer_id).unwrap();
                 let (_, requests) = self.sync.remove_source(sync_source_id);
 
@@ -1162,11 +1159,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 }
             }
 
-            network_service::Event::BlockAnnounce {
-                chain_id,
-                peer_id,
-                announce,
-            } if chain_id == self.network_chain_id => {
+            network_service::Event::BlockAnnounce { peer_id, announce } => {
                 let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
                 let decoded = announce.decode();
 
@@ -1264,19 +1257,14 @@ impl<TPlat: PlatformRef> Task<TPlat> {
 
             network_service::Event::GrandpaNeighborPacket {
                 peer_id,
-                chain_id,
                 finalized_block_height,
-            } if chain_id == self.network_chain_id => {
+            } => {
                 let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
                 self.sync
                     .update_source_finality_state(sync_source_id, finalized_block_height);
             }
 
-            network_service::Event::GrandpaCommitMessage {
-                chain_id,
-                peer_id,
-                message,
-            } if chain_id == self.network_chain_id => {
+            network_service::Event::GrandpaCommitMessage { peer_id, message } => {
                 let sync_source_id = *self.peers_source_id_map.get(&peer_id).unwrap();
                 match self
                     .sync
@@ -1296,10 +1284,6 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         );
                     }
                 }
-            }
-
-            _ => {
-                // Different chain index.
             }
         }
     }


### PR DESCRIPTION
Instead of creating "event senders" at initialization, the networking service now has a `subscribe()` function which can be called later.

This is necessary for #1343 and #519, and might be useful for #111.
