### PR TITLE
Fix logic mistake in `increase_address_connections`

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -843,7 +843,7 @@ async fn background_task(mut inner: Inner) {
                                     remote_addr.as_ref(),
                                 );
                             debug_assert!(_was_in.is_ok());
-                            if let basic_peering_strategy::InsertAddressResult::Inserted {
+                            if let basic_peering_strategy::InsertAddressConnectionsResult::Inserted {
                                 address_removed: Some(addr_rm),
                             } = inner.peering_strategy.increase_address_connections(
                                 &peer_id,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The order in which smoldot connects to peers is now random rather than depending on the peer. ([#1424](https://github.com/smol-dot/smoldot/pull/1424))
 - Increase the rate at which connections are opened to 10 per second, with a pool of 8 simultaneous connections openings. ([#1425](https://github.com/smol-dot/smoldot/pull/1425))
 
+### Fixed
+
+- Fix panic when disconnecting from a peer whose identity didn't match the identity that was expected when connecting to it.
+
 ## 2.0.12 - 2023-11-27
 
 ### Fixed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Fix panic when disconnecting from a peer whose identity didn't match the identity that was expected when connecting to it.
+- Fix panic when disconnecting from a peer whose identity didn't match the identity that was expected when connecting to it. ([#1431](https://github.com/smol-dot/smoldot/pull/1431))
 
 ## 2.0.12 - 2023-11-27
 


### PR DESCRIPTION
Fix #1429
 
`insert_address_connections` should insert the `PeerId` if it is unknown, instead of not inserting.
