### PR TITLE
Fix rare bug in `ChainNetwork`

### DIFF
--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -2290,7 +2290,7 @@ where
                     let _was_in = self.notification_substreams_by_peer_id.remove(&(
                         NotificationsProtocol::BlockAnnounces { chain_index },
                         peer_index, // TODO: cloning overhead :-/
-                        SubstreamDirection::Out,
+                        SubstreamDirection::In,
                         NotificationsSubstreamState::Open,
                         substream_id,
                     ));


### PR DESCRIPTION
In the uncommon situation where a `NotificationsInOpenCancel` event is generated, there would be a state mismatch.