### PR TITLE
Clean up `network/service.rs`

### DIFF
--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -2030,9 +2030,11 @@ where
                             // Note that in the situation where the connection is shutting down,
                             // we don't re-open the substream on a different connection, but
                             // that's ok as the block announces substream should be closed soon.
-                            if result.is_err()
-                                && !self.inner.connection_state(connection_id).shutting_down
-                            {
+                            if result.is_err() {
+                                if self.inner.connection_state(connection_id).shutting_down {
+                                    continue;
+                                }
+
                                 let new_substream_id = self.inner.open_out_notifications(
                                     connection_id,
                                     codec::encode_protocol_name_string(match substream_protocol {
@@ -2062,7 +2064,6 @@ where
                                         substream_protocol,
                                     ),
                                 );
-
                                 let _was_inserted =
                                     self.notification_substreams_by_peer_id.insert((
                                         substream_protocol,
@@ -2072,7 +2073,6 @@ where
                                         new_substream_id,
                                     ));
                                 debug_assert!(_was_inserted);
-
                                 let _prev_value = self.substreams.insert(
                                     new_substream_id,
                                     SubstreamInfo {
@@ -2081,7 +2081,6 @@ where
                                     },
                                 );
                                 debug_assert!(_prev_value.is_none());
-
                                 continue;
                             }
 

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -346,6 +346,16 @@ enum SubstreamDirection {
     Out,
 }
 
+impl SubstreamDirection {
+    fn min_value() -> Self {
+        SubstreamDirection::In
+    }
+
+    fn max_value() -> Self {
+        SubstreamDirection::Out
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum NotificationsSubstreamState {
     Pending,
@@ -550,15 +560,15 @@ where
                     (
                         protocol,
                         PeerIndex(usize::min_value()),
-                        SubstreamDirection::In,
-                        NotificationsSubstreamState::Pending,
+                        SubstreamDirection::min_value(),
+                        NotificationsSubstreamState::min_value(),
                         SubstreamId::min_value(),
                     )
                         ..=(
                             protocol,
                             PeerIndex(usize::max_value()),
-                            SubstreamDirection::Out,
-                            NotificationsSubstreamState::Open,
+                            SubstreamDirection::max_value(),
+                            NotificationsSubstreamState::max_value(),
                             SubstreamId::max_value(),
                         ),
                 )

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -1999,6 +1999,8 @@ where
 
                         NotificationsProtocol::Transactions { chain_index }
                         | NotificationsProtocol::Grandpa { chain_index } => {
+                            // TODO: doesn't check the handshakes
+
                             // This can only happen if we have a block announces substream with
                             // that peer, otherwise the substream opening attempt should have
                             // been cancelled.

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -487,14 +487,14 @@ where
                         protocol,
                         PeerIndex(usize::min_value()),
                         SubstreamDirection::Out,
-                        NotificationsSubstreamState::min_value(),
+                        NotificationsSubstreamState::open_min_value(),
                         SubstreamId::min_value(),
                     )
                         ..=(
                             protocol,
                             PeerIndex(usize::max_value()),
                             SubstreamDirection::Out,
-                            NotificationsSubstreamState::max_value(),
+                            NotificationsSubstreamState::open_max_value(),
                             SubstreamId::max_value(),
                         ),
                 )

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -526,11 +526,10 @@ where
                         PeerIndex(usize::max_value()),
                     ),
             )
-            // TODO: optimize to not Clone? is that possible?
-            .map(|(_, _, peer_index)| self.peers[peer_index.0].clone())
+            .map(|(_, _, peer_index)| *peer_index)
             .collect::<Vec<_>>();
         for desired in desired {
-            self.gossip_remove_desired(chain_id, &desired, GossipKind::ConsensusTransactions);
+            self.gossip_remove_desired_inner(chain_id, desired, GossipKind::ConsensusTransactions);
         }
 
         // Close any notifications substream of the chain.
@@ -791,6 +790,15 @@ where
             return false;
         };
 
+        self.gossip_remove_desired_inner(chain_id, peer_index, kind)
+    }
+
+    fn gossip_remove_desired_inner(
+        &mut self,
+        chain_id: ChainId,
+        peer_index: PeerIndex,
+        kind: GossipKind,
+    ) -> bool {
         if !self
             .gossip_desired_peers_by_chain
             .remove(&(chain_id.0, kind, peer_index))

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -3229,7 +3229,7 @@ where
                     },
                     PeerIndex(usize::min_value()),
                     SubstreamDirection::Out,
-                    NotificationsSubstreamState::open_min_value(),
+                    NotificationsSubstreamState::min_value(),
                     SubstreamId::min_value(),
                 )
                     ..=(
@@ -3238,7 +3238,7 @@ where
                         },
                         PeerIndex(usize::max_value()),
                         SubstreamDirection::Out,
-                        NotificationsSubstreamState::open_max_value(),
+                        NotificationsSubstreamState::max_value(),
                         SubstreamId::max_value(),
                     ),
             )

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
 - Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
 - Fix panic when the discovery system finds same address attributed to two different peers. ([#1412](https://github.com/smol-dot/smoldot/pull/1412))
+- Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations.
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix panic when the discovery system finds same address attributed to two different peers. ([#1412](https://github.com/smol-dot/smoldot/pull/1412))
 - Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations.
 - Fix automatically refusing inbound notification substreams if a different inbound substream of the same protocol existed on the same connection, even when that other substream has been closed.
+- Inbound notification substreams opened by the remote and that are no longer wanted are now forcefully closed if the remote doesn't close them gracefully.
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations.
 - Fix automatically refusing inbound notification substreams if a different inbound substream of the same protocol existed on the same connection, even when that other substream has been closed.
 - Inbound notification substreams opened by the remote and that are no longer wanted are now forcefully closed if the remote doesn't close them gracefully.
+- Fix panic when a connection is shutting down after the notification substreams of that connection were opened in an unconventional order.
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
 - Fix panic when the discovery system finds same address attributed to two different peers. ([#1412](https://github.com/smol-dot/smoldot/pull/1412))
 - Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations.
+- Fix automatically refusing inbound notification substreams if a different inbound substream of the same protocol existed on the same connection, even when that other substream has been closed.
 
 ## 2.0.10 - 2023-11-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -15,10 +15,10 @@
 - Fix panic when `chainHead_unstable_follow` is called too many times. ([#1392](https://github.com/smol-dot/smoldot/pull/1392))
 - Fix panic when opening a gossiping link to a peer that we were previously connected to. ([#1395](https://github.com/smol-dot/smoldot/pull/1395))
 - Fix panic when the discovery system finds same address attributed to two different peers. ([#1412](https://github.com/smol-dot/smoldot/pull/1412))
-- Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations.
-- Fix automatically refusing inbound notification substreams if a different inbound substream of the same protocol existed on the same connection, even when that other substream has been closed.
-- Inbound notification substreams opened by the remote and that are no longer wanted are now forcefully closed if the remote doesn't close them gracefully.
-- Fix panic when a connection is shutting down after the notification substreams of that connection were opened in an unconventional order.
+- Fix sending a block announce handshake when accepting an inbound transactions or grandpa substream in some rare situations. ((#1417)[https://github.com/smol-dot/smoldot/pull/1417])
+- Fix automatically refusing inbound notification substreams if a different inbound substream of the same protocol existed on the same connection, even when that other substream has been closed. ((#1417)[https://github.com/smol-dot/smoldot/pull/1417])
+- Inbound notification substreams opened by the remote and that are no longer wanted are now forcefully closed if the remote doesn't close them gracefully. ((#1417)[https://github.com/smol-dot/smoldot/pull/1417])
+- Fix panic when a connection is shutting down after the notification substreams of that connection were opened in an unconventional order. ((#1417)[https://github.com/smol-dot/smoldot/pull/1417])
 
 ## 2.0.10 - 2023-11-17
 


### PR DESCRIPTION
This PR does a big clean-up pass on `network/service.rs`, making the code more readable and fixing several bugs which have been mentioned in the CHANGELOG.

Close https://github.com/smol-dot/smoldot/issues/1248