### PR TITLE
Fix Yamux never filling `expected_incoming_bytes` properly

### DIFF
--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -772,16 +772,12 @@ where
                         usize::try_from(*remaining_bytes).unwrap_or(usize::max_value())
                     } else {
                         cmp::min(
-                            cmp::max(
-                                expected_incoming_bytes
-                                    .unwrap_or(0)
-                                    .saturating_sub(read_buffer.len()),
-                                outer_read_write.incoming_buffer.len(),
-                            ),
+                            expected_incoming_bytes
+                                .unwrap_or(0)
+                                .saturating_sub(read_buffer.len()),
                             usize::try_from(*remaining_bytes).unwrap_or(usize::max_value()),
                         )
                     };
-                    debug_assert!(to_copy != 0 || expected_incoming_bytes.is_none());
 
                     match outer_read_write.incoming_bytes_take(to_copy) {
                         Ok(Some(mut data)) => {


### PR DESCRIPTION
Close #1318

It turns out that Yamux was never filling the `expected_incoming_bytes` field of the outer `ReadWrite` properly, due to this erroneous `max`.
`to_copy` represents the number of bytes that we would like to copy, not the number to actually copy. The situation where there isn't enough data available is handled afterwards.

This does not lead to a bug in practice, but just a missed optimization.
