### PR TITLE
Treat non-localhost non-secure WebSocket as not supported in browsers

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Addresses that are not supported by the host platform are now ignored during the discovery process. For example, TCP/IP connections are ignored while in a browser. This avoids populating the address book with peers that we know we can't connect to anyway. ([#1359](https://github.com/smol-dot/smoldot/pull/1359))
+- Addresses that are not supported by the host platform are now ignored during the discovery process. For example, TCP/IP connections are ignored while in a browser. This avoids populating the address book with peers that we know we can't connect to anyway. ([#1359](https://github.com/smol-dot/smoldot/pull/1359), [#1360](https://github.com/smol-dot/smoldot/pull/1360))
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -54,7 +54,7 @@ export function startWithBytecode(options: ClientOptionsWithBytecode): Client {
     // an issue.
     if ((typeof isSecureContext === 'boolean' && isSecureContext) && typeof location !== undefined) {
         const loc = location.toString();
-        if (loc.indexOf('localhost') !== -1 || loc.indexOf('127.0.0.1') !== -1 || loc.indexOf('::1') !== -1) {
+        if (loc.indexOf('localhost') !== -1 && loc.indexOf('127.0.0.1') !== -1 && loc.indexOf('::1') !== -1) {
             options.forbidNonLocalWs = true;
         }
     }


### PR DESCRIPTION
Complementing #1359, it is overall better to detect as much as possible ahead of time the addresses that we can't connect to anyway.