### PR TITLE
Properly handle change in maximum protocol name length

### DIFF
--- a/fuzz/fuzz_targets/network-connection-raw.rs
+++ b/fuzz/fuzz_targets/network-connection-raw.rs
@@ -35,6 +35,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             randomness_seed: [0; 32],
             capacity: 0,
             max_inbound_substreams: 10,
+            max_protocol_name_len: 128,
             // This timeout doesn't matter as we pass dummy time values.
             handshake_timeout: Duration::from_secs(5),
             ping_protocol: "ping".into(),
@@ -58,7 +59,6 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
             noise_key: &smoldot::libp2p::connection::NoiseKey::new(&[0; 32], &[0; 32]),
         },
         0,
-        128,
         (),
     );
 

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -126,6 +126,11 @@ pub struct Config {
     /// >           many substreams.
     pub max_inbound_substreams: usize,
 
+    /// Maximum size in bytes of the protocols supported by the local node. Any protocol larger
+    /// than that requested by the remote is automatically refused. Necessary in order to avoid
+    /// situations where the remote sends an infinitely-sized protocol name.
+    pub max_protocol_name_len: usize,
+
     /// Amount of time after which a connection handshake is considered to have taken too long
     /// and must be aborted.
     pub handshake_timeout: Duration,
@@ -264,6 +269,9 @@ pub struct Network<TConn, TNow> {
     /// See [`Config::max_inbound_substreams`].
     max_inbound_substreams: usize,
 
+    /// See [`Config::max_protocol_name_len`].
+    max_protocol_name_len: usize,
+
     /// See [`Config::handshake_timeout`].
     handshake_timeout: Duration,
 
@@ -356,6 +364,7 @@ where
             ingoing_negotiated_substreams_by_connection: BTreeMap::new(),
             randomness_seeds: ChaCha20Rng::from_seed(config.randomness_seed),
             max_inbound_substreams: config.max_inbound_substreams,
+            max_protocol_name_len: config.max_protocol_name_len,
             ping_protocol: config.ping_protocol.into(),
             now_pin: PhantomData,
         }
@@ -370,7 +379,6 @@ where
         when_connection_start: TNow,
         handshake_kind: SingleStreamHandshakeKind,
         substreams_capacity: usize,
-        max_protocol_name_len: usize,
         user_data: TConn,
     ) -> (ConnectionId, SingleStreamConnectionTask<TNow>) {
         let connection_id = self.next_connection_id;
@@ -401,7 +409,7 @@ where
             handshake_timeout: when_connection_start + self.handshake_timeout,
             max_inbound_substreams: self.max_inbound_substreams,
             substreams_capacity,
-            max_protocol_name_len,
+            max_protocol_name_len: self.max_protocol_name_len,
             ping_protocol: self.ping_protocol.clone(),
         });
 
@@ -426,7 +434,6 @@ where
         when_connection_start: TNow,
         handshake_kind: MultiStreamHandshakeKind,
         substreams_capacity: usize,
-        max_protocol_name_len: usize,
         user_data: TConn,
     ) -> (ConnectionId, MultiStreamConnectionTask<TNow, TSubId>)
     where
@@ -488,7 +495,7 @@ where
             handshake,
             self.max_inbound_substreams,
             substreams_capacity,
-            max_protocol_name_len,
+            self.max_protocol_name_len,
             self.ping_protocol.clone(),
         );
 

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -400,6 +400,24 @@ where
                 }
             }
             (
+                CoordinatorToConnectionInner::SetMaxProtocolNameLen { new_max_length },
+                MultiStreamConnectionTaskInner::Handshake {
+                    established: Some(established),
+                    ..
+                }
+                | MultiStreamConnectionTaskInner::Established { established, .. },
+            ) => {
+                established.set_max_protocol_name_len(new_max_length);
+            }
+            (
+                CoordinatorToConnectionInner::SetMaxProtocolNameLen { .. },
+                MultiStreamConnectionTaskInner::Handshake {
+                    established: None, ..
+                },
+            ) => {
+                unreachable!()
+            }
+            (
                 CoordinatorToConnectionInner::StartRequest {
                     protocol_name,
                     request_data,
@@ -562,6 +580,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInbound { .. }
                 | CoordinatorToConnectionInner::RejectInbound { .. }
+                | CoordinatorToConnectionInner::SetMaxProtocolNameLen { .. }
                 | CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
                 | CoordinatorToConnectionInner::CloseInNotifications { .. }
@@ -576,6 +595,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInbound { .. }
                 | CoordinatorToConnectionInner::RejectInbound { .. }
+                | CoordinatorToConnectionInner::SetMaxProtocolNameLen { .. }
                 | CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
                 | CoordinatorToConnectionInner::CloseInNotifications { .. }

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -251,6 +251,21 @@ where
                 }
             }
             (
+                CoordinatorToConnectionInner::SetMaxProtocolNameLen { new_max_length },
+                SingleStreamConnectionTaskInner::Handshake {
+                    max_protocol_name_len,
+                    ..
+                },
+            ) => {
+                *max_protocol_name_len = new_max_length;
+            }
+            (
+                CoordinatorToConnectionInner::SetMaxProtocolNameLen { new_max_length },
+                SingleStreamConnectionTaskInner::Established { established, .. },
+            ) => {
+                established.set_max_protocol_name_len(new_max_length);
+            }
+            (
                 CoordinatorToConnectionInner::StartRequest {
                     protocol_name,
                     request_data,
@@ -431,6 +446,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInbound { .. }
                 | CoordinatorToConnectionInner::RejectInbound { .. }
+                | CoordinatorToConnectionInner::SetMaxProtocolNameLen { .. }
                 | CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
                 | CoordinatorToConnectionInner::CloseInNotifications { .. }
@@ -445,6 +461,7 @@ where
             (
                 CoordinatorToConnectionInner::AcceptInbound { .. }
                 | CoordinatorToConnectionInner::RejectInbound { .. }
+                | CoordinatorToConnectionInner::SetMaxProtocolNameLen { .. }
                 | CoordinatorToConnectionInner::AcceptInNotifications { .. }
                 | CoordinatorToConnectionInner::RejectInNotifications { .. }
                 | CoordinatorToConnectionInner::CloseInNotifications { .. }

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -153,6 +153,13 @@ where
         self.pending_events.pop_front()
     }
 
+    /// Modifies the value that was initially passed through [`Config::max_protocol_name_len`].
+    ///
+    /// The new value only applies to substreams opened after this function has been called.
+    pub fn set_max_protocol_name_len(&mut self, new_value: usize) {
+        self.max_protocol_name_len = new_value;
+    }
+
     /// Returns the number of new outbound substreams that the state machine would like to see
     /// opened.
     ///

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -423,6 +423,13 @@ where
             .unwrap()
     }
 
+    /// Modifies the value that was initially passed through [`Config::max_protocol_name_len`].
+    ///
+    /// The new value only applies to substreams opened after this function has been called.
+    pub fn set_max_protocol_name_len(&mut self, new_value: usize) {
+        self.inner.max_protocol_name_len = new_value;
+    }
+
     /// Sends a request to the remote.
     ///
     /// This method only inserts the request into the connection object. Use

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -369,10 +369,14 @@ where
     pub fn new(config: Config) -> Self {
         let mut randomness = rand_chacha::ChaCha20Rng::from_seed(config.randomness_seed);
 
+        // TODO: do the max protocol name length better ; knowing that it can later change if a chain with a long forkId is added
+        let max_protocol_name_len = 256;
+
         ChainNetwork {
             inner: collection::Network::new(collection::Config {
                 capacity: config.connections_capacity,
                 max_inbound_substreams: 128, // TODO: arbitrary value ; this value should be dynamically adjusted based on the number of chains that have been added
+                max_protocol_name_len,
                 randomness_seed: {
                     let mut seed = [0; 32];
                     randomness.fill_bytes(&mut seed);
@@ -795,8 +799,6 @@ where
         expected_peer_id: Option<PeerId>,
         user_data: TConn,
     ) -> (ConnectionId, SingleStreamConnectionTask<TNow>) {
-        // TODO: do the max protocol name length better ; knowing that it can later change if a chain with a long forkId is added
-        let max_protocol_name_len = 256;
         let substreams_capacity = 16; // TODO: ?
         let ed25519_public_key = match handshake_kind {
             SingleStreamHandshakeKind::MultistreamSelectNoiseYamux { noise_key, .. } => {
@@ -809,7 +811,6 @@ where
             when_connection_start,
             handshake_kind,
             substreams_capacity,
-            max_protocol_name_len,
             ConnectionInfo {
                 address: remote_addr,
                 ed25519_public_key,
@@ -852,8 +853,6 @@ where
     where
         TSubId: Clone + PartialEq + Eq + Hash,
     {
-        // TODO: do the max protocol name length better ; knowing that it can later change if a chain with a long forkId is added
-        let max_protocol_name_len = 256;
         let substreams_capacity = 16; // TODO: ?
         let ed25519_public_key = match handshake_kind {
             MultiStreamHandshakeKind::WebRtc { noise_key, .. } => {
@@ -866,7 +865,6 @@ where
             when_connection_start,
             handshake_kind,
             substreams_capacity,
-            max_protocol_name_len,
             ConnectionInfo {
                 address: remote_addr,
                 peer_index: expected_peer_index,


### PR DESCRIPTION
This is a pretty niche problem, but if someone were to add a chain with a very large fork ID (before this PR, "very large" being 200 bytes) they could reach the hardcoded maximum protocol name length. 

In order to properly handle this situation, we now dynamically adjust the maximum protocol name length by sending messages to connection tasks.
