### PR TITLE
Fix missing check in `with_buffers`

### DIFF
--- a/lib/src/libp2p/with_buffers.rs
+++ b/lib/src/libp2p/with_buffers.rs
@@ -235,7 +235,7 @@ where
                     }
                 },
                 SocketProj::Resolved(mut socket) => {
-                    if !*this.read_closed {
+                    if !*this.read_closed && *this.read_buffer_valid < this.read_buffer.len() {
                         let read_result = AsyncRead::poll_read(
                             socket.as_mut(),
                             cx,


### PR DESCRIPTION
We call `poll_read` and pass as parameter a buffer. If this buffer is empty, `poll_read` will return 0, which is interpreted as "EOF", which then makes the code believe that the remote has closed its writing side.
