### PR TITLE
Track number of connections per address in peering strategy

### DIFF
--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -802,7 +802,7 @@ where
     }
 }
 
-/// See [`BasicPeeringStrategy::disconnect_addr`].
+/// See [`BasicPeeringStrategy::decrease_address_connections`].
 #[derive(Debug, derive_more::Display)]
 pub enum DecreaseAddressConnectionsError {
     /// Address isn't known to the collection.

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Incoming notification substreams are now properly when accepted when a peer doesn't have a slot or gets a slot later on. ([#1369](https://github.com/smol-dot/smoldot/pull/1369))
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
 - Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
+- Fix panic when the discovery system finds same address attributed to two different peers.
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Incoming notification substreams are now properly when accepted when a peer doesn't have a slot or gets a slot later on. ([#1369](https://github.com/smol-dot/smoldot/pull/1369))
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
 - Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
-- Fix panic when the discovery system finds same address attributed to two different peers.
+- Fix panic when the discovery system finds same address attributed to two different peers. ([#1412](https://github.com/smol-dot/smoldot/pull/1412))
 
 ## 2.0.10 - 2023-11-17
 


### PR DESCRIPTION
In the situation where the discovery system discovers the same address for two different peers (Alice and Bob), the code will try to connect to both.
Inevitably, one of them will redirect to the wrong peer, for example connecting to Alice will actually connect to Bob.
Later, when we disconnect a second time from Bob, a state mismatch is found and a panic happens.

This PR does things properly and tracks the number of connections per peer.

We also handle weird situations properly, such as connecting to the same address multiple times leading to multiple different peer ids, by removing the `remove_address` function entirely.