### PR TITLE
Recreate network service subscription if crash

### DIFF
--- a/lib/src/sync/all_forks/sources.rs
+++ b/lib/src/sync/all_forks/sources.rs
@@ -97,6 +97,13 @@ impl<TSrc> AllForksSources<TSrc> {
         self.sources.len()
     }
 
+    /// Remove all the sources.
+    pub fn clear(&mut self) {
+        self.sources.clear();
+        self.known_blocks1.clear();
+        self.known_blocks2.clear();
+    }
+
     /// Returns the list of all user datas of all sources.
     pub fn user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> + '_ {
         self.sources.values_mut().map(|s| &mut s.user_data)

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -301,15 +301,20 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
     /// The new channel will immediately receive events about all the existing connections, so
     /// that it is able to maintain a coherent view of the network.
     ///
+    /// Note that this function is `async`, but it should return very quickly.
+    ///
     /// The `Receiver` **must** be polled continuously. When the channel is full, the networking
     /// connections will be back-pressured until the channel isn't full anymore.
     ///
-    /// The `Receiver` never returns `None` unless the [`NetworkService`] is destroyed.
+    /// The `Receiver` never yields `None` unless the [`NetworkService`] crashes or is destroyed.
+    /// If `None` is yielded and the [`NetworkService`] is still alive, you should call
+    /// [`NetworkService::subscribe`] again to obtain a new `Receiver`.
     ///
     /// # Panic
     ///
     /// Panics if the given [`ChainId`] is invalid.
     ///
+    // TODO: consider not killing the background until the channel is destroyed, as that would be a more sensical behaviour
     pub async fn subscribe(&self, chain_id: ChainId) -> async_channel::Receiver<Event> {
         assert!(self.log_chain_names.contains_key(&chain_id));
 


### PR DESCRIPTION
cc #519 

This PR makes the two users of networking service subscriptions recreate their subscription in case it abruptly ends. This is a step towards making it possible to recover after a crash.
