### PR TITLE
Fix `source_num_ongoing_requests` not being implemented properly when warp syncing

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -649,7 +649,9 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             (AllSyncInner::Optimistic { inner }, SourceMapping::Optimistic(src)) => {
                 inner.source_num_ongoing_requests(*src)
             }
-            (AllSyncInner::WarpSync { .. }, SourceMapping::WarpSync(_)) => 0,
+            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(src)) => {
+                inner.source_num_ongoing_requests(*src)
+            }
 
             (AllSyncInner::Poisoned, _) => unreachable!(),
             // Invalid combinations of syncing state machine and source id.

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -583,6 +583,19 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
         self.sources.iter().map(|(id, _)| SourceId(id))
     }
 
+    /// Returns the number of ongoing requests that concern this source.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the [`SourceId`] is invalid.
+    ///
+    pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
+        assert!(self.sources.contains(source_id.0));
+        self.in_progress_requests_by_source
+            .range((source_id, RequestId(usize::MIN))..=(source_id, RequestId(usize::MAX)))
+            .count()
+    }
+
     /// Add a source to the list of sources.
     ///
     /// The source has a finalized block height of 0, which should later be updated using


### PR DESCRIPTION
Change extracted from https://github.com/smol-dot/smoldot/pull/1483