### PR TITLE
Pass a buffer of buffers to `stream_send` instead of calling it several times

### DIFF
--- a/wasm-node/javascript/src/internals/client.ts
+++ b/wasm-node/javascript/src/internals/client.ts
@@ -91,7 +91,7 @@ export interface Connection {
      *
      * Must not be called after `closeSend` has been called.
      */
-    send(data: Uint8Array, streamId?: number): void;
+    send(data: Array<Uint8Array>, streamId?: number): void;
 
     /**
      * Closes the writing side of the given stream of the given connection.

--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -69,7 +69,7 @@ export type Event =
     { ty: "connection-reset", connectionId: number } |
     { ty: "connection-stream-open", connectionId: number } |
     { ty: "connection-stream-reset", connectionId: number, streamId: number } |
-    { ty: "stream-send", connectionId: number, streamId?: number, data: Uint8Array } |
+    { ty: "stream-send", connectionId: number, streamId?: number, data: Array<Uint8Array> } |
     { ty: "stream-send-close", connectionId: number, streamId?: number };
 
 export type ParsedMultiaddr =
@@ -355,11 +355,18 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
         // that this function is called only when the connection is in an open state.
         stream_send: (connectionId: number, streamId: number, ptr: number, len: number) => {
             const instance = state.instance!;
+            const mem = new Uint8Array(instance.exports.memory.buffer);
 
             ptr >>>= 0;
             len >>>= 0;
 
-            const data = new Uint8Array(instance.exports.memory.buffer).slice(ptr, ptr + len);
+            const data = new Array();
+            for (let i = 0; i < len; ++i) {
+                const bufPtr = buffer.readUInt32LE(mem, ptr + 8 * i);
+                const bufLen = buffer.readUInt32LE(mem, ptr + 8 * i + 4);
+                data.push(mem.slice(bufPtr, bufPtr + bufLen));
+            } 
+
             // TODO: docs says the streamId is provided only for multi-stream connections, but here it's always provided
             eventCallback({ ty: "stream-send", connectionId, streamId, data });
         },

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -176,13 +176,15 @@ function connect(config: ConnectionConfig): Connection {
                 connection = null;
             },
 
-            send: (data: Uint8Array): void => {
-                (connection as WebSocket).send(data);
+            send: (data: Array<Uint8Array>): void => {
                 if (bufferedAmountCheck.quenedUnreportedBytes == 0) {
                     bufferedAmountCheck.nextTimeout = 10;
                     setTimeout(checkBufferedAmount, 10);
                 }
-                bufferedAmountCheck.quenedUnreportedBytes += data.length;
+                for (const buffer of data) {
+                    (connection as WebSocket).send(buffer);
+                    bufferedAmountCheck.quenedUnreportedBytes += buffer.length;
+                }
             },
 
             closeSend: (): void => { throw new Error('Wrong connection type') },
@@ -490,10 +492,12 @@ function connect(config: ConnectionConfig): Connection {
                 }
             },
 
-            send: (data: Uint8Array, streamId: number): void => {
+            send: (data: Array<Uint8Array>, streamId: number): void => {
                 const channel = state.dataChannels.get(streamId)!;
-                channel.channel.send(data);
-                channel.bufferedBytes += data.length;
+                for (const buffer of data) {
+                    channel.channel.send(buffer);
+                    channel.bufferedBytes += buffer.length;
+                }
             },
 
             closeSend: (): void => { throw new Error('Wrong connection type') },

--- a/wasm-node/javascript/src/no-auto-bytecode-browser.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-browser.ts
@@ -182,9 +182,9 @@ function connect(config: ConnectionConfig): Connection {
                     setTimeout(checkBufferedAmount, 10);
                 }
                 for (const buffer of data) {
-                    (connection as WebSocket).send(buffer);
                     bufferedAmountCheck.quenedUnreportedBytes += buffer.length;
                 }
+                (connection as WebSocket).send(new Blob(data));
             },
 
             closeSend: (): void => { throw new Error('Wrong connection type') },
@@ -495,9 +495,9 @@ function connect(config: ConnectionConfig): Connection {
             send: (data: Array<Uint8Array>, streamId: number): void => {
                 const channel = state.dataChannels.get(streamId)!;
                 for (const buffer of data) {
-                    channel.channel.send(buffer);
                     channel.bufferedBytes += buffer.length;
                 }
+                channel.channel.send(new Blob(data));
             },
 
             closeSend: (): void => { throw new Error('Wrong connection type') },

--- a/wasm-node/javascript/src/no-auto-bytecode-deno.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-deno.ts
@@ -114,19 +114,21 @@ function connect(config: ConnectionConfig): Connection {
                 socket.onerror = () => { };
                 socket.close();
             },
-            send: (data: Uint8Array): void => {
+            send: (data: Array<Uint8Array>): void => {
                 // The WebSocket library that we use seems to spontaneously transition connections
                 // to the "closed" state but not call the `onclosed` callback immediately. Calling
                 // `send` on that object throws an exception. In order to avoid panicking smoldot,
                 // we thus absorb any exception thrown here.
                 // See also <https://github.com/paritytech/smoldot/issues/2937>.
                 try {
-                    socket.send(data);
                     if (bufferedAmountCheck.quenedUnreportedBytes == 0) {
                         bufferedAmountCheck.nextTimeout = 10;
                         setTimeout(checkBufferedAmount, 10);
                     }
-                    bufferedAmountCheck.quenedUnreportedBytes += data.length;
+                    for (const buffer of data) {
+                        socket.send(buffer);
+                        bufferedAmountCheck.quenedUnreportedBytes += buffer.length;
+                    }
                 } catch (_error) { }
             },
             closeSend: (): void => { throw new Error('Wrong connection type') },
@@ -191,31 +193,35 @@ function connect(config: ConnectionConfig): Connection {
                 socket.inner.then((connec) => connec!.close());
             },
 
-            send: (data: Uint8Array): void => {
-                let dataCopy = Uint8Array.from(data)  // Deep copy of the data
+            send: (data: Array<Uint8Array>): void => {
+                let dataCopy = data.map((buf) => Uint8Array.from(buf));  // Deep copy of the data
                 socket.inner = socket.inner.then(async (c) => {
-                    while (dataCopy.length > 0) {
-                        if (socket.destroyed || c === null)
-                            return c;
-                        let outcome: number | string;
-                        try {
-                            outcome = await c.write(dataCopy);
-                            config.onWritableBytes(dataCopy.length);
-                        } catch (error) {
-                            // The type of `error` is unclear, but we assume that it implements `Error`
-                            outcome = (error as Error).toString()
+                    for (let buffer of dataCopy) {
+                        while (buffer.length > 0) {
+                            if (socket.destroyed || c === null)
+                                return c;
+                            let outcome: number | string;
+                            try {
+                                outcome = await c.write(buffer);
+                                config.onWritableBytes(buffer.length);
+                            } catch (error) {
+                                // The type of `error` is unclear, but we assume that it
+                                // implements `Error`
+                                outcome = (error as Error).toString()
+                            }
+                            if (typeof outcome !== 'number') {
+                                // The socket is reported closed, but `socket.destroyed` is still
+                                // `false` (see check above). As such, we must inform the
+                                // inner layers.
+                                socket.destroyed = true;
+                                config.onConnectionReset(outcome);
+                                return c;
+                            }
+                            // Note that, contrary to `read`, it is possible for `outcome` to be 0.
+                            // This happen if the write had to be interrupted, and the only thing
+                            // we have to do is try writing again.
+                            buffer = buffer.slice(outcome);
                         }
-                        if (typeof outcome !== 'number') {
-                            // The socket is reported closed, but `socket.destroyed` is still
-                            // `false` (see check above). As such, we must inform the inner layers.
-                            socket.destroyed = true;
-                            config.onConnectionReset(outcome);
-                            return c;
-                        }
-                        // Note that, contrary to `read`, it is possible for `outcome` to be 0.
-                        // This happen if the write had to be interrupted, and the only thing
-                        // we have to do is try writing again.
-                        dataCopy = dataCopy.slice(outcome);
                     }
                     return c;
                 });

--- a/wasm-node/javascript/src/no-auto-bytecode-deno.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-deno.ts
@@ -126,9 +126,9 @@ function connect(config: ConnectionConfig): Connection {
                         setTimeout(checkBufferedAmount, 10);
                     }
                     for (const buffer of data) {
-                        socket.send(buffer);
                         bufferedAmountCheck.quenedUnreportedBytes += buffer.length;
                     }
+                    socket.send(new Blob(data));
                 } catch (_error) { }
             },
             closeSend: (): void => { throw new Error('Wrong connection type') },

--- a/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
+++ b/wasm-node/javascript/src/no-auto-bytecode-nodejs.ts
@@ -136,13 +136,15 @@ function connect(config: ConnectionConfig): Connection {
                 socket.onerror = () => { };
                 socket.close();
             },
-            send: (data: Uint8Array): void => {
-                socket.send(data);
+            send: (data: Array<Uint8Array>): void => {
                 if (bufferedAmountCheck.quenedUnreportedBytes == 0) {
                     bufferedAmountCheck.nextTimeout = 10;
                     setTimeout(checkBufferedAmount, 10);
                 }
-                bufferedAmountCheck.quenedUnreportedBytes += data.length;
+                for (const buffer of data) {
+                    socket.send(buffer);
+                    bufferedAmountCheck.quenedUnreportedBytes += buffer.length;
+                }
             },
             closeSend: (): void => { throw new Error('Wrong connection type') },
             openOutSubstream: () => { throw new Error('Wrong connection type') }
@@ -188,16 +190,18 @@ function connect(config: ConnectionConfig): Connection {
             reset: (): void => {
                 socket.destroy();
             },
-            send: (data: Uint8Array): void => {
-                const dataLen = data.length;
-                const allWritten = socket.write(data);
-                if (allWritten) {
-                    setImmediate(() => {
-                        if (!socket.writable) return;
-                        config.onWritableBytes(dataLen)
-                    });
-                } else {
-                    drainingBytes.num += dataLen;
+            send: (data: Array<Uint8Array>): void => {
+                for (const buffer of data) {
+                    const bufferLen = buffer.length;
+                    const allWritten = socket.write(buffer);
+                    if (allWritten) {
+                        setImmediate(() => {
+                            if (!socket.writable) return;
+                            config.onWritableBytes(bufferLen)
+                        });
+                    } else {
+                        drainingBytes.num += bufferLen;
+                    }
                 }
             },
             closeSend: (): void => {

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -249,8 +249,16 @@ extern "C" {
     /// currently be in the `Open` state. See the documentation of [`connection_new`] for details.
     pub fn connection_stream_reset(connection_id: u32, stream_id: u32);
 
-    /// Queues data on the given stream. The data is found in the memory of the WebAssembly
-    /// virtual machine, at the given pointer.
+    /// Queues data on the given stream.
+    ///
+    /// `ptr` is a memory address where `len` consecutive elements of type [`StreamSendIoVector`]
+    /// are found. Each element consists in two little-endian 32 bits unsigned integers: the first
+    /// one is a pointer, and the second one is a length in bytes. The data to write on the stream
+    /// consists in the concatenation of all these buffers.
+    ///
+    /// > **Note**: This interface is similar the famous UNIX function `writev`. `ptr` is the same
+    /// >           as `iov`, and `len` the same as `iovcnt`.
+    /// >           See <https://linux.die.net/man/2/writev>.
     ///
     /// If `connection_id` is a single-stream connection, then the value of `stream_id` should
     /// be ignored. If `connection_id` is a multi-stream connection, then the value of `stream_id`
@@ -294,6 +302,16 @@ extern "C" {
     ///
     /// Only one task can be currently executing at any time.
     pub fn current_task_exit();
+}
+
+/// See [`stream_send`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(C)]
+pub struct StreamSendIoVector {
+    /// Pointer to a buffer of data to write.
+    pub ptr: u32,
+    /// Length of the buffer of data.
+    pub len: u32,
 }
 
 /// Initializes the client.


### PR DESCRIPTION
`stream_send` now accepts a list of buffers, instead of a single buffer.

By batching all the data to send on a socket into one call, we avoid going through the slow host <-> client interface, and also potentially reduce the number of TCP/UDP packets being sent by the browser or by NodeJS.
