### PR TITLE
Fix multihash encoding of WebRTC certificates

### DIFF
--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -2140,11 +2140,11 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             .await;
 
                         // Convert the SHA256 hashes into multihashes.
-                        let local_tls_certificate_multihash = [12u8, 32]
+                        let local_tls_certificate_multihash = [18u8, 32]
                             .into_iter()
                             .chain(connection.local_tls_certificate_sha256.into_iter())
                             .collect();
-                        let remote_tls_certificate_multihash = [12u8, 32]
+                        let remote_tls_certificate_multihash = [18u8, 32]
                             .into_iter()
                             .chain(remote_certificate_sha256.into_iter())
                             .collect();

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix several WebRTC-related panics and bugs. ([#1348](https://github.com/smol-dot/smoldot/pull/1348))
+- Fix several WebRTC-related panics and bugs. ([#1348](https://github.com/smol-dot/smoldot/pull/1348), [#1350](https://github.com/smol-dot/smoldot/pull/1350), [#1354](https://github.com/smol-dot/smoldot/pull/1354))
 
 ## 2.0.9 - 2023-11-16
 


### PR DESCRIPTION
It's `0x12`, not `12`.