### PR TITLE
Refactor `Multiaddr` to have a generic parameter with its buffer

### DIFF
--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -32,7 +32,7 @@
 use smoldot::{
     identity::seed_phrase,
     libp2p::{
-        multiaddr::{Multiaddr, ProtocolRef},
+        multiaddr::{Multiaddr, Protocol},
         PeerId,
     },
 };
@@ -220,7 +220,7 @@ pub struct Bootnode {
 
 fn parse_bootnode(string: &str) -> Result<Bootnode, String> {
     let mut address = string.parse::<Multiaddr>().map_err(|err| err.to_string())?;
-    let Some(ProtocolRef::P2p(peer_id)) = address.iter().last() else {
+    let Some(Protocol::P2p(peer_id)) = address.iter().last() else {
         return Err("Bootnode address must end with /p2p/...".into());
     };
     let peer_id = PeerId::from_bytes(peer_id.to_vec())

--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -223,7 +223,7 @@ fn parse_bootnode(string: &str) -> Result<Bootnode, String> {
     let Some(Protocol::P2p(peer_id)) = address.iter().last() else {
         return Err("Bootnode address must end with /p2p/...".into());
     };
-    let peer_id = PeerId::from_bytes(peer_id.to_vec())
+    let peer_id = PeerId::from_bytes(peer_id.into_bytes().to_vec())
         .map_err(|(err, _)| format!("Failed to parse PeerId in bootnode: {err}"))?;
     address.pop();
     Ok(Bootnode { address, peer_id })

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -336,7 +336,7 @@ impl NetworkService {
                 // Note that we must call this function before `insert_address`, as documented
                 // in `basic_peering_strategy`.
                 peering_strategy.insert_chain_peer(chain_id, peer_id.clone(), usize::max_value());
-                peering_strategy.insert_address(&peer_id, addr.into_vec(), usize::max_value());
+                peering_strategy.insert_address(&peer_id, addr.into_bytes(), usize::max_value());
             }
 
             chain_names.insert(chain_id, chain.log_name);
@@ -843,7 +843,7 @@ async fn background_task(mut inner: Inner) {
                                 address_removed: Some(addr_rm),
                             } = inner.peering_strategy.insert_or_set_connected_address(
                                 &peer_id,
-                                remote_addr.clone().into_vec(),
+                                remote_addr.clone().into_bytes(),
                                 10, // TODO: constant
                             ) {
                                 let addr_rm = Multiaddr::try_from(addr_rm).unwrap();
@@ -1180,7 +1180,7 @@ async fn background_task(mut inner: Inner) {
                             for addr in valid_addrs {
                                 match inner
                                     .peering_strategy
-                                     .insert_address(&peer_id, addr.into_vec(), 10) // TODO: constant
+                                     .insert_address(&peer_id, addr.into_bytes(), 10) // TODO: constant
                                     {
                                         basic_peering_strategy::InsertAddressResult::Inserted { address_removed: Some(addr_rm) } => {
                                             let addr_rm = Multiaddr::try_from(addr_rm).unwrap();
@@ -1474,7 +1474,7 @@ async fn background_task(mut inner: Inner) {
                         is_initiator: true,
                         noise_key: &inner.noise_key,
                     },
-                    multiaddr.clone().into_vec(),
+                    multiaddr.clone().into_bytes(),
                     Some(peer_id.clone()),
                     tx,
                 );
@@ -1569,7 +1569,7 @@ async fn background_task(mut inner: Inner) {
                         is_initiator: false,
                         noise_key: &inner.noise_key,
                     },
-                    multiaddr.clone().into_vec(),
+                    multiaddr.clone().into_bytes(),
                     None,
                     tx,
                 );

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -45,7 +45,7 @@ use smoldot::{
     informant::HashDisplay,
     libp2p::{
         connection,
-        multiaddr::{self, Multiaddr, ProtocolRef},
+        multiaddr::{self, Multiaddr, Protocol},
         peer_id::{self, PeerId},
     },
     network::{basic_peering_strategy, codec, service},
@@ -385,10 +385,10 @@ impl NetworkService {
                     let proto2 = iter.next();
                     let proto3 = iter.next();
                     match (proto1, proto2, proto3) {
-                        (Some(ProtocolRef::Ip4(ip)), Some(ProtocolRef::Tcp(port)), None) => {
+                        (Some(Protocol::Ip4(ip)), Some(Protocol::Tcp(port)), None) => {
                             Some(SocketAddr::from((ip, port)))
                         }
-                        (Some(ProtocolRef::Ip6(ip)), Some(ProtocolRef::Tcp(port)), None) => {
+                        (Some(Protocol::Ip6(ip)), Some(Protocol::Tcp(port)), None) => {
                             Some(SocketAddr::from((ip, port)))
                         }
                         _ => None,
@@ -456,10 +456,10 @@ impl NetworkService {
 
                         let multiaddr = [
                             match addr.ip() {
-                                IpAddr::V4(ip) => ProtocolRef::Ip4(ip.octets()),
-                                IpAddr::V6(ip) => ProtocolRef::Ip6(ip.octets()),
+                                IpAddr::V4(ip) => Protocol::<&[u8]>::Ip4(ip.octets()),
+                                IpAddr::V6(ip) => Protocol::Ip6(ip.octets()),
                             },
-                            ProtocolRef::Tcp(addr.port()),
+                            Protocol::Tcp(addr.port()),
                         ]
                         .into_iter()
                         .collect::<Multiaddr>();

--- a/full-node/src/network_service/tasks.rs
+++ b/full-node/src/network_service/tasks.rs
@@ -26,7 +26,7 @@ use smol::{
 };
 use smoldot::{
     libp2p::{
-        multiaddr::{Multiaddr, ProtocolRef},
+        multiaddr::{Multiaddr, Protocol},
         websocket, with_buffers,
     },
     network::service::{self, CoordinatorToConnection},
@@ -214,33 +214,33 @@ pub(super) fn multiaddr_to_socket(
 
     // Ensure ahead of time that the multiaddress is supported.
     let (addr, host_if_websocket) = match (&proto1, &proto2, &proto3) {
-        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), None) => (
+        (Protocol::Ip4(ip), Protocol::Tcp(port), None) => (
             either::Left(SocketAddr::new(IpAddr::V4((*ip).into()), *port)),
             None,
         ),
-        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), None) => (
+        (Protocol::Ip6(ip), Protocol::Tcp(port), None) => (
             either::Left(SocketAddr::new(IpAddr::V6((*ip).into()), *port)),
             None,
         ),
-        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => {
+        (Protocol::Ip4(ip), Protocol::Tcp(port), Some(Protocol::Ws)) => {
             let addr = SocketAddr::new(IpAddr::V4((*ip).into()), *port);
             (either::Left(addr), Some(addr.to_string()))
         }
-        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws)) => {
+        (Protocol::Ip6(ip), Protocol::Tcp(port), Some(Protocol::Ws)) => {
             let addr = SocketAddr::new(IpAddr::V6((*ip).into()), *port);
             (either::Left(addr), Some(addr.to_string()))
         }
 
         // TODO: we don't care about the differences between Dns, Dns4, and Dns6
         (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
             None,
         ) => (either::Right((addr.to_string(), *port)), None),
         (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
-            Some(ProtocolRef::Ws),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
+            Some(Protocol::Ws),
         ) => (
             either::Right((addr.to_string(), *port)),
             Some(format!("{}:{}", addr, *port)),

--- a/fuzz/fuzz_targets/multiaddr-bytes.rs
+++ b/fuzz/fuzz_targets/multiaddr-bytes.rs
@@ -20,5 +20,5 @@
 use core::convert::TryFrom as _;
 
 libfuzzer_sys::fuzz_target!(|data: Vec<u8>| {
-    let _ = smoldot::libp2p::multiaddr::Multiaddr::try_from(data);
+    let _ = smoldot::libp2p::multiaddr::Multiaddr::from_bytes(data);
 });

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -255,7 +255,9 @@ impl ChainSpec {
         self.client_spec.boot_nodes.iter().map(|unparsed| {
             if let Ok(mut addr) = unparsed.parse::<libp2p::Multiaddr>() {
                 if let Some(libp2p::multiaddr::Protocol::P2p(peer_id)) = addr.iter().last() {
-                    if let Ok(peer_id) = libp2p::peer_id::PeerId::from_bytes(peer_id.to_vec()) {
+                    if let Ok(peer_id) =
+                        libp2p::peer_id::PeerId::from_bytes(peer_id.into_bytes().to_vec())
+                    {
                         addr.pop();
                         return Bootnode::Parsed {
                             multiaddr: addr.to_string(),

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -254,7 +254,7 @@ impl ChainSpec {
         // not tie the code that parses chain specifications to the libp2p code.
         self.client_spec.boot_nodes.iter().map(|unparsed| {
             if let Ok(mut addr) = unparsed.parse::<libp2p::Multiaddr>() {
-                if let Some(libp2p::multiaddr::ProtocolRef::P2p(peer_id)) = addr.iter().last() {
+                if let Some(libp2p::multiaddr::Protocol::P2p(peer_id)) = addr.iter().last() {
                     if let Ok(peer_id) = libp2p::peer_id::PeerId::from_bytes(peer_id.to_vec()) {
                         addr.pop();
                         return Bootnode::Parsed {

--- a/lib/src/network/codec/kademlia.rs
+++ b/lib/src/network/codec/kademlia.rs
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-    libp2p::{multiaddr, peer_id},
-    util::protobuf,
-};
+use crate::{libp2p::peer_id, util::protobuf};
 
 use alloc::vec::Vec;
 
@@ -91,9 +88,6 @@ pub enum DecodeFindNodeResponseError {
     /// Error while parsing a [`peer_id::PeerId`] in the response.
     #[display(fmt = "Invalid PeerId: {_0}")]
     BadPeerId(peer_id::FromBytesError),
-    /// Error while parsing a [`multiaddr::Multiaddr`] in the response.
-    #[display(fmt = "Invalid multiaddress: {_0}")]
-    BadMultiaddr(multiaddr::FromBytesError),
 }
 
 /// Error while decoding the Protobuf encoding.

--- a/lib/src/network/codec/kademlia.rs
+++ b/lib/src/network/codec/kademlia.rs
@@ -93,7 +93,7 @@ pub enum DecodeFindNodeResponseError {
     BadPeerId(peer_id::FromBytesError),
     /// Error while parsing a [`multiaddr::Multiaddr`] in the response.
     #[display(fmt = "Invalid multiaddress: {_0}")]
-    BadMultiaddr(multiaddr::FromVecError),
+    BadMultiaddr(multiaddr::FromBytesError),
 }
 
 /// Error while decoding the Protobuf encoding.

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -672,7 +672,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         match multiaddr.parse::<multiaddr::Multiaddr>() {
             Ok(mut addr) if matches!(addr.iter().last(), Some(multiaddr::Protocol::P2p(_))) => {
                 let peer_id_bytes = match addr.iter().last() {
-                    Some(multiaddr::Protocol::P2p(peer_id)) => peer_id.to_owned(),
+                    Some(multiaddr::Protocol::P2p(peer_id)) => peer_id.into_bytes().to_owned(),
                     _ => unreachable!(),
                 };
                 addr.pop();

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -670,9 +670,9 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         };
 
         match multiaddr.parse::<multiaddr::Multiaddr>() {
-            Ok(mut addr) if matches!(addr.iter().last(), Some(multiaddr::ProtocolRef::P2p(_))) => {
+            Ok(mut addr) if matches!(addr.iter().last(), Some(multiaddr::Protocol::P2p(_))) => {
                 let peer_id_bytes = match addr.iter().last() {
-                    Some(multiaddr::ProtocolRef::P2p(peer_id)) => peer_id.into_owned(),
+                    Some(multiaddr::Protocol::P2p(peer_id)) => peer_id.to_owned(),
                     _ => unreachable!(),
                 };
                 addr.pop();

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1431,9 +1431,10 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                         .insert_chain_peer(chain_id, peer_id.clone(), 30); // TODO: constant
 
                     for addr in addrs {
-                        let _ = task
-                            .peering_strategy
-                            .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
+                        let _ =
+                            task.peering_strategy
+                                .insert_address(&peer_id, addr.into_bytes(), 10);
+                        // TODO: constant
                     }
                 }
             }
@@ -1534,7 +1535,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     // TODO: if Bob says that its address is the same as Alice's, and we try to connect to both Alice and Bob, then the Bob connection will reach this path and set Alice's address as connected even though it's already connected; this will later cause a state mismatch when disconnecting
                     let _ = task.peering_strategy.insert_or_set_connected_address(
                         &peer_id,
-                        remote_addr.clone().into_vec(),
+                        remote_addr.clone().into_bytes(),
                         10,
                     );
                 } else {
@@ -1889,7 +1890,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     for addr in valid_addrs {
                         let _insert_result =
                             task.peering_strategy
-                                .insert_address(&peer_id, addr.into_vec(), 10); // TODO: constant
+                                .insert_address(&peer_id, addr.into_bytes(), 10); // TODO: constant
                         debug_assert!(!matches!(
                             _insert_result,
                             basic_peering_strategy::InsertAddressResult::UnknownPeer
@@ -2189,7 +2190,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                     is_initiator: true,
                                     noise_key: &noise_key,
                                 },
-                                multiaddr.clone().into_vec(),
+                                multiaddr.clone().into_bytes(),
                                 Some(expected_peer_id.clone()),
                                 coordinator_to_connection_tx,
                             );
@@ -2246,7 +2247,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                     remote_tls_certificate_multihash,
                                     noise_key: &noise_key,
                                 },
-                                multiaddr.clone().into_vec(),
+                                multiaddr.clone().into_bytes(),
                                 Some(expected_peer_id.clone()),
                                 coordinator_to_connection_tx,
                             );

--- a/light-base/src/platform/address_parse.rs
+++ b/light-base/src/platform/address_parse.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use smoldot::libp2p::{multiaddr::Protocol, multihash, Multiaddr};
+use smoldot::libp2p::multiaddr::{Multiaddr, Protocol};
 
 use super::{Address, ConnectionType, IpAddr, MultiStreamAddress};
 use core::str;
@@ -112,10 +112,8 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             Protocol::Ip4(ip),
             Protocol::Udp(port),
             Some(Protocol::WebRtcDirect),
-            Some(Protocol::Certhash(hash)),
+            Some(Protocol::Certhash(multihash)),
         ) => {
-            // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
-            let multihash = multihash::Multihash::from_bytes(&hash).unwrap();
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
@@ -133,10 +131,8 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             Protocol::Ip6(ip),
             Protocol::Udp(port),
             Some(Protocol::WebRtcDirect),
-            Some(Protocol::Certhash(hash)),
+            Some(Protocol::Certhash(multihash)),
         ) => {
-            // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
-            let multihash = multihash::Multihash::from_bytes(&hash).unwrap();
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }

--- a/light-base/src/platform/address_parse.rs
+++ b/light-base/src/platform/address_parse.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use smoldot::libp2p::{multiaddr::ProtocolRef, multihash, Multiaddr};
+use smoldot::libp2p::{multiaddr::Protocol, multihash, Multiaddr};
 
 use super::{Address, ConnectionType, IpAddr, MultiStreamAddress};
 use core::str;
@@ -48,43 +48,43 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
     }
 
     Ok(match (proto1, proto2, proto3, proto4) {
-        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), None, None) => {
+        (Protocol::Ip4(ip), Protocol::Tcp(port), None, None) => {
             AddressOrMultiStreamAddress::Address(Address::TcpIp {
                 ip: IpAddr::V4(ip),
                 port,
             })
         }
-        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), None, None) => {
+        (Protocol::Ip6(ip), Protocol::Tcp(port), None, None) => {
             AddressOrMultiStreamAddress::Address(Address::TcpIp {
                 ip: IpAddr::V6(ip),
                 port,
             })
         }
         (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
             None,
             None,
         ) => AddressOrMultiStreamAddress::Address(Address::TcpDns {
             hostname: str::from_utf8(addr.into_bytes()).map_err(Error::NonUtf8DomainName)?,
             port,
         }),
-        (ProtocolRef::Ip4(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws), None) => {
+        (Protocol::Ip4(ip), Protocol::Tcp(port), Some(Protocol::Ws), None) => {
             AddressOrMultiStreamAddress::Address(Address::WebSocketIp {
                 ip: IpAddr::V4(ip),
                 port,
             })
         }
-        (ProtocolRef::Ip6(ip), ProtocolRef::Tcp(port), Some(ProtocolRef::Ws), None) => {
+        (Protocol::Ip6(ip), Protocol::Tcp(port), Some(Protocol::Ws), None) => {
             AddressOrMultiStreamAddress::Address(Address::WebSocketIp {
                 ip: IpAddr::V6(ip),
                 port,
             })
         }
         (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
-            Some(ProtocolRef::Ws),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
+            Some(Protocol::Ws),
             None,
         ) => AddressOrMultiStreamAddress::Address(Address::WebSocketDns {
             hostname: str::from_utf8(addr.into_bytes()).map_err(Error::NonUtf8DomainName)?,
@@ -92,16 +92,16 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             secure: false,
         }),
         (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
-            Some(ProtocolRef::Wss),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
+            Some(Protocol::Wss),
             None,
         )
         | (
-            ProtocolRef::Dns(addr) | ProtocolRef::Dns4(addr) | ProtocolRef::Dns6(addr),
-            ProtocolRef::Tcp(port),
-            Some(ProtocolRef::Tls),
-            Some(ProtocolRef::Ws),
+            Protocol::Dns(addr) | Protocol::Dns4(addr) | Protocol::Dns6(addr),
+            Protocol::Tcp(port),
+            Some(Protocol::Tls),
+            Some(Protocol::Ws),
         ) => AddressOrMultiStreamAddress::Address(Address::WebSocketDns {
             hostname: str::from_utf8(addr.into_bytes()).map_err(Error::NonUtf8DomainName)?,
             port,
@@ -109,10 +109,10 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
         }),
 
         (
-            ProtocolRef::Ip4(ip),
-            ProtocolRef::Udp(port),
-            Some(ProtocolRef::WebRtcDirect),
-            Some(ProtocolRef::Certhash(hash)),
+            Protocol::Ip4(ip),
+            Protocol::Udp(port),
+            Some(Protocol::WebRtcDirect),
+            Some(Protocol::Certhash(hash)),
         ) => {
             // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
             let multihash = multihash::Multihash::from_bytes(&hash).unwrap();
@@ -130,10 +130,10 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
         }
 
         (
-            ProtocolRef::Ip6(ip),
-            ProtocolRef::Udp(port),
-            Some(ProtocolRef::WebRtcDirect),
-            Some(ProtocolRef::Certhash(hash)),
+            Protocol::Ip6(ip),
+            Protocol::Udp(port),
+            Some(Protocol::WebRtcDirect),
+            Some(Protocol::Certhash(hash)),
         ) => {
             // TODO: unwrapping is hacky because Multiaddr is supposed to guarantee that this is a valid multihash but doesn't due to typing issues
             let multihash = multihash::Multihash::from_bytes(&hash).unwrap();


### PR DESCRIPTION
This PR renames `ProtocolRef` and `DomainNameRef` to just `Protocol` and `DomainName`, and applies the same changes as https://github.com/smol-dot/smoldot/pull/1372 but for these two types and `Multiaddr`.

This makes it possible to parse multiaddresses without cloning buffers, and also allows using `Multihash` in `Protocol` for additional strong typing guarantees.

It's unclear to me whether `Protocol::P2p` should always be a `PeerId` or not, so I've left this on the side.
