### PR TITLE
Update `upload-artifact` and `download-artifact` to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
       - run: |
           mkdir -p ./doc
           mv ./repo/wasm-node/javascript/dist/doc/* ./doc
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: javascript-documentation
           path: ./doc/
@@ -96,7 +96,7 @@ jobs:
       - run: |
           mkdir -p ./doc
           mv ./repo/target/doc/* ./doc
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rust-documentation
           path: ./doc/
@@ -123,7 +123,7 @@ jobs:
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse ./coverage/default_*.profraw -o ./coverage/tests-coverage.profdata
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov show --format=html --output-dir=./html-out --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='cargo/registry' --ignore-filename-regex='/rustc/' --show-instantiations --show-line-counts-or-regions $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
           `rustc --print sysroot`/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report --instr-profile=./coverage/tests-coverage.profdata --ignore-filename-regex='cargo/registry' --ignore-filename-regex='/rustc/' $(for file in `cat ./coverage/binaries-list`; do printf "%s %s " -object $file; done)
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: ./html-out/
@@ -142,15 +142,15 @@ jobs:
           mkdir -p ./upload/doc-rust
           mkdir -p ./upload/tests-coverage
           touch ./upload/.nojekyll
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: javascript-documentation
           path: ./upload/doc-javascript
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rust-documentation
           path: ./upload/doc-rust
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: code-coverage-report
           path: ./upload/tests-coverage


### PR DESCRIPTION
https://github.com/smol-dot/smoldot/pull/1471 and https://github.com/smol-dot/smoldot/pull/1472 are failing CI and I assume it's because they need to be updated at the same time.