### PR TITLE
Simplify the flow of execution of `light-base/sync/relay`

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1878,6 +1878,7 @@ pub enum DesiredRequest {
 
 impl DesiredRequest {
     /// Caps the number of blocks to request to `max`.
+    // TODO: consider removing due to the many types of requests
     pub fn num_blocks_clamp(&mut self, max: NonZeroU64) {
         if let DesiredRequest::BlocksRequest { num_blocks, .. } = self {
             *num_blocks = NonZeroU64::new(cmp::min(num_blocks.get(), max.get())).unwrap();
@@ -1885,6 +1886,7 @@ impl DesiredRequest {
     }
 
     /// Caps the number of blocks to request to `max`.
+    // TODO: consider removing due to the many types of requests
     pub fn with_num_blocks_clamp(mut self, max: NonZeroU64) -> Self {
         self.num_blocks_clamp(max);
         self

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -133,6 +133,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
         // Try to perform some CPU-heavy operations.
         // If any CPU-heavy verification was performed, then `queue_empty` will be `false`, in
         // which case we will loop again as soon as possible.
+        // TODO: integrate this within WakeUpReason, see https://github.com/smol-dot/smoldot/issues/1382 this is however complicated because process_one() moves out from sync, and that sync doesn't impl Sync, a refactor of AllSync might be necessary
         let queue_empty = {
             let mut queue_empty = true;
 


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1382

This PR simplifies the flow of execution of the sync service by moving move things within that single match block.

Unfortunately, finishing https://github.com/smol-dot/smoldot/issues/1382 is kind of complicated because of quirks in the API of `all.rs`.
