### PR TITLE
Fix panic in networking state machine

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fix panic when the runtime of a chain provides consensus information that is inconsistent with the information found in the finalized block. ([#1317](https://github.com/smol-dot/smoldot/pull/1317))
 - Incoming notification substreams are now properly when accepted when a peer doesn't have a slot or gets a slot later on. ([#1369](https://github.com/smol-dot/smoldot/pull/1369))
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
-- Fix panic when opening a gossiping link to a peer that we were previously connected to.
+- Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix panic when the runtime of a chain provides consensus information that is inconsistent with the information found in the finalized block. ([#1317](https://github.com/smol-dot/smoldot/pull/1317))
 - Incoming notification substreams are now properly when accepted when a peer doesn't have a slot or gets a slot later on. ([#1369](https://github.com/smol-dot/smoldot/pull/1369))
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
+- Fix panic when opening a gossiping link to a peer that we were previously connected to.
 
 ## 2.0.10 - 2023-11-17
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1371

`connected_unopened_gossip_desired` must not contain any peer that doesn't have an established connection.
At the moment, this isn't properly respected, as it can contain peers that have connections that are still handshaking.
This then causes `gossip_open` to fail, which leads to a panic.