### PR TITLE
Make the runtime service follow the same paradigms as the other services

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1126,210 +1126,212 @@ async fn run_background<TPlat: PlatformRef>(
                 background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
             WakeUpReason::MustAdvanceTree => {
-                loop {
-                    match &mut background.tree {
-                        Tree::FinalizedBlockRuntimeKnown {
-                            tree,
-                            finalized_block,
-                            all_blocks_subscriptions,
-                            pinned_blocks,
-                        } => match tree.try_advance_output() {
-                            None => break,
-                            Some(async_tree::OutputUpdate::Finalized {
-                                user_data: new_finalized,
-                                best_block_index,
-                                pruned_blocks,
-                                former_finalized_async_op_user_data: former_finalized_runtime,
-                                ..
-                            }) => {
-                                *finalized_block = new_finalized;
-                                let best_block_hash = best_block_index
-                                    .map_or(finalized_block.hash, |idx| {
-                                        tree.block_user_data(idx).hash
-                                    });
+                background.must_update_tree_and_notify_subscribers = true;
 
-                                log::debug!(
-                                    target: &background.log_target,
-                                    "Worker => OutputFinalized(hash={}, best={})",
-                                    HashDisplay(&finalized_block.hash), HashDisplay(&best_block_hash)
-                                );
+                match &mut background.tree {
+                    Tree::FinalizedBlockRuntimeKnown {
+                        tree,
+                        finalized_block,
+                        all_blocks_subscriptions,
+                        pinned_blocks,
+                    } => match tree.try_advance_output() {
+                        None => {
+                            background.must_update_tree_and_notify_subscribers = false;
+                            continue;
+                        }
+                        Some(async_tree::OutputUpdate::Finalized {
+                            user_data: new_finalized,
+                            best_block_index,
+                            pruned_blocks,
+                            former_finalized_async_op_user_data: former_finalized_runtime,
+                            ..
+                        }) => {
+                            *finalized_block = new_finalized;
+                            let best_block_hash = best_block_index
+                                .map_or(finalized_block.hash, |idx| tree.block_user_data(idx).hash);
 
-                                // The finalization might cause some runtimes in the list of runtimes
-                                // to have become unused. Clean them up.
-                                drop(former_finalized_runtime);
-                                background
-                                    .runtimes
-                                    .retain(|_, runtime| runtime.strong_count() > 0);
+                            log::debug!(
+                                target: &background.log_target,
+                                "Worker => OutputFinalized(hash={}, best={})",
+                                HashDisplay(&finalized_block.hash), HashDisplay(&best_block_hash)
+                            );
 
-                                let all_blocks_notif = Notification::Finalized {
-                                    best_block_hash,
-                                    hash: finalized_block.hash,
-                                    pruned_blocks: pruned_blocks
-                                        .iter()
-                                        .map(|(_, b, _)| b.hash)
-                                        .collect(),
-                                };
+                            // The finalization might cause some runtimes in the list of runtimes
+                            // to have become unused. Clean them up.
+                            drop(former_finalized_runtime);
+                            background
+                                .runtimes
+                                .retain(|_, runtime| runtime.strong_count() > 0);
 
-                                let mut to_remove = Vec::new();
-                                for (subscription_id, (sender, finalized_pinned_remaining)) in
-                                    all_blocks_subscriptions.iter_mut()
-                                {
-                                    let count_limit = pruned_blocks.len() + 1;
+                            let all_blocks_notif = Notification::Finalized {
+                                best_block_hash,
+                                hash: finalized_block.hash,
+                                pruned_blocks: pruned_blocks
+                                    .iter()
+                                    .map(|(_, b, _)| b.hash)
+                                    .collect(),
+                            };
 
-                                    if *finalized_pinned_remaining < count_limit {
-                                        to_remove.push(*subscription_id);
-                                        continue;
-                                    }
+                            let mut to_remove = Vec::new();
+                            for (subscription_id, (sender, finalized_pinned_remaining)) in
+                                all_blocks_subscriptions.iter_mut()
+                            {
+                                let count_limit = pruned_blocks.len() + 1;
 
-                                    if sender.try_send(all_blocks_notif.clone()).is_err() {
-                                        to_remove.push(*subscription_id);
-                                        continue;
-                                    }
-
-                                    *finalized_pinned_remaining -= count_limit;
-
-                                    // Mark the finalized and pruned blocks as finalized or non-canonical.
-                                    for block in iter::once(&finalized_block.hash)
-                                        .chain(pruned_blocks.iter().map(|(_, b, _)| &b.hash))
-                                    {
-                                        if let Some(pin) =
-                                            pinned_blocks.get_mut(&(*subscription_id, *block))
-                                        {
-                                            debug_assert!(pin.block_ignores_limit);
-                                            pin.block_ignores_limit = false;
-                                        }
-                                    }
+                                if *finalized_pinned_remaining < count_limit {
+                                    to_remove.push(*subscription_id);
+                                    continue;
                                 }
-                                for to_remove in to_remove {
-                                    all_blocks_subscriptions.remove(&to_remove);
-                                    let pinned_blocks_to_remove = pinned_blocks
-                                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                        .map(|((_, h), _)| *h)
-                                        .collect::<Vec<_>>();
-                                    for block in pinned_blocks_to_remove {
-                                        pinned_blocks.remove(&(to_remove, block));
+
+                                if sender.try_send(all_blocks_notif.clone()).is_err() {
+                                    to_remove.push(*subscription_id);
+                                    continue;
+                                }
+
+                                *finalized_pinned_remaining -= count_limit;
+
+                                // Mark the finalized and pruned blocks as finalized or non-canonical.
+                                for block in iter::once(&finalized_block.hash)
+                                    .chain(pruned_blocks.iter().map(|(_, b, _)| &b.hash))
+                                {
+                                    if let Some(pin) =
+                                        pinned_blocks.get_mut(&(*subscription_id, *block))
+                                    {
+                                        debug_assert!(pin.block_ignores_limit);
+                                        pin.block_ignores_limit = false;
                                     }
                                 }
                             }
-                            Some(async_tree::OutputUpdate::Block(block)) => {
-                                let block_index = block.index;
-                                let block_runtime = block.async_op_user_data.clone();
-                                let block_hash = block.user_data.hash;
-                                let scale_encoded_header =
-                                    block.user_data.scale_encoded_header.clone();
-                                let is_new_best = block.is_new_best;
+                            for to_remove in to_remove {
+                                all_blocks_subscriptions.remove(&to_remove);
+                                let pinned_blocks_to_remove = pinned_blocks
+                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                                    .map(|((_, h), _)| *h)
+                                    .collect::<Vec<_>>();
+                                for block in pinned_blocks_to_remove {
+                                    pinned_blocks.remove(&(to_remove, block));
+                                }
+                            }
+                        }
+                        Some(async_tree::OutputUpdate::Block(block)) => {
+                            let block_index = block.index;
+                            let block_runtime = block.async_op_user_data.clone();
+                            let block_hash = block.user_data.hash;
+                            let scale_encoded_header = block.user_data.scale_encoded_header.clone();
+                            let is_new_best = block.is_new_best;
 
-                                let (block_number, state_trie_root_hash) = {
-                                    let decoded = header::decode(
-                                        &scale_encoded_header,
-                                        background.sync_service.block_number_bytes(),
-                                    )
-                                    .unwrap();
-                                    (decoded.number, *decoded.state_root)
-                                };
+                            let (block_number, state_trie_root_hash) = {
+                                let decoded = header::decode(
+                                    &scale_encoded_header,
+                                    background.sync_service.block_number_bytes(),
+                                )
+                                .unwrap();
+                                (decoded.number, *decoded.state_root)
+                            };
 
-                                let parent_runtime = tree.parent(block_index).map_or(
-                                    tree.output_finalized_async_user_data().clone(),
-                                    |idx| tree.block_async_user_data(idx).unwrap().clone(),
-                                );
-
-                                log::debug!(
-                                    target: &background.log_target,
-                                    "Worker => OutputNewBlock(hash={}, is_new_best={})",
-                                    HashDisplay(&tree.block_user_data(block_index).hash),
-                                    is_new_best
-                                );
-
-                                let notif = Notification::Block(BlockNotification {
-                                    parent_hash: tree
-                                        .parent(block_index)
-                                        .map_or(finalized_block.hash, |idx| {
-                                            tree.block_user_data(idx).hash
-                                        }),
-                                    is_new_best,
-                                    scale_encoded_header,
-                                    new_runtime: if !Arc::ptr_eq(&parent_runtime, &block_runtime) {
-                                        Some(
-                                            block_runtime
-                                                .runtime
-                                                .as_ref()
-                                                .map(|rt| rt.runtime_spec.clone())
-                                                .map_err(|err| err.clone()),
-                                        )
-                                    } else {
-                                        None
-                                    },
+                            let parent_runtime = tree
+                                .parent(block_index)
+                                .map_or(tree.output_finalized_async_user_data().clone(), |idx| {
+                                    tree.block_async_user_data(idx).unwrap().clone()
                                 });
 
-                                let mut to_remove = Vec::new();
-                                for (subscription_id, (sender, _)) in
-                                    all_blocks_subscriptions.iter_mut()
-                                {
-                                    if sender.try_send(notif.clone()).is_ok() {
-                                        let _prev_value = pinned_blocks.insert(
-                                            (*subscription_id, block_hash),
-                                            PinnedBlock {
-                                                runtime: block_runtime.clone(),
-                                                state_trie_root_hash,
-                                                block_number,
-                                                block_ignores_limit: true,
-                                            },
-                                        );
-                                        debug_assert!(_prev_value.is_none());
-                                    } else {
-                                        to_remove.push(*subscription_id);
-                                    }
-                                }
-                                for to_remove in to_remove {
-                                    all_blocks_subscriptions.remove(&to_remove);
-                                    let pinned_blocks_to_remove = pinned_blocks
-                                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                        .map(|((_, h), _)| *h)
-                                        .collect::<Vec<_>>();
-                                    for block in pinned_blocks_to_remove {
-                                        pinned_blocks.remove(&(to_remove, block));
-                                    }
+                            log::debug!(
+                                target: &background.log_target,
+                                "Worker => OutputNewBlock(hash={}, is_new_best={})",
+                                HashDisplay(&tree.block_user_data(block_index).hash),
+                                is_new_best
+                            );
+
+                            let notif = Notification::Block(BlockNotification {
+                                parent_hash: tree
+                                    .parent(block_index)
+                                    .map_or(finalized_block.hash, |idx| {
+                                        tree.block_user_data(idx).hash
+                                    }),
+                                is_new_best,
+                                scale_encoded_header,
+                                new_runtime: if !Arc::ptr_eq(&parent_runtime, &block_runtime) {
+                                    Some(
+                                        block_runtime
+                                            .runtime
+                                            .as_ref()
+                                            .map(|rt| rt.runtime_spec.clone())
+                                            .map_err(|err| err.clone()),
+                                    )
+                                } else {
+                                    None
+                                },
+                            });
+
+                            let mut to_remove = Vec::new();
+                            for (subscription_id, (sender, _)) in
+                                all_blocks_subscriptions.iter_mut()
+                            {
+                                if sender.try_send(notif.clone()).is_ok() {
+                                    let _prev_value = pinned_blocks.insert(
+                                        (*subscription_id, block_hash),
+                                        PinnedBlock {
+                                            runtime: block_runtime.clone(),
+                                            state_trie_root_hash,
+                                            block_number,
+                                            block_ignores_limit: true,
+                                        },
+                                    );
+                                    debug_assert!(_prev_value.is_none());
+                                } else {
+                                    to_remove.push(*subscription_id);
                                 }
                             }
-                            Some(async_tree::OutputUpdate::BestBlockChanged {
-                                best_block_index,
-                            }) => {
-                                let hash = best_block_index
-                                    .map_or(&*finalized_block, |idx| tree.block_user_data(idx))
-                                    .hash;
-
-                                log::debug!(
-                                    target: &background.log_target,
-                                    "Worker => OutputBestBlockChanged(hash={})",
-                                    HashDisplay(&hash),
-                                );
-
-                                let notif = Notification::BestBlockChanged { hash };
-
-                                let mut to_remove = Vec::new();
-                                for (subscription_id, (sender, _)) in
-                                    all_blocks_subscriptions.iter_mut()
-                                {
-                                    if sender.try_send(notif.clone()).is_err() {
-                                        to_remove.push(*subscription_id);
-                                    }
-                                }
-                                for to_remove in to_remove {
-                                    all_blocks_subscriptions.remove(&to_remove);
-                                    let pinned_blocks_to_remove = pinned_blocks
-                                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                        .map(|((_, h), _)| *h)
-                                        .collect::<Vec<_>>();
-                                    for block in pinned_blocks_to_remove {
-                                        pinned_blocks.remove(&(to_remove, block));
-                                    }
+                            for to_remove in to_remove {
+                                all_blocks_subscriptions.remove(&to_remove);
+                                let pinned_blocks_to_remove = pinned_blocks
+                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                                    .map(|((_, h), _)| *h)
+                                    .collect::<Vec<_>>();
+                                for block in pinned_blocks_to_remove {
+                                    pinned_blocks.remove(&(to_remove, block));
                                 }
                             }
-                        },
-                        Tree::FinalizedBlockRuntimeUnknown { tree } => match tree
-                            .try_advance_output()
-                        {
-                            None => break,
+                        }
+                        Some(async_tree::OutputUpdate::BestBlockChanged { best_block_index }) => {
+                            let hash = best_block_index
+                                .map_or(&*finalized_block, |idx| tree.block_user_data(idx))
+                                .hash;
+
+                            log::debug!(
+                                target: &background.log_target,
+                                "Worker => OutputBestBlockChanged(hash={})",
+                                HashDisplay(&hash),
+                            );
+
+                            let notif = Notification::BestBlockChanged { hash };
+
+                            let mut to_remove = Vec::new();
+                            for (subscription_id, (sender, _)) in
+                                all_blocks_subscriptions.iter_mut()
+                            {
+                                if sender.try_send(notif.clone()).is_err() {
+                                    to_remove.push(*subscription_id);
+                                }
+                            }
+                            for to_remove in to_remove {
+                                all_blocks_subscriptions.remove(&to_remove);
+                                let pinned_blocks_to_remove = pinned_blocks
+                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                                    .map(|((_, h), _)| *h)
+                                    .collect::<Vec<_>>();
+                                for block in pinned_blocks_to_remove {
+                                    pinned_blocks.remove(&(to_remove, block));
+                                }
+                            }
+                        }
+                    },
+                    Tree::FinalizedBlockRuntimeUnknown { tree } => {
+                        match tree.try_advance_output() {
+                            None => {
+                                background.must_update_tree_and_notify_subscribers = false;
+                                continue;
+                            }
                             Some(async_tree::OutputUpdate::Block(_))
                             | Some(async_tree::OutputUpdate::BestBlockChanged { .. }) => continue,
                             Some(async_tree::OutputUpdate::Finalized {
@@ -1379,7 +1381,7 @@ async fn run_background<TPlat: PlatformRef>(
                                     finalized_block: new_finalized,
                                 };
                             }
-                        },
+                        }
                     }
                 }
             }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1854,6 +1854,7 @@ async fn run_background<TPlat: PlatformRef>(
                 block_hash,
             })) => {
                 // Foreground wants a block unpinned.
+
                 if let Tree::FinalizedBlockRuntimeKnown {
                     all_blocks_subscriptions,
                     pinned_blocks,
@@ -2109,8 +2110,8 @@ async fn run_background<TPlat: PlatformRef>(
                         tree.input_set_best_block(Some(idx));
                     }
                 }
-
                 background.must_update_tree_and_notify_subscribers = true;
+
                 background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
 
@@ -2128,9 +2129,9 @@ async fn run_background<TPlat: PlatformRef>(
                 // TODO: the line below is a complete hack; the code that updates this value is never reached for parachains, and as such the line below is here to update this field
                 background.best_near_head_of_chain = true;
 
-                // Try to find an existing runtime identical to the one that has just been downloaded.
-                // This loop is `O(n)`, but given that we expect this list to very small (at most 1 or
-                // 2 elements), this is not a problem.
+                // Try to find an existing runtime identical to the one that has just been
+                // downloaded. This loop is `O(n)`, but given that we expect this list to very
+                // small (at most 1 or 2 elements), this is not a problem.
                 let existing_runtime = background
                     .runtimes
                     .iter()
@@ -2186,8 +2187,10 @@ async fn run_background<TPlat: PlatformRef>(
                         tree.async_op_finished(async_op_id, Some(runtime));
                     }
                 }
-
                 background.must_update_tree_and_notify_subscribers = true;
+
+                // Because runtime downloads are clamped to a maximum, when a download is finished
+                // we should try to start new downloads.
                 background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
 
@@ -2229,6 +2232,8 @@ async fn run_background<TPlat: PlatformRef>(
                     }
                 }
 
+                // Because runtime downloads are clamped to a maximum, when a download is finished
+                // we should try to start new downloads.
                 background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
         }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -969,7 +969,151 @@ async fn run_background<TPlat: PlatformRef>(
 
         match wake_up_reason {
             WakeUpReason::NewNecessaryDownload => {
-                background.start_necessary_downloads().await;
+                loop {
+                    // Don't download more than 2 runtimes at a time.
+                    if background.runtime_downloads.len() >= 2 {
+                        break;
+                    }
+        
+                    // If there's nothing more to download, break out of the loop.
+                    let download_params = {
+                        let async_op = match &mut background.tree {
+                            Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
+                                tree.next_necessary_async_op(&background.platform.now())
+                            }
+                            Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
+                                tree.next_necessary_async_op(&background.platform.now())
+                            }
+                        };
+        
+                        match async_op {
+                            async_tree::NextNecessaryAsyncOp::Ready(dl) => dl,
+                            async_tree::NextNecessaryAsyncOp::NotReady { when } => {
+                                background.wake_up_new_necessary_download = if let Some(when) = when {
+                                    Box::pin(background.platform.sleep_until(when)) as Pin<Box<_>>
+                                } else {
+                                    Box::pin(future::pending()) as Pin<Box<_>>
+                                };
+                                break;
+                            }
+                        }
+                    };
+        
+                    log::debug!(
+                        target: &background.log_target,
+                        "Worker => NewDownload(block={})",
+                        HashDisplay(&download_params.block_user_data.hash)
+                    );
+        
+                    // Dispatches a runtime download task to `runtime_downloads`.
+                    background.runtime_downloads.push({
+                        let download_id = download_params.id;
+        
+                        // In order to perform the download, we need to known the state root hash of the
+                        // block in question, which requires decoding the block. If the decoding fails,
+                        // we report that the asynchronous operation has failed with the hope that this
+                        // block gets pruned in the future.
+                        match header::decode(
+                            &download_params.block_user_data.scale_encoded_header,
+                            background.sync_service.block_number_bytes(),
+                        ) {
+                            Ok(decoded_header) => {
+                                let sync_service = background.sync_service.clone();
+                                let block_hash = download_params.block_user_data.hash;
+                                let state_root = *decoded_header.state_root;
+                                let block_number = decoded_header.number;
+        
+                                Box::pin(async move {
+                                    let result = sync_service
+                                        .storage_query(
+                                            block_number,
+                                            &block_hash,
+                                            &state_root,
+                                            [
+                                                sync_service::StorageRequestItem {
+                                                    key: b":code".to_vec(),
+                                                    ty: sync_service::StorageRequestItemTy::ClosestDescendantMerkleValue,
+                                                },
+                                                sync_service::StorageRequestItem {
+                                                    key: b":code".to_vec(),
+                                                    ty: sync_service::StorageRequestItemTy::Value,
+                                                },
+                                                sync_service::StorageRequestItem {
+                                                    key: b":heappages".to_vec(),
+                                                    ty: sync_service::StorageRequestItemTy::Value,
+                                                },
+                                            ]
+                                            .into_iter(),
+                                            3,
+                                            Duration::from_secs(20),
+                                            NonZeroU32::new(3).unwrap(),
+                                        )
+                                        .await;
+        
+                                    let result = match result {
+                                        Ok(entries) => {
+                                            let heap_pages = entries
+                                                .iter()
+                                                .find_map(|entry| match entry {
+                                                    sync_service::StorageResultItem::Value {
+                                                        key,
+                                                        value,
+                                                    } if key == b":heappages" => {
+                                                        Some(value.clone()) // TODO: overhead
+                                                    }
+                                                    _ => None,
+                                                })
+                                                .unwrap();
+                                            let code = entries
+                                                .iter()
+                                                .find_map(|entry| match entry {
+                                                    sync_service::StorageResultItem::Value {
+                                                        key,
+                                                        value,
+                                                    } if key == b":code" => {
+                                                        Some(value.clone()) // TODO: overhead
+                                                    }
+                                                    _ => None,
+                                                })
+                                                .unwrap();
+                                            let (code_merkle_value, code_closest_ancestor) = if code.is_some() {
+                                                entries
+                                                    .iter()
+                                                    .find_map(|entry| match entry {
+                                                        sync_service::StorageResultItem::ClosestDescendantMerkleValue {
+                                                            requested_key,
+                                                            found_closest_ancestor_excluding,
+                                                            closest_descendant_merkle_value,
+                                                        } if requested_key == b":code" => {
+                                                            Some((closest_descendant_merkle_value.clone(), found_closest_ancestor_excluding.clone())) // TODO overhead
+                                                        }
+                                                        _ => None
+                                                    })
+                                                    .unwrap()
+                                            } else {
+                                                (None, None)
+                                            };
+                                            Ok((code, heap_pages, code_merkle_value, code_closest_ancestor))
+                                        }
+                                        Err(error) => Err(RuntimeDownloadError::StorageQuery(error)),
+                                    };
+        
+                                    (download_id, result)
+                                })
+                            }
+                            Err(error) => {
+                                log::warn!(
+                                    target: &background.log_target,
+                                    "Failed to decode header from sync service: {}", error
+                                );
+        
+                                Box::pin(async move {
+                                    (download_id, Err(RuntimeDownloadError::InvalidHeader(error)))
+                                })
+                            }
+                        }
+                    });
+                }
             }
             WakeUpReason::MustSubscribe => {
                 // The buffer size should be large enough so that, if the CPU is busy, it
@@ -2174,155 +2318,6 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     }
                 },
             }
-        }
-    }
-
-    /// Examines the state of `self` and starts downloading runtimes if necessary.
-    async fn start_necessary_downloads(&mut self) {
-        loop {
-            // Don't download more than 2 runtimes at a time.
-            if self.runtime_downloads.len() >= 2 {
-                break;
-            }
-
-            // If there's nothing more to download, break out of the loop.
-            let download_params = {
-                let async_op = match &mut self.tree {
-                    Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
-                        tree.next_necessary_async_op(&self.platform.now())
-                    }
-                    Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
-                        tree.next_necessary_async_op(&self.platform.now())
-                    }
-                };
-
-                match async_op {
-                    async_tree::NextNecessaryAsyncOp::Ready(dl) => dl,
-                    async_tree::NextNecessaryAsyncOp::NotReady { when } => {
-                        self.wake_up_new_necessary_download = if let Some(when) = when {
-                            Box::pin(self.platform.sleep_until(when)) as Pin<Box<_>>
-                        } else {
-                            Box::pin(future::pending()) as Pin<Box<_>>
-                        };
-                        break;
-                    }
-                }
-            };
-
-            log::debug!(
-                target: &self.log_target,
-                "Worker => NewDownload(block={})",
-                HashDisplay(&download_params.block_user_data.hash)
-            );
-
-            // Dispatches a runtime download task to `runtime_downloads`.
-            self.runtime_downloads.push({
-                let download_id = download_params.id;
-
-                // In order to perform the download, we need to known the state root hash of the
-                // block in question, which requires decoding the block. If the decoding fails,
-                // we report that the asynchronous operation has failed with the hope that this
-                // block gets pruned in the future.
-                match header::decode(
-                    &download_params.block_user_data.scale_encoded_header,
-                    self.sync_service.block_number_bytes(),
-                ) {
-                    Ok(decoded_header) => {
-                        let sync_service = self.sync_service.clone();
-                        let block_hash = download_params.block_user_data.hash;
-                        let state_root = *decoded_header.state_root;
-                        let block_number = decoded_header.number;
-
-                        Box::pin(async move {
-                            let result = sync_service
-                                .storage_query(
-                                    block_number,
-                                    &block_hash,
-                                    &state_root,
-                                    [
-                                        sync_service::StorageRequestItem {
-                                            key: b":code".to_vec(),
-                                            ty: sync_service::StorageRequestItemTy::ClosestDescendantMerkleValue,
-                                        },
-                                        sync_service::StorageRequestItem {
-                                            key: b":code".to_vec(),
-                                            ty: sync_service::StorageRequestItemTy::Value,
-                                        },
-                                        sync_service::StorageRequestItem {
-                                            key: b":heappages".to_vec(),
-                                            ty: sync_service::StorageRequestItemTy::Value,
-                                        },
-                                    ]
-                                    .into_iter(),
-                                    3,
-                                    Duration::from_secs(20),
-                                    NonZeroU32::new(3).unwrap(),
-                                )
-                                .await;
-
-                            let result = match result {
-                                Ok(entries) => {
-                                    let heap_pages = entries
-                                        .iter()
-                                        .find_map(|entry| match entry {
-                                            sync_service::StorageResultItem::Value {
-                                                key,
-                                                value,
-                                            } if key == b":heappages" => {
-                                                Some(value.clone()) // TODO: overhead
-                                            }
-                                            _ => None,
-                                        })
-                                        .unwrap();
-                                    let code = entries
-                                        .iter()
-                                        .find_map(|entry| match entry {
-                                            sync_service::StorageResultItem::Value {
-                                                key,
-                                                value,
-                                            } if key == b":code" => {
-                                                Some(value.clone()) // TODO: overhead
-                                            }
-                                            _ => None,
-                                        })
-                                        .unwrap();
-                                    let (code_merkle_value, code_closest_ancestor) = if code.is_some() {
-                                        entries
-                                            .iter()
-                                            .find_map(|entry| match entry {
-                                                sync_service::StorageResultItem::ClosestDescendantMerkleValue {
-                                                    requested_key,
-                                                    found_closest_ancestor_excluding,
-                                                    closest_descendant_merkle_value,
-                                                } if requested_key == b":code" => {
-                                                    Some((closest_descendant_merkle_value.clone(), found_closest_ancestor_excluding.clone())) // TODO overhead
-                                                }
-                                                _ => None
-                                            })
-                                            .unwrap()
-                                    } else {
-                                        (None, None)
-                                    };
-                                    Ok((code, heap_pages, code_merkle_value, code_closest_ancestor))
-                                }
-                                Err(error) => Err(RuntimeDownloadError::StorageQuery(error)),
-                            };
-
-                            (download_id, result)
-                        })
-                    }
-                    Err(error) => {
-                        log::warn!(
-                            target: &self.log_target,
-                            "Failed to decode header from sync service: {}", error
-                        );
-
-                        Box::pin(async move {
-                            (download_id, Err(RuntimeDownloadError::InvalidHeader(error)))
-                        })
-                    }
-                }
-            });
         }
     }
 }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1167,7 +1167,7 @@ async fn run_background<TPlat: PlatformRef>(
                 }
 
                 background.blocks_stream = Some(Box::pin(subscription.new_blocks));
-                background.wake_up_new_necessary_download = Box::pin(future::pending());
+                background.wake_up_new_necessary_download = Box::pin(future::ready(()));
                 background.runtime_downloads = stream::FuturesUnordered::new();
             }
             WakeUpReason::StartPendingSubscribeAll => {
@@ -1620,8 +1620,7 @@ async fn run_background<TPlat: PlatformRef>(
                     }
                 };
 
-                // TODO: process any other pending event from blocks_stream before doing that; otherwise we might start download for blocks that we don't care about because they're immediately overwritten by others
-                background.start_necessary_downloads().await;
+                background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
             WakeUpReason::RuntimeDownloadFinished(async_op_id, download_result) => {
                 let concerned_blocks = match &background.tree {
@@ -1688,7 +1687,7 @@ async fn run_background<TPlat: PlatformRef>(
                     }
                 }
 
-                background.start_necessary_downloads().await;
+                background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
         }
     }


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1382

While this leads to a huge `match` block, I think it is more readable this way because the control flow is now trivial to read.