### PR TITLE
Implement full mode in `all_forks.rs`

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1449,6 +1449,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                         // TODO: many of the errors don't properly translate here, needs some refactoring
                         match blocks_append.add_block(
                             &block.scale_encoded_header,
+                            block.scale_encoded_extrinsics,
                             block
                                 .scale_encoded_justifications
                                 .into_iter()
@@ -2358,8 +2359,12 @@ impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
         &'_ self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
         match &self.inner {
-            HeaderVerifySuccessInner::AllForks(_verify) => todo!(), // TODO: /!\
-            HeaderVerifySuccessInner::Optimistic(verify) => verify.scale_encoded_extrinsics(),
+            HeaderVerifySuccessInner::AllForks(verify) => verify
+                .scale_encoded_extrinsics()
+                .map(|iter| either::Left(iter.map(either::Left))),
+            HeaderVerifySuccessInner::Optimistic(verify) => verify
+                .scale_encoded_extrinsics()
+                .map(|iter| either::Right(iter.map(either::Right))),
         }
     }
 
@@ -2803,7 +2808,7 @@ impl<TRq> Shared<TRq> {
             max_disjoint_headers: self.max_disjoint_headers,
             max_requests_per_block: self.max_requests_per_block,
             allow_unknown_consensus_engines: self.allow_unknown_consensus_engines,
-            full: false,
+            download_bodies: false,
         });
 
         debug_assert!(self

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -42,14 +42,6 @@
 //! >              block. This is necessary in case it is this other block 5 that will end up
 //! >              being finalized.
 //!
-//! # Full vs non-full
-//!
-//! The [`Config::full`] option configures whether the state machine only holds headers of the
-//! non-finalized blocks (`full` equal to `false`), or the headers, and bodies, and storage
-//! (`full` equal to `true`).
-//!
-//! In full mode, .
-//!
 //! # Bounded and unbounded containers
 //!
 //! It is important to limit the memory usage of this state machine no matter how the
@@ -170,14 +162,13 @@ pub struct Config {
     /// The higher the value, the more bandwidth is potentially wasted.
     pub max_requests_per_block: NonZeroU32,
 
-    /// If true, the block bodies and storage are also synchronized.
-    pub full: bool,
+    /// If true, the body of a block is downloaded (if necessary) before a
+    /// [`ProcessOne::BlockVerify`] is generated.
+    pub download_bodies: bool,
 }
 
 pub struct AllForksSync<TBl, TRq, TSrc> {
     /// Data structure containing the non-finalized blocks.
-    ///
-    /// If [`Config::full`], this only contains blocks whose header *and* body have been verified.
     chain: blocks_tree::NonFinalizedTree<TBl>,
 
     /// Extra fields. In a separate structure in order to be moved around.
@@ -191,7 +182,9 @@ struct Inner<TBl, TRq, TSrc> {
 
 struct PendingBlock<TBl> {
     header: Option<header::Header>,
-    // TODO: add body: Option<Vec<Vec<u8>>>, when adding full node support
+    /// SCALE-encoded extrinsics of the block. `None` if unknown. Only ever filled
+    /// if [`Config::download_bodies`] was `true`.
+    body: Option<Vec<Vec<u8>>>,
     user_data: TBl,
 }
 
@@ -440,7 +433,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                     finalized_block_height,
                     max_requests_per_block: config.max_requests_per_block,
                     sources_capacity: config.sources_capacity,
-                    verify_bodies: config.full,
+                    download_bodies: config.download_bodies,
                 }),
             }),
         }
@@ -1052,59 +1045,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             ProcessOne::AllSync { sync: self }
         }
     }
-
-    /*/// Call in response to a [`BlockAnnounceOutcome::BlockBodyDownloadStart`].
-    ///
-    /// # Panic
-    ///
-    /// Panics if the [`RequestId`] is invalid.
-    ///
-    pub fn block_body_response(
-        mut self,
-        now_from_unix_epoch: Duration,
-        request_id: RequestId,
-        block_body: impl Iterator<Item = impl AsRef<[u8]>>,
-    ) -> (BlockBodyVerify<TBl, TRq, TSrc>, Option<Request>) {
-        // TODO: unfinished
-
-        todo!()
-
-        /*// TODO: update occupation
-
-        // Removes traces of the request from the state machine.
-        let block_header_hash = if let Some((h, _)) = self
-            .inner
-            .pending_body_downloads
-            .iter_mut()
-            .find(|(_, (_, s))| *s == Some(source_id))
-        {
-            let hash = *h;
-            let header = self.inner.pending_body_downloads.remove(&hash).unwrap().0;
-            (header, hash)
-        } else {
-            panic!()
-        };
-
-        // Sanity check.
-        debug_assert_eq!(block_header_hash.1, block_header_hash.0.hash());
-
-        // If not full, there shouldn't be any block body download happening in the first place.
-        debug_assert!(self.inner.full);
-
-        match self
-            .chain
-            .verify_body(
-                block_header_hash.0.scale_encoding()
-                    .fold(Vec::new(), |mut a, b| { a.extend_from_slice(b.as_ref()); a }), now_from_unix_epoch) // TODO: stupid extra allocation
-        {
-            blocks_tree::BodyVerifyStep1::BadParent { .. }
-            | blocks_tree::BodyVerifyStep1::InvalidHeader(..)
-            | blocks_tree::BodyVerifyStep1::Duplicate(_) => unreachable!(),
-            blocks_tree::BodyVerifyStep1::ParentRuntimeRequired(_runtime_req) => {
-                todo!()
-            }
-        }*/
-    }*/
 }
 
 impl<TBl, TRq, TSrc> ops::Index<SourceId> for AllForksSync<TBl, TRq, TSrc> {
@@ -1171,9 +1111,13 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
     ///
     /// If an error is returned, the [`FinishAncestrySearch`] is turned back again into a
     /// [`AllForksSync`], but all the blocks that have already been added are retained.
+    ///
+    /// If [`Config::download_bodies`] was `false`, the content of `scale_encoded_extrinsics`
+    /// is ignored.
     pub fn add_block(
         mut self,
         scale_encoded_header: &[u8],
+        scale_encoded_extrinsics: Vec<Vec<u8>>,
         scale_encoded_justifications: impl Iterator<Item = ([u8; 4], impl AsRef<[u8]>)>,
     ) -> Result<AddBlock<TBl, TRq, TSrc>, (AncestrySearchResponseError, AllForksSync<TBl, TRq, TSrc>)>
     {
@@ -1204,6 +1148,8 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
             return Err((AncestrySearchResponseError::UnexpectedBlock, self.finish()));
         }
 
+        // TODO: /!\ must verify that scale_encoded_extrinsics matches the header's extrinsics root
+
         // At this point, the source has given us correct blocks, and we consider the response
         // as a whole to be useful.
         self.any_progress = true;
@@ -1224,6 +1170,8 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
             .collect::<Vec<_>>();
 
         // If the block is already part of the local tree of blocks, nothing more to do.
+        // Note that the block body is silently discarded, as in the API only non-verified blocks
+        // exhibit a body.
         if self
             .inner
             .chain
@@ -1274,6 +1222,7 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
             Ok(AddBlock::UnknownBlock(AddBlockVacant {
                 inner: self,
                 decoded_header: decoded_header.into(),
+                scale_encoded_extrinsics,
                 justifications,
             }))
         } else {
@@ -1284,6 +1233,22 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
                         decoded_header.number,
                         FinalityProofs::Justifications(justifications),
                     );
+            }
+
+            if self.inner.inner.blocks.downloading_bodies() {
+                self.inner
+                    .inner
+                    .blocks
+                    .set_unverified_block_header_body_known(
+                        decoded_header.number,
+                        &self.expected_next_hash,
+                        *decoded_header.parent_hash,
+                    );
+                self.inner
+                    .inner
+                    .blocks
+                    .unverified_block_user_data_mut(decoded_header.number, &self.expected_next_hash)
+                    .body = Some(scale_encoded_extrinsics);
             }
 
             Ok(AddBlock::AlreadyPending(AddBlockOccupied {
@@ -1446,6 +1411,7 @@ pub struct AddBlockVacant<TBl, TRq, TSrc> {
     inner: FinishAncestrySearch<TBl, TRq, TSrc>,
     decoded_header: header::Header,
     justifications: Vec<([u8; 4], Vec<u8>)>,
+    scale_encoded_extrinsics: Vec<Vec<u8>>,
 }
 
 impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
@@ -1469,11 +1435,18 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
         self.inner.inner.inner.blocks.insert_unverified_block(
             self.decoded_header.number,
             self.inner.expected_next_hash,
-            pending_blocks::UnverifiedBlockState::Header {
-                parent_hash: self.decoded_header.parent_hash,
+            if self.inner.inner.inner.blocks.downloading_bodies() {
+                pending_blocks::UnverifiedBlockState::HeaderBody {
+                    parent_hash: self.decoded_header.parent_hash,
+                }
+            } else {
+                pending_blocks::UnverifiedBlockState::Header {
+                    parent_hash: self.decoded_header.parent_hash,
+                }
             },
             PendingBlock {
                 header: Some(self.decoded_header.clone()),
+                body: Some(self.scale_encoded_extrinsics),
                 user_data,
             },
         );
@@ -1712,6 +1685,7 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
             },
             PendingBlock {
                 header: Some(self.announced_header_encoded),
+                body: None,
                 user_data,
             },
         );
@@ -1916,6 +1890,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
             pending_blocks::UnverifiedBlockState::HeightHash,
             PendingBlock {
                 header: None,
+                body: None,
                 user_data: best_block_user_data,
             },
         );
@@ -2065,6 +2040,31 @@ impl<TBl, TRq, TSrc> HeaderVerifySuccess<TBl, TRq, TSrc> {
     /// Returns the SCALE-encoded header of the block that was verified.
     pub fn scale_encoded_header(&self) -> &[u8] {
         self.verified_header.scale_encoded_header()
+    }
+
+    /// Returns the list of SCALE-encoded extrinsics of the block to verify.
+    ///
+    /// This is `Some` if and only if [`Config::download_bodies`] is `true`
+    pub fn scale_encoded_extrinsics(
+        &'_ self,
+    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
+        if self.parent.inner.blocks.downloading_bodies() {
+            Some(
+                self.parent
+                    .inner
+                    .blocks
+                    .unverified_block_user_data(
+                        self.block_to_verify.block_number,
+                        &self.block_to_verify.block_hash,
+                    )
+                    .body
+                    .as_ref()
+                    .unwrap()
+                    .iter(),
+            )
+        } else {
+            None
+        }
     }
 
     /// Reject the block and mark it as bad.

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -2059,7 +2059,9 @@ impl<TBl, TRq, TSrc> HeaderVerifySuccess<TBl, TRq, TSrc> {
                     )
                     .body
                     .as_ref()
-                    .unwrap()
+                    // The block shouldn't have been proposed for verification if it doesn't
+                    // have its body available.
+                    .unwrap_or_else(|| unreachable!())
                     .iter(),
             )
         } else {

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -116,7 +116,7 @@ pub struct Config {
 
     /// If `true`, block bodies are downloaded and verified. If `false`, only headers are
     /// verified.
-    pub verify_bodies: bool,
+    pub download_bodies: bool,
 
     /// Maximum number of simultaneous pending requests made towards the same block.
     ///
@@ -172,8 +172,8 @@ pub struct PendingBlocks<TBl, TRq, TSrc> {
     /// Blocks whose validity couldn't be determined yet.
     blocks: disjoint::DisjointBlocks<UnverifiedBlock<TBl>>,
 
-    /// See [`Config::verify_bodies`].
-    verify_bodies: bool,
+    /// See [`Config::download_bodies`].
+    download_bodies: bool,
 
     /// Set of `(block_height, block_hash, request_id)`.
     /// Contains the list of all requests, associated to their block.
@@ -232,7 +232,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
                 config.finalized_block_height,
             ),
             blocks: disjoint::DisjointBlocks::with_capacity(config.blocks_capacity),
-            verify_bodies: config.verify_bodies,
+            download_bodies: config.download_bodies,
             blocks_requests: Default::default(),
             requested_blocks: Default::default(),
             source_occupations: Default::default(),
@@ -244,6 +244,11 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
             max_requests_per_block: usize::try_from(config.max_requests_per_block.get())
                 .unwrap_or(usize::max_value()),
         }
+    }
+
+    /// Returns the value that was passed as [`Config::download_bodies`]
+    pub fn downloading_bodies(&self) -> bool {
+        self.download_bodies
     }
 
     /// Add a new source to the container.
@@ -677,7 +682,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// blocks. These blocks can potentially be verified.
     ///
     /// All the returned block are guaranteed to be in a "header known" state. If
-    /// [`Config::verify_bodies`] if `true`, they they are also guaranteed to be in a "body known"
+    /// [`Config::download_bodies`] if `true`, they they are also guaranteed to be in a "body known"
     /// state.
     ///
     /// > **Note**: The naming of this function assumes that all blocks that are referenced by
@@ -692,7 +697,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
                 .state
             {
                 UnverifiedBlockState::HeightHash => false,
-                UnverifiedBlockState::Header { .. } => !self.verify_bodies,
+                UnverifiedBlockState::Header { .. } => !self.download_bodies,
                 UnverifiedBlockState::HeaderBody { .. } => true,
             }
         })
@@ -896,7 +901,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// In details, the requests concern:
     ///
-    /// - If [`Config::verify_bodies`] was `true`, downloading the body of blocks whose body is
+    /// - If [`Config::download_bodies`] was `true`, downloading the body of blocks whose body is
     /// unknown.
     /// - Downloading headers of blocks whose state is [`UnverifiedBlockState::HeightHash`].
     ///
@@ -958,7 +963,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         // TODO: could provide more optimized requests by avoiding potentially overlapping requests (e.g. if blocks #4 and #5 are unknown, ask for block #5 with num_blocks=2), but this is complicated because peers aren't obligated to respond with the given number of blocks
 
         // List of blocks whose header is known but not its body.
-        let unknown_body_iter = if self.verify_bodies {
+        let unknown_body_iter = if self.download_bodies {
             either::Left(
                 self.blocks
                     .iter()

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -1022,7 +1022,6 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
                     )
                     .count();
 
-                debug_assert!(num_existing_requests <= self.max_requests_per_block);
                 num_existing_requests < self.max_requests_per_block
             })
             .flat_map(move |(unknown_block_height, unknown_block_hash)| {

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -1002,8 +1002,9 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         // Combine the two block iterators and find sources.
         // There isn't any overlap between the two iterators.
         unknown_body_iter
-            .chain(unknown_header_iter)
-            .filter(move |(unknown_block_height, unknown_block_hash)| {
+            .map(|(n, h)| (n, h, false))
+            .chain(unknown_header_iter.map(|(n, h)| (n, h, true)))
+            .filter(move |(unknown_block_height, unknown_block_hash, _)| {
                 // Cap by `max_requests_per_block`.
                 // TODO: O(n)?
                 let num_existing_requests = self
@@ -1024,66 +1025,71 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
 
                 num_existing_requests < self.max_requests_per_block
             })
-            .flat_map(move |(unknown_block_height, unknown_block_hash)| {
-                // Try to find all appropriate sources.
-                let possible_sources = if let Some(force_source) = force_source {
-                    either::Left(iter::once(force_source).filter(move |id| {
-                        self.sources.source_knows_non_finalized_block(
-                            *id,
-                            unknown_block_height,
-                            unknown_block_hash,
-                        )
-                    }))
-                } else {
-                    either::Right(
-                        self.sources
-                            .knows_non_finalized_block(unknown_block_height, unknown_block_hash),
-                    )
-                };
-
-                possible_sources
-                    .filter(move |source_id| {
-                        // Don't start any request towards this source if there's another request
-                        // for the same block from the same source.
-                        // TODO: O(n)?
-                        !self
-                            .blocks_requests
-                            .range(
-                                (
+            .flat_map(
+                move |(unknown_block_height, unknown_block_hash, download_many)| {
+                    // Try to find all appropriate sources.
+                    let possible_sources =
+                        if let Some(force_source) = force_source {
+                            either::Left(iter::once(force_source).filter(move |id| {
+                                self.sources.source_knows_non_finalized_block(
+                                    *id,
                                     unknown_block_height,
-                                    *unknown_block_hash,
-                                    RequestId(usize::min_value()),
+                                    unknown_block_hash,
                                 )
-                                    ..=(
+                            }))
+                        } else {
+                            either::Right(self.sources.knows_non_finalized_block(
+                                unknown_block_height,
+                                unknown_block_hash,
+                            ))
+                        };
+
+                    possible_sources
+                        .filter(move |source_id| {
+                            // Don't start any request towards this source if there's another request
+                            // for the same block from the same source.
+                            // TODO: O(n)?
+                            !self
+                                .blocks_requests
+                                .range(
+                                    (
                                         unknown_block_height,
                                         *unknown_block_hash,
-                                        RequestId(usize::max_value()),
-                                    ),
-                            )
-                            .any(|(_, _, request_id)| {
-                                self.requests[request_id.0].source_id == *source_id
-                            })
-                    })
-                    .map(move |source_id| {
-                        debug_assert!(self.sources.source_knows_non_finalized_block(
-                            source_id,
-                            unknown_block_height,
-                            unknown_block_hash
-                        ));
-
-                        DesiredRequest {
-                            source_id,
-                            request_params: RequestParams {
-                                first_block_hash: *unknown_block_hash,
-                                first_block_height: unknown_block_height,
-                                num_blocks: NonZeroU64::new(
-                                    unknown_block_height - self.sources.finalized_block_height(),
+                                        RequestId(usize::min_value()),
+                                    )
+                                        ..=(
+                                            unknown_block_height,
+                                            *unknown_block_hash,
+                                            RequestId(usize::max_value()),
+                                        ),
                                 )
-                                .unwrap(),
-                            },
-                        }
-                    })
-            })
+                                .any(|(_, _, request_id)| {
+                                    self.requests[request_id.0].source_id == *source_id
+                                })
+                        })
+                        .map(move |source_id| {
+                            debug_assert!(self.sources.source_knows_non_finalized_block(
+                                source_id,
+                                unknown_block_height,
+                                unknown_block_hash
+                            ));
+
+                            DesiredRequest {
+                                source_id,
+                                request_params: RequestParams {
+                                    first_block_hash: *unknown_block_hash,
+                                    first_block_height: unknown_block_height,
+                                    num_blocks: NonZeroU64::new(if download_many {
+                                        unknown_block_height - self.sources.finalized_block_height()
+                                    } else {
+                                        1
+                                    })
+                                    .unwrap(),
+                                },
+                            }
+                        })
+                },
+            )
     }
 }
 


### PR DESCRIPTION
Change extracted from https://github.com/smol-dot/smoldot/pull/1483 then expanded further.

This implements "full mode" in `all_forks.rs`.
While "full mode" seems like an elaborate thing, all it actually does is making sure that we download the body of a block before proposing it for verification. The PR also adds a function to fetch that block body that has been downloaded. The rest is out of scope of that module.

This essentially finishes the API of `all_forks.rs`.
