### PR TITLE
Make transactions service panic-resilient

### DIFF
--- a/light-base/src/json_rpc_service/background/transactions.rs
+++ b/light-base/src/json_rpc_service/background/transactions.rs
@@ -265,6 +265,12 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                                     transactions_service::DropReason::ValidateError(_),
                                 ),
                                 true,
+                            )
+                            | (
+                                transactions_service::TransactionStatus::Dropped(
+                                    transactions_service::DropReason::Crashed,
+                                ),
+                                true,
                             ) => {
                                 subscription.send_notification(methods::ServerToClient::author_extrinsicUpdate {
                                     subscription: (&subscription_id).into(),
@@ -315,6 +321,17 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                                 subscription: (&subscription_id).into(),
                                 result: methods::TransactionWatchEvent::Error {
                                     error: error.to_string().into(),
+                                },
+                            }).await,
+                            (
+                                transactions_service::TransactionStatus::Dropped(
+                                    transactions_service::DropReason::Crashed,
+                                ),
+                                false,
+                            ) => subscription.send_notification(methods::ServerToClient::transaction_unstable_watchEvent {
+                                subscription: (&subscription_id).into(),
+                                result: methods::TransactionWatchEvent::Error {
+                                    error: "transactions service has crashed".into(),
                                 },
                             }).await,
 

--- a/light-base/src/json_rpc_service/background/transactions.rs
+++ b/light-base/src/json_rpc_service/background/transactions.rs
@@ -24,7 +24,6 @@ use crate::transactions_service;
 use alloc::{borrow::ToOwned as _, format, string::ToString as _, sync::Arc, vec::Vec};
 use core::pin;
 use futures_lite::future;
-use futures_util::StreamExt as _;
 use smoldot::json_rpc::{methods, service};
 
 impl<TPlat: PlatformRef> Background<TPlat> {
@@ -108,7 +107,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
                     loop {
                         let status_update = match future::or(
-                            async { Some(transaction_updates.next().await) },
+                            async { Some(transaction_updates.as_mut().next().await) },
                             async { subscription.wait_until_stale().await; None }
                         ).await {
                             Some(Some(status)) => status,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -207,6 +207,7 @@ impl<TPlat: PlatformRef> TransactionsService<TPlat> {
         TransactionWatcher {
             rx,
             has_yielded_drop_reason: false,
+            _dummy_keep_alive: self.to_background.clone(),
         }
     }
 
@@ -231,6 +232,9 @@ pub struct TransactionWatcher {
     rx: async_channel::Receiver<TransactionStatus>,
     /// `true` if a [`TransactionStatus::Dropped`] has already been yielded.
     has_yielded_drop_reason: bool,
+    /// Dummy copy of [`TransactionsService::to_background`] that guarantees that the background
+    /// stays alive.
+    _dummy_keep_alive: async_channel::Sender<ToBackground>,
 }
 
 impl TransactionWatcher {

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -180,9 +180,8 @@ impl<TPlat: PlatformRef> TransactionsService<TPlat> {
     ///
     /// Must pass as parameter the SCALE-encoded transaction.
     ///
-    /// The return value of this method is a channel which will receive updates on the state
-    /// of the transaction. The channel is closed when no new update is expected or if it becomes
-    /// full.
+    /// The return value of this method is an object receives updates on the state of the
+    /// transaction.
     ///
     /// > **Note**: Dropping the value returned does not cancel sending out the transaction.
     ///


### PR DESCRIPTION
cc #519 

This PR adds `DropReason::Crashed`, and interprets the updates channel closing as a `Crashed`.

If the sender is closed when submitting a transaction, we restart a new service.
