### PR TITLE
Update to Rust 1.74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add wasm32-unknown-unknown
@@ -66,7 +66,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -100,7 +100,7 @@ jobs:
   check-no-std:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add thumbv7m-none-eabi
@@ -112,7 +112,7 @@ jobs:
   fuzzing-binaries-compile:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
       # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -132,7 +132,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -141,7 +141,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -201,7 +201,7 @@ jobs:
   wasm-node-versions-match:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
       - run: apt-get update && apt install -y jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
   build-js-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
   build-rust-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - run: apt update && apt install -y jq
       - run: rustup component add llvm-tools-preview
@@ -174,7 +174,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
@@ -217,7 +217,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: 1.72
+          toolchain: 1.74
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
@@ -244,7 +244,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
       - uses: actions/checkout@v4
       - run: cargo publish --dry-run --locked

--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-update:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.72
+      image: rust:1.74
     steps:
     - uses: actions/checkout@v4
     # Note: `cargo update --workspace` doesn't seem to have any effect.


### PR DESCRIPTION
We were still on Rust v1.72

Versions 1.73 and 1.74 don't change anything relevant to smoldot.