### PR TITLE
Fix pings never being sent

### DIFF
--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -143,7 +143,9 @@ where
                     .unwrap()
                     .0
                     .queue_ping(&payload, read_write.now.clone() + self.inner.ping_timeout);
-                self.inner.yamux.mark_substream_write_ready(self.inner.outgoing_pings);
+                self.inner
+                    .yamux
+                    .mark_substream_write_ready(self.inner.outgoing_pings);
             } else {
                 return Ok((self, Some(Event::PingOutFailed)));
             }

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -1053,7 +1053,7 @@ where
                 // We check the timeouts before checking the incoming data, as otherwise pings
                 // might succeed after their timeout.
                 for timeout in queued_pings.iter_mut() {
-                    if timeout.as_ref().map_or(false, |t| *t < read_write.now) {
+                    if timeout.as_ref().map_or(false, |t| *t <= read_write.now) {
                         *timeout = None;
                         read_write.wake_up_asap();
                         return (

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix pings never being sent to peers, which means that smoldot would fail to detect when a connection is no longer responsive.
 - Fix connection being properly killed when the ping substream fails to be negotiated. ([#1459](https://github.com/smol-dot/smoldot/pull/1459))
 
 ## 2.0.13 - 2023-11-28

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix pings never being sent to peers, which means that smoldot would fail to detect when a connection is no longer responsive.
+- Fix pings never being sent to peers, which means that smoldot would fail to detect when a connection is no longer responsive. ([#1461](https://github.com/smol-dot/smoldot/pull/1461))
 - Fix connection being properly killed when the ping substream fails to be negotiated. ([#1459](https://github.com/smol-dot/smoldot/pull/1459))
 
 ## 2.0.13 - 2023-11-28


### PR DESCRIPTION
It turns out that we would never process the ping substream, which means that pings were never actually sent to the remote.