### PR TITLE
Remove concept of subscription name from runtime service

### DIFF
--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -114,7 +114,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let events = if with_runtime {
             let subscribe_all = self
                 .runtime_service
-                .subscribe_all("chainHead_follow", 32, NonZeroUsize::new(32).unwrap())
+                .subscribe_all(32, NonZeroUsize::new(32).unwrap())
                 .await;
             let id = subscribe_all.new_blocks.id();
             either::Left((subscribe_all, id))

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -35,7 +35,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
     ) {
         let finalized_hash = header::hash_from_scale_encoded_header(
             self.runtime_service
-                .subscribe_all("chain_getFinalizedHead", 16, NonZeroUsize::new(24).unwrap())
+                .subscribe_all(16, NonZeroUsize::new(24).unwrap())
                 .await
                 .finalized_block_scale_encoded_header,
         );

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -1295,7 +1295,6 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 task.subscription = Subscription::Pending(Box::pin(async move {
                     runtime_service
                         .subscribe_all(
-                            "json-rpc-blocks-cache",
                             32,
                             NonZeroUsize::new(usize::max_value()).unwrap(),
                         )

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -82,11 +82,7 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
                 let relay_chain_sync = relay_chain_sync.clone();
                 Box::pin(async move {
                     relay_chain_sync
-                        .subscribe_all(
-                            "parachain-sync",
-                            32,
-                            NonZeroUsize::new(usize::max_value()).unwrap(),
-                        )
+                        .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
                         .await
                 })
             },
@@ -371,7 +367,6 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                             Box::pin(async move {
                                 relay_chain_sync
                                     .subscribe_all(
-                                        "parachain-sync",
                                         32,
                                         NonZeroUsize::new(usize::max_value()).unwrap(),
                                     )
@@ -787,11 +782,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                         let relay_chain_sync = self.relay_chain_sync.clone();
                         Box::pin(async move {
                             relay_chain_sync
-                                .subscribe_all(
-                                    "parachain-sync",
-                                    32,
-                                    NonZeroUsize::new(usize::max_value()).unwrap(),
-                                )
+                                .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
                                 .await
                         })
                     },

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -362,11 +362,7 @@ async fn background_task<TPlat: PlatformRef>(mut config: BackgroundTaskConfig<TP
                     // malicious.
                     worker
                         .runtime_service
-                        .subscribe_all(
-                            "transactions-service",
-                            32,
-                            NonZeroUsize::new(usize::max_value()).unwrap(),
-                        )
+                        .subscribe_all(32, NonZeroUsize::new(usize::max_value()).unwrap())
                         .await,
                 )
             };


### PR DESCRIPTION
Since we want to make the various subservices panic-resilient (#519), it's no longer the background task of the runtime service that panics in case of a bad pinned block but the frontend. For this reason, having the subscription name is no longer something useful. This PR removes this concept.