### PR TITLE
Remove restriction about parent having to be present in database

### DIFF
--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -333,9 +333,6 @@ impl SqliteFullDatabase {
     ///
     /// Must pass the header and body of the block.
     ///
-    /// Blocks must be inserted in the correct order. An error is returned if the parent of the
-    /// newly-inserted block isn't present in the database.
-    ///
     /// > **Note**: It is not necessary for the newly-inserted block to be a descendant of the
     /// >           finalized block, unless `is_new_best` is true.
     ///
@@ -364,11 +361,6 @@ impl SqliteFullDatabase {
         // Make sure that the block to insert isn't already in the database.
         if has_block(&transaction, &block_hash)? {
             return Err(InsertError::Duplicate);
-        }
-
-        // Make sure that the parent of the block to insert is in the database.
-        if !has_block(&transaction, header.parent_hash)? {
-            return Err(InsertError::MissingParent);
         }
 
         transaction
@@ -1369,8 +1361,6 @@ pub enum InsertError {
     /// Error when decoding the header to import.
     #[display(fmt = "Failed to decode header: {_0}")]
     BadHeader(header::Error),
-    /// Parent of the block to insert isn't in the database.
-    MissingParent,
     /// The new best block would be outside of the finalized chain.
     BestNotInFinalizedChain,
 }

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -1401,8 +1401,6 @@ pub enum CorruptedError {
     /// Values in the database are all well-formatted, but are incoherent.
     #[display(fmt = "Invalid chain information: {_0}")]
     InvalidChainInformation(chain_information::ValidityError),
-    /// The parent of a block in the database couldn't be found in that same database.
-    BrokenChain,
     /// Missing a key in the `meta` table.
     MissingMetaKey,
     /// Some parts of the database refer to a block by its hash, but the block's constituents

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -198,8 +198,7 @@ CREATE TABLE blocks(
     header BLOB NOT NULL,
     justification BLOB,
     is_best_chain BOOLEAN NOT NULL,
-    UNIQUE(number, hash),
-    FOREIGN KEY (parent_hash) REFERENCES blocks(hash) ON UPDATE RESTRICT ON DELETE NO ACTION
+    UNIQUE(number, hash)
 );
 CREATE INDEX blocks_by_number ON blocks(number);
 CREATE INDEX blocks_by_parent ON blocks(parent_hash);


### PR DESCRIPTION
For https://github.com/smol-dot/smoldot/issues/131, we will need to insert blocks after having finished warp syncing.
In order for this to work, we have to remove the restriction that the database has about parent blocks having to be present as well.