### PR TITLE
Ban peer after disconnect

### DIFF
--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -901,6 +901,21 @@ where
         &self.inner[id].address
     }
 
+    /// Returns the number of connections with the given peer.
+    ///
+    /// Both connections that have and have not finished their handshaking phase are considered.
+    pub fn num_potential_and_established_connections(&self, peer_id: &PeerId) -> usize {
+        let Some(&peer_index) = self.peers_by_peer_id.get(peer_id) else {
+            return 0;
+        };
+
+        self.connections_by_peer_id
+            .range(
+                (peer_index, ConnectionId::min_value())..=(peer_index, ConnectionId::max_value()),
+            )
+            .count()
+    }
+
     /// Pulls a message that must be sent to a connection.
     ///
     /// The message must be passed to [`SingleStreamConnectionTask::inject_coordinator_message`]

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1569,6 +1569,10 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 // it is not possible to be sure that we will reach 0 connections or connection
                 // attempts, and thus we ban the peer every time.
                 let ban_duration = Duration::from_secs(5);
+                task.network.gossip_remove_desired_all(
+                    &peer_id,
+                    service::GossipKind::ConsensusTransactions,
+                );
                 for (&chain_id, what_happened) in task
                     .peering_strategy
                     .unassign_slots_and_ban(&peer_id, task.platform.now() + ban_duration)

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Addresses that are not supported by the host platform are now ignored during the discovery process. For example, TCP/IP connections are ignored while in a browser. This avoids populating the address book with peers that we know we can't connect to anyway. ([#1359](https://github.com/smol-dot/smoldot/pull/1359))
+- Smoldot will no longer try to connect to the same address over and over again. ([#1358](https://github.com/smol-dot/smoldot/pull/1358))
 
 ## 2.0.10 - 2023-11-17
 


### PR DESCRIPTION
We currently don't ban peers when we fail to connect to them, leading to smoldot trying over and over again to connect to the same address.

Work in progress, because I need the changes in https://github.com/smol-dot/smoldot/pull/1357