### PR TITLE
Catch panics in the default platform and add comment to `Platform`

### DIFF
--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -131,6 +131,17 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     /// The first parameter is the name of the task, which can be useful for debugging purposes.
     ///
     /// The `Future` must be run until it yields a value.
+    ///
+    /// Implementers should be aware of the fact that polling the `Future` might panic (never
+    /// intentionally, but in case of a bug). Many tasks can be restarted if they panic, and
+    /// implementers are encouraged to absorb the panics that happen when polling. If a panic
+    /// happens, the `Future` that has panicked must never be polled again.
+    ///
+    /// > **Note**: Ideally, the `task` parameter would require the `UnwindSafe` trait.
+    /// >           Unfortunately, at the time of writing of this comment, it is extremely
+    /// >           difficult if not impossible to implement this trait on `Future`s. It is for
+    /// >           the same reason that the `std::thread::spawn` function of the standard library
+    /// >           doesn't require its parameter to implement `UnwindSafe`.
     fn spawn_task(
         &self,
         task_name: Cow<str>,

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -37,7 +37,7 @@ use super::{
 };
 
 use alloc::{borrow::Cow, sync::Arc};
-use core::{pin::Pin, str, time::Duration};
+use core::{panic, pin::Pin, str, time::Duration};
 use futures_util::{future, FutureExt as _};
 use smoldot::libp2p::websocket;
 use std::{
@@ -138,7 +138,9 @@ impl PlatformRef for Arc<DefaultPlatform> {
         _task_name: Cow<str>,
         task: impl future::Future<Output = ()> + Send + 'static,
     ) {
-        self.tasks_executor.spawn(task).detach();
+        self.tasks_executor
+            .spawn(panic::AssertUnwindSafe(task).catch_unwind())
+            .detach();
     }
 
     fn client_name(&self) -> Cow<str> {


### PR DESCRIPTION
cc #519 

cc @lexnv @skunert (you are the two embedders of smoldot that I know of)

Smoldot now supports restarting some services if they crash (of course this is done properly, so JSON-RPC functions send back errors and things like that). Consequently, if a task panics, you are encouraged to not just propagate panics and let the thread crash, but instead silently drop the task and continue running.

I've considered instead adding `.catch_unwind` internally within smoldot's code everywhere relevant, but I think that it's better to make the embedder aware of this.
