### PR TITLE
Always consider a stream as ready the first time

### DIFF
--- a/lib/src/libp2p/with_buffers.rs
+++ b/lib/src/libp2p/with_buffers.rs
@@ -171,6 +171,8 @@ where
 {
     /// Waits until [`WithBuffers::read_write_access`] should be called again.
     ///
+    /// Returns immediately if [`WithBuffers::read_write_access`] has never been called.
+    ///
     /// Returns if an error happens on the socket. If an error happened in the past on the socket,
     /// the future never yields.
     pub async fn wait_read_write_again<F>(
@@ -181,8 +183,9 @@ where
     {
         let mut this = self.project();
 
-        // Return immediately if `wake_up_after <= now`.
+        // Return immediately if `read_write_access` was never called or if `wake_up_after <= now`.
         match (&*this.read_write_wake_up_after, &*this.read_write_now) {
+            (_, None) => return,
             (Some(when_wake_up), Some(now)) if *when_wake_up <= *now => {
                 return;
             }

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -250,6 +250,9 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     /// Returns a future that becomes ready when [`PlatformRef::read_write_access`] should be
     /// called again on this stream.
     ///
+    /// Must always returned immediately if [`PlatformRef::read_write_access`] has never been
+    /// called on this stream.
+    ///
     /// See the documentation of [`read_write`] for more information.
     ///
     /// > **Note**: The `with_buffers` module provides a helper to more easily implement this


### PR DESCRIPTION
This is a "just in case" corner case.
If a stream was never processed, then it is now considered immediately ready.

The code of the networking services already consider that it is the case, however for #1382 it will be useful to have the guarantee that waiting will always yield at the first iteration. 
