### PR TITLE
Increase the connections opening rate limit

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1093,8 +1093,8 @@ fn start_services<TPlat: platform::PlatformRef>(
         network_service::NetworkService::new(network_service::Config {
             platform: platform.clone(),
             identify_agent_version: network_identify_agent_version,
-            connections_open_pool_size: 5,
-            connections_open_pool_restore_delay: Duration::from_secs(1),
+            connections_open_pool_size: 8,
+            connections_open_pool_restore_delay: Duration::from_millis(100),
             chains_capacity: 1,
         })
     });

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Increase the rate at which connections are opened to 10 per second, with a pool of 8 simultaneous connections openings.
+- Increase the rate at which connections are opened to 10 per second, with a pool of 8 simultaneous connections openings. ([#1425](https://github.com/smol-dot/smoldot/pull/1425))
 
 ## 2.0.12 - 2023-11-27
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Increase the rate at which connections are opened to 10 per second, with a pool of 8 simultaneous connections openings.
+
 ## 2.0.12 - 2023-11-27
 
 ### Fixed


### PR DESCRIPTION
This PR updates https://github.com/smol-dot/smoldot/pull/1340 after https://github.com/smol-dot/smoldot/pull/1398.

https://github.com/smol-dot/smoldot/pull/1340 assumed one networking service per chain, and so the rate was relatively low.
After https://github.com/smol-dot/smoldot/pull/1398, however, the rate applies to all chains together, making it a bit too low when many chains are added.
