### PR TITLE
wasm-node: Better error reporting from JS side

### DIFF
--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -172,7 +172,7 @@ export interface ConnectionConfig {
      *
      * This function must only be called for connections of type "multi-stream".
      */
-    onStreamReset: (streamId: number) => void;
+    onStreamReset: (streamId: number, message: string) => void;
 
     /**
      * Callback called when some data sent using {@link Connection.send} has effectively been
@@ -354,10 +354,10 @@ export function start(options: ClientOptions, wasmModule: SmoldotBytecode | Prom
                             throw new Error();
                         state.instance.instance.streamWritableBytes(connectionId, numExtra, streamId);
                     },
-                    onStreamReset(streamId) {
+                    onStreamReset(streamId, message) {
                         if (state.instance.status !== "ready")
                             throw new Error();
-                        state.instance.instance.streamReset(connectionId, streamId);
+                        state.instance.instance.streamReset(connectionId, streamId, message);
                     },
                 }));
                 break;

--- a/wasm-node/javascript/src/internals/remote-instance.ts
+++ b/wasm-node/javascript/src/internals/remote-instance.ts
@@ -216,9 +216,9 @@ export async function connectToInstanceServer(config: ConnectConfig): Promise<in
             portToServer.postMessage(msg);
         },
 
-        streamReset(connectionId, streamId) {
+        streamReset(connectionId, streamId, message) {
             state.connections.get(connectionId)!.delete(streamId);
-            const msg: ClientToServer = { ty: "stream-reset", connectionId, streamId };
+            const msg: ClientToServer = { ty: "stream-reset", connectionId, streamId, message };
             portToServer.postMessage(msg);
         },
     };
@@ -418,7 +418,7 @@ export async function startInstanceServer(config: ServerConfig, initPortToClient
                 if (!state.connections.get(message.connectionId)!.has(message.streamId))
                     return;
                 state.connections.get(message.connectionId)!.delete(message.streamId);
-                state.instance!.streamReset(message.connectionId, message.streamId);
+                state.instance!.streamReset(message.connectionId, message.streamId, message.message);
                 break;
             }
         }
@@ -453,4 +453,4 @@ type ClientToServer =
     { ty: "stream-message", connectionId: number, streamId?: number, message: Uint8Array } |
     { ty: "stream-opened", connectionId: number, streamId: number, direction: "inbound" | "outbound" } |
     { ty: "stream-writable-bytes", connectionId: number, streamId?: number, numExtra: number } |
-    { ty: "stream-reset", connectionId: number, streamId: number };
+    { ty: "stream-reset", connectionId: number, streamId: number, message: string };

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -584,10 +584,15 @@ pub extern "C" fn connection_reset(connection_id: u32, buffer_index: u32) {
 ///
 /// It is illegal to call this function on a single-stream connections.
 ///
+/// Assign a so-called "buffer index" (a `u32`) representing the buffer containing the UTF-8
+/// reason for closing, then provide this buffer index to the function. The Rust code will call
+/// [`buffer_size`] and [`buffer_copy`] in order to obtain the content of this buffer. The buffer
+/// index can be de-assigned and buffer destroyed once this function returns.
+///
 /// See also [`connection_new`].
 #[no_mangle]
-pub extern "C" fn stream_reset(connection_id: u32, stream_id: u32) {
-    crate::platform::stream_reset(connection_id, stream_id);
+pub extern "C" fn stream_reset(connection_id: u32, stream_id: u32, buffer_index: u32) {
+    crate::platform::stream_reset(connection_id, stream_id, get_buffer(buffer_index));
 }
 
 pub(crate) fn get_buffer(buffer_index: u32) -> Vec<u8> {


### PR DESCRIPTION
This side goes alongside with https://github.com/smol-dot/smoldot/pull/1351

Improves the error reporting by making it possible to provide an error message when a stream is reset.
When a multistream connection gets reset, its message is copied to all of its still-open substreams.
