### PR TITLE
Use only one networking service for all chains

### DIFF
--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -501,7 +501,10 @@ where
                             SubstreamId::max_value(),
                         ),
                 )
-                .find(|(_, _, direction, _, _)| matches!(*direction, SubstreamDirection::Out))
+                .find(|(_, _, direction, state, _)| {
+                    matches!(*direction, SubstreamDirection::Out)
+                        && matches!(*state, NotificationsSubstreamState::Open)
+                })
                 .is_some()
             {
                 return Err(RemoveChainError::InUse);

--- a/light-base/src/database.rs
+++ b/light-base/src/database.rs
@@ -82,8 +82,7 @@ pub struct DatabaseContentRuntimeCodeHint {
 /// The returned string is guaranteed to not exceed `max_size` bytes. A truncated or invalid
 /// database is intentionally returned if `max_size` is too low to fit all the information.
 pub async fn encode_database<TPlat: platform::PlatformRef>(
-    network_service: &network_service::NetworkService<TPlat>,
-    network_service_chain_id: network_service::ChainId,
+    network_service: &network_service::NetworkServiceChain<TPlat>,
     sync_service: &sync_service::SyncService<TPlat>,
     runtime_service: &runtime_service::RuntimeService<TPlat>,
     genesis_block_hash: &[u8; 32],
@@ -102,7 +101,7 @@ pub async fn encode_database<TPlat: platform::PlatformRef>(
             serde_json::from_str(&encoded).unwrap()
         }),
         nodes: network_service
-            .discovered_nodes(network_service_chain_id)
+            .discovered_nodes()
             .await
             .map(|(peer_id, addrs)| {
                 (

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -206,10 +206,7 @@ pub struct StartConfig<'a, TPlat: PlatformRef> {
 
     /// Access to the network, and identifier of the chain from the point of view of the network
     /// service.
-    pub network_service: (
-        Arc<network_service::NetworkService<TPlat>>,
-        network_service::ChainId,
-    ),
+    pub network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
 
     /// Service responsible for synchronizing the chain.
     pub sync_service: Arc<sync_service::SyncService<TPlat>>,

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -72,10 +72,8 @@ struct Background<TPlat: PlatformRef> {
     system_version: String,
 
     /// See [`StartConfig::network_service`].
-    network_service: (
-        Arc<network_service::NetworkService<TPlat>>,
-        network_service::ChainId,
-    ),
+    network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
+
     /// See [`StartConfig::sync_service`].
     sync_service: Arc<sync_service::SyncService<TPlat>>,
     /// See [`StartConfig::runtime_service`].
@@ -680,12 +678,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 match PeerId::from_bytes(peer_id_bytes) {
                     Ok(peer_id) => {
                         self.network_service
-                            .0
-                            .discover(
-                                self.network_service.1,
-                                iter::once((peer_id, iter::once(addr))),
-                                false,
-                            )
+                            .discover(iter::once((peer_id, iter::once(addr))), false)
                             .await;
                         request.respond(methods::Response::sudo_unstable_p2pDiscover(()));
                     }

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -183,8 +183,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         };
 
         let response = crate::database::encode_database(
-            &self.network_service.0,
-            self.network_service.1,
+            &self.network_service,
             &self.sync_service,
             &self.runtime_service,
             &self.genesis_block_hash,

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -278,8 +278,7 @@ struct RunningChain<TPlat: platform::PlatformRef> {
 }
 
 struct ChainServices<TPlat: platform::PlatformRef> {
-    network_service: Arc<network_service::NetworkService<TPlat>>,
-    network_service_chain_id: network_service::ChainId,
+    network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
     sync_service: Arc<sync_service::SyncService<TPlat>>,
     runtime_service: Arc<runtime_service::RuntimeService<TPlat>>,
     transactions_service: Arc<transactions_service::TransactionsService<TPlat>>,
@@ -289,7 +288,6 @@ impl<TPlat: platform::PlatformRef> Clone for ChainServices<TPlat> {
     fn clone(&self) -> Self {
         ChainServices {
             network_service: self.network_service.clone(),
-            network_service_chain_id: self.network_service_chain_id,
             sync_service: self.sync_service.clone(),
             runtime_service: self.runtime_service.clone(),
             transactions_service: self.transactions_service.clone(),
@@ -861,14 +859,9 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
         self.platform
             .spawn_task("network-service-add-initial-topology".into(), {
                 let network_service = services.network_service.clone();
-                let network_service_chain_id = services.network_service_chain_id;
                 async move {
-                    network_service
-                        .discover(network_service_chain_id, known_nodes, false)
-                        .await;
-                    network_service
-                        .discover(network_service_chain_id, bootstrap_nodes, true)
-                        .await;
+                    network_service.discover(known_nodes, false).await;
+                    network_service.discover(bootstrap_nodes, true).await;
                 }
                 .boxed()
             });
@@ -897,10 +890,7 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
             service_starter.start(json_rpc_service::StartConfig {
                 platform: self.platform.clone(),
                 sync_service: services.sync_service.clone(),
-                network_service: (
-                    services.network_service.clone(),
-                    services.network_service_chain_id,
-                ),
+                network_service: services.network_service.clone(),
                 transactions_service: services.transactions_service.clone(),
                 runtime_service: services.runtime_service.clone(),
                 chain_spec: &chain_spec,
@@ -1093,69 +1083,67 @@ fn start_services<TPlat: platform::PlatformRef>(
     network_identify_agent_version: String,
 ) -> ChainServices<TPlat> {
     // The network service is responsible for connecting to the peer-to-peer network.
-    let (network_service, network_service_chain_ids) =
-        network_service::NetworkService::new(network_service::Config {
-            platform: platform.clone(),
-            identify_agent_version: network_identify_agent_version,
-            connections_open_pool_size: 5,
-            connections_open_pool_restore_delay: Duration::from_secs(1),
-            chains: vec![network_service::ConfigChain {
-                log_name: log_name.clone(),
-                num_out_slots: 4,
-                grandpa_protocol_finalized_block_height: if let StartServicesChainTy::RelayChain {
-                    chain_information,
-                } = &config
-                {
-                    if matches!(
-                        chain_information.as_ref().finality,
-                        chain::chain_information::ChainInformationFinalityRef::Grandpa { .. }
-                    ) {
-                        Some(chain_information.as_ref().finalized_block_header.number)
-                    } else {
-                        None
-                    }
+    let (_, network_service) = network_service::NetworkService::new(network_service::Config {
+        platform: platform.clone(),
+        identify_agent_version: network_identify_agent_version,
+        connections_open_pool_size: 5,
+        connections_open_pool_restore_delay: Duration::from_secs(1),
+        chains: vec![network_service::ConfigChain {
+            log_name: log_name.clone(),
+            num_out_slots: 4,
+            grandpa_protocol_finalized_block_height: if let StartServicesChainTy::RelayChain {
+                chain_information,
+            } = &config
+            {
+                if matches!(
+                    chain_information.as_ref().finality,
+                    chain::chain_information::ChainInformationFinalityRef::Grandpa { .. }
+                ) {
+                    Some(chain_information.as_ref().finalized_block_header.number)
                 } else {
-                    // Parachains never use GrandPa.
                     None
-                },
-                genesis_block_hash: header::hash_from_scale_encoded_header(
-                    &genesis_block_scale_encoded_header,
+                }
+            } else {
+                // Parachains never use GrandPa.
+                None
+            },
+            genesis_block_hash: header::hash_from_scale_encoded_header(
+                &genesis_block_scale_encoded_header,
+            ),
+            best_block: match &config {
+                StartServicesChainTy::RelayChain { chain_information } => (
+                    chain_information.as_ref().finalized_block_header.number,
+                    chain_information
+                        .as_ref()
+                        .finalized_block_header
+                        .hash(block_number_bytes),
                 ),
-                best_block: match &config {
-                    StartServicesChainTy::RelayChain { chain_information } => (
-                        chain_information.as_ref().finalized_block_header.number,
-                        chain_information
-                            .as_ref()
-                            .finalized_block_header
-                            .hash(block_number_bytes),
-                    ),
-                    StartServicesChainTy::Parachain {
-                        finalized_block_header,
-                        ..
-                    } => {
-                        if let Ok(decoded) =
-                            header::decode(finalized_block_header, block_number_bytes)
-                        {
-                            (
-                                decoded.number,
-                                header::hash_from_scale_encoded_header(finalized_block_header),
-                            )
-                        } else {
-                            (
-                                0,
-                                header::hash_from_scale_encoded_header(
-                                    &genesis_block_scale_encoded_header,
-                                ),
-                            )
-                        }
+                StartServicesChainTy::Parachain {
+                    finalized_block_header,
+                    ..
+                } => {
+                    if let Ok(decoded) = header::decode(finalized_block_header, block_number_bytes)
+                    {
+                        (
+                            decoded.number,
+                            header::hash_from_scale_encoded_header(finalized_block_header),
+                        )
+                    } else {
+                        (
+                            0,
+                            header::hash_from_scale_encoded_header(
+                                &genesis_block_scale_encoded_header,
+                            ),
+                        )
                     }
-                },
-                fork_id,
-                block_number_bytes,
-            }],
-        });
+                }
+            },
+            fork_id,
+            block_number_bytes,
+        }],
+    });
 
-    let network_service_chain_id = network_service_chain_ids.into_iter().next().unwrap();
+    let network_service = network_service.into_iter().next().unwrap();
 
     let (sync_service, runtime_service) = match config {
         StartServicesChainTy::Parachain {
@@ -1173,7 +1161,7 @@ fn start_services<TPlat: platform::PlatformRef>(
                 platform: platform.clone(),
                 log_name: log_name.clone(),
                 block_number_bytes,
-                network_service: (network_service.clone(), network_service_chain_id),
+                network_service: network_service.clone(),
                 chain_type: sync_service::ConfigChainType::Parachain(
                     sync_service::ConfigParachain {
                         finalized_block_header,
@@ -1209,7 +1197,7 @@ fn start_services<TPlat: platform::PlatformRef>(
                 log_name: log_name.clone(),
                 block_number_bytes,
                 platform: platform.clone(),
-                network_service: (network_service.clone(), network_service_chain_id),
+                network_service: network_service.clone(),
                 chain_type: sync_service::ConfigChainType::RelayChain(
                     sync_service::ConfigRelayChain {
                         chain_information: chain_information.clone(),
@@ -1249,7 +1237,7 @@ fn start_services<TPlat: platform::PlatformRef>(
             platform: platform.clone(),
             sync_service: sync_service.clone(),
             runtime_service: runtime_service.clone(),
-            network_service: (network_service.clone(), network_service_chain_id),
+            network_service: network_service.clone(),
             max_pending_transactions: NonZeroU32::new(64).unwrap(),
             max_concurrent_downloads: NonZeroU32::new(3).unwrap(),
             max_concurrent_validations: NonZeroU32::new(2).unwrap(),
@@ -1258,7 +1246,6 @@ fn start_services<TPlat: platform::PlatformRef>(
 
     ChainServices {
         network_service,
-        network_service_chain_id,
         runtime_service,
         sync_service,
         transactions_service,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1129,6 +1129,8 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                 ToBackgroundChain::RemoveChain,
                             )))),
                     ) as Pin<Box<_>>);
+
+                log::debug!(target: "network", "Chains <= AddChain(id={})", task.network[chain_id].log_name);
             }
             WakeUpReason::EventSendersReady => {
                 // Dispatch the pending event, if any to the various senders.
@@ -1219,6 +1221,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                         .unwrap();
                 }
 
+                log::debug!(target: "network", "Chains <= RemoveChain(id={})", task.network[chain_id].log_name);
                 task.network.remove_chain(chain_id).unwrap();
             }
             WakeUpReason::MessageForChain(chain_id, ToBackgroundChain::Subscribe { sender }) => {

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -97,7 +97,7 @@ pub struct Config<TPlat> {
     pub connections_open_pool_restore_delay: Duration,
 }
 
-/// See [`Config::chains`].
+/// See [`NetworkService::add_chain`].
 ///
 /// Note that this configuration is intentionally missing a field containing the bootstrap
 /// nodes of the chain. Bootstrap nodes are supposed to be added afterwards by calling

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -1223,6 +1223,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
 
                 log::debug!(target: "network", "Chains <= RemoveChain(id={})", task.network[chain_id].log_name);
                 task.network.remove_chain(chain_id).unwrap();
+                task.peering_strategy.remove_chain_peers(&chain_id);
             }
             WakeUpReason::MessageForChain(chain_id, ToBackgroundChain::Subscribe { sender }) => {
                 task.pending_new_subscriptions.push((chain_id, sender));

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- A single networking service is now shared between all chains. This means that the same connection (such as a WebSocket or WebRTC connection) can now be used to open multiple block announces substreams for multiple different chains. ([#1398](https://github.com/smol-dot/smoldot/pull/1398))
 - Addresses that are not supported by the host platform are now ignored during the discovery process. For example, TCP/IP connections are ignored while in a browser. This avoids populating the address book with peers that we know we can't connect to anyway. ([#1359](https://github.com/smol-dot/smoldot/pull/1359), [#1360](https://github.com/smol-dot/smoldot/pull/1360))
 - Smoldot will no longer try to connect to the same address over and over again. ([#1358](https://github.com/smol-dot/smoldot/pull/1358))
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/111

This PR refactors the networking service so that it just has a single function: `add_chain`.
`add_chain` returns an `Arc<NetworkingServiceChain>` that can be used to interact with that chain. Once all the `Arc`s are dead, the chain is removed from the networking service.

The `Client` now has a single networking service that is initialized lazily.

I've had to introduce a small hack because `start_services` can't be made async before https://github.com/smol-dot/smoldot/issues/735. For this reason, adding a chain is done by sending a sender to the background, rather than receiving a receiver, which would have been more clean.
