### PR TITLE
Update to wasmi v0.32 and add lazy validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,10 +2856,10 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfc1e384a36ca532d070a315925887247f3c7e23567e23e0ac9b1c5d6b8bf76"
+version = "0.32.0-beta.0"
+source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
 dependencies = [
+ "multi-stash",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -2864,14 +2870,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
 
 [[package]]
 name = "wasmi_core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+version = "0.14.0"
+source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,8 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.0-beta.1"
-source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
+version = "0.32.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab06f5b4dadd225f47efe41308550ab01f0b6aa2585d7823c3f215e5777ebd"
 dependencies = [
  "multi-stash",
  "num-derive",
@@ -2883,12 +2884,14 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
 
 [[package]]
 name = "wasmi_core"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac482df6761020b2b75c9aade41c105993c5b9f64156c349bb7ccad226a6ecd"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,10 +2868,11 @@ dependencies = [
 [[package]]
 name = "wasmi"
 version = "0.32.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0aad9322aebdae4ab039e53bcd5a81dae75047dd55cada2c04124bd3438a99e"
+source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
 dependencies = [
  "multi-stash",
+ "num-derive",
+ "num-traits",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -2871,14 +2883,12 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
 
 [[package]]
 name = "wasmi_core"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac482df6761020b2b75c9aade41c105993c5b9f64156c349bb7ccad226a6ecd"
+source = "git+https://github.com/paritytech/wasmi#f96475ef1135d11858e0859cee97ea07f93c6d3d"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,8 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.0-beta.0"
-source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
+version = "0.32.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0aad9322aebdae4ab039e53bcd5a81dae75047dd55cada2c04124bd3438a99e"
 dependencies = [
  "multi-stash",
  "smallvec",
@@ -2870,12 +2871,14 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
 
 [[package]]
 name = "wasmi_core"
-version = "0.14.0"
-source = "git+https://github.com/paritytech/wasmi#86d097623592dc499852ea4bb01cace0097d70a4"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac482df6761020b2b75c9aade41c105993c5b9f64156c349bb7ccad226a6ecd"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -316,7 +316,7 @@ impl ConsensusService {
             executor::host::HostVmPrototype::new(executor::host::Config {
                 module: finalized_code,
                 heap_pages,
-                exec_hint: executor::vm::ExecHint::CompileAheadOfTime, // TODO: probably should be decided by the optimisticsync
+                exec_hint: executor::vm::ExecHint::ValidateAndCompile, // TODO: probably should be decided by the optimisticsync
                 allow_unresolved_imports: false,
             })
             .map_err(InitError::FinalizedRuntimeInit)?

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1927,7 +1927,7 @@ impl SyncBackground {
             }
             all::ProcessOne::WarpSyncBuildRuntime(build_runtime) => {
                 let (new_sync, outcome) =
-                    build_runtime.build(all::ExecHint::CompileAheadOfTime, true);
+                    build_runtime.build(all::ExecHint::ValidateAndCompile, true);
                 self.sync = new_sync;
                 if let Err(err) = outcome {
                     self.log_callback.log(

--- a/full-node/src/json_rpc_service/runtime_caches_service.rs
+++ b/full-node/src/json_rpc_service/runtime_caches_service.rs
@@ -105,7 +105,7 @@ impl RuntimeCachesService {
                                         executor::host::Config {
                                             module: &code,
                                             heap_pages,
-                                            exec_hint: executor::vm::ExecHint::CompileAheadOfTime,
+                                            exec_hint: executor::vm::ExecHint::ValidateAndCompile,
                                             allow_unresolved_imports: true, // TODO: configurable? or if not, document
                                         },
                                     )

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -853,7 +853,7 @@ async fn open_database(
                     genesis_storage.value(b":heappages"),
                 )
                 .unwrap(),
-                exec_hint: executor::vm::ExecHint::Oneshot,
+                exec_hint: executor::vm::ExecHint::ValidateAndExecuteOnce,
                 allow_unresolved_imports: true,
             })
             .unwrap()

--- a/fuzz/fuzz_targets/wasm-module-wasmi.rs
+++ b/fuzz/fuzz_targets/wasm-module-wasmi.rs
@@ -21,7 +21,9 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     let _ = smoldot::executor::host::HostVmPrototype::new(smoldot::executor::host::Config {
         module: data,
         heap_pages: smoldot::executor::DEFAULT_HEAP_PAGES,
-        exec_hint: smoldot::executor::vm::ExecHint::ForceWasmi,
+        exec_hint: smoldot::executor::vm::ExecHint::ForceWasmi {
+            lazy_validation: false,
+        },
         allow_unresolved_imports: true,
     });
 });

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { version = "0.32.0-beta.1", default-features = false }
+wasmi = { git = "https://github.com/paritytech/wasmi", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { git = "https://github.com/paritytech/wasmi", default-features = false }
+wasmi = { version = "0.32.0-beta.2", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { version = "0.31.0", default-features = false }
+wasmi = { git = "https://github.com/paritytech/wasmi", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { git = "https://github.com/paritytech/wasmi", default-features = false }
+wasmi = { version = "0.32.0-beta.1", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -116,7 +116,7 @@ impl ChainSpec {
         let vm_prototype = executor::host::HostVmPrototype::new(executor::host::Config {
             module: &wasm_code,
             heap_pages,
-            exec_hint: executor::vm::ExecHint::Oneshot,
+            exec_hint: executor::vm::ExecHint::ValidateAndExecuteOnce,
             allow_unresolved_imports: true,
         })
         .map_err(FromGenesisStorageError::VmInitialization)?;

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -152,7 +152,7 @@
 //!     let prototype = HostVmPrototype::new(Config {
 //!         module: &wasm_binary_code,
 //!         heap_pages: HeapPages::from(2048),
-//!         exec_hint: smoldot::executor::vm::ExecHint::Oneshot,
+//!         exec_hint: smoldot::executor::vm::ExecHint::ValidateAndExecuteOnce,
 //!         allow_unresolved_imports: false
 //!     }).unwrap();
 //!     prototype.run_no_param("Core_version").unwrap().into()

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -1775,7 +1775,7 @@ impl Inner {
                     let vm_prototype = match host::HostVmPrototype::new(host::Config {
                         module: req.wasm_code(),
                         heap_pages: executor::DEFAULT_HEAP_PAGES,
-                        exec_hint: vm::ExecHint::Oneshot,
+                        exec_hint: vm::ExecHint::ValidateAndExecuteOnce,
                         allow_unresolved_imports: false, // TODO: what is a correct value here?
                     }) {
                         Ok(w) => w,

--- a/lib/src/executor/runtime_host/tests.rs
+++ b/lib/src/executor/runtime_host/tests.rs
@@ -74,7 +74,7 @@ fn execute_blocks() {
             host::HostVmPrototype::new(host::Config {
                 module: code,
                 heap_pages,
-                exec_hint: crate::executor::vm::ExecHint::Oneshot,
+                exec_hint: crate::executor::vm::ExecHint::ExecuteOnceWithNonDeterministicValidation,
                 allow_unresolved_imports: false,
             })
             .unwrap()

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -145,7 +145,7 @@ impl VirtualMachinePrototype {
                     ),
                     feature = "wasmtime"
                 ))]
-                ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Jit(
+                ExecHint::ValidateAndCompile => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
                 #[cfg(not(all(
@@ -159,13 +159,41 @@ impl VirtualMachinePrototype {
                     ),
                     feature = "wasmtime"
                 )))]
-                ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Interpreter(
-                    interpreter::InterpreterPrototype::new(config.module_bytes, config.symbols)?,
+                ExecHint::ValidateAndCompile => VirtualMachinePrototypeInner::Interpreter(
+                    interpreter::InterpreterPrototype::new(
+                        config.module_bytes,
+                        interpreter::CompilationMode::Eager,
+                        config.symbols,
+                    )?,
                 ),
-                ExecHint::Oneshot | ExecHint::Untrusted | ExecHint::ForceWasmi => {
+                ExecHint::ValidateAndExecuteOnce | ExecHint::Untrusted => {
                     VirtualMachinePrototypeInner::Interpreter(
                         interpreter::InterpreterPrototype::new(
                             config.module_bytes,
+                            interpreter::CompilationMode::Eager,
+                            config.symbols,
+                        )?,
+                    )
+                }
+                ExecHint::CompileWithNonDeterministicValidation
+                | ExecHint::ExecuteOnceWithNonDeterministicValidation => {
+                    VirtualMachinePrototypeInner::Interpreter(
+                        interpreter::InterpreterPrototype::new(
+                            config.module_bytes,
+                            interpreter::CompilationMode::Lazy,
+                            config.symbols,
+                        )?,
+                    )
+                }
+                ExecHint::ForceWasmi { lazy_validation } => {
+                    VirtualMachinePrototypeInner::Interpreter(
+                        interpreter::InterpreterPrototype::new(
+                            config.module_bytes,
+                            if lazy_validation {
+                                interpreter::CompilationMode::Lazy
+                            } else {
+                                interpreter::CompilationMode::Eager
+                            },
                             config.symbols,
                         )?,
                     )
@@ -713,18 +741,37 @@ impl fmt::Debug for VirtualMachine {
 pub enum ExecHint {
     /// The WebAssembly code will be instantiated once and run many times.
     /// If possible, compile this WebAssembly code ahead of time.
-    CompileAheadOfTime,
+    ValidateAndCompile,
+
+    /// The WebAssembly code will be instantiated once and run many times.
+    /// Contrary to [`ExecHint::ValidateAndCompile`], the WebAssembly code isn't fully validated
+    /// ahead of time, meaning that invalid WebAssembly modules might successfully be compiled,
+    /// which is an indesirable property in some contexts.
+    CompileWithNonDeterministicValidation,
+
     /// The WebAssembly code is expected to be only run once.
     ///
     /// > **Note**: This isn't a hard requirement but a hint.
-    Oneshot,
+    ValidateAndExecuteOnce,
+
+    /// The WebAssembly code will be instantiated once and run many times.
+    /// Contrary to [`ExecHint::ValidateAndExecuteOnce`], the WebAssembly code isn't fully
+    /// validated ahead of time, meaning that invalid WebAssembly modules might successfully be
+    /// compiled, which is an indesirable property in some contexts.
+    ExecuteOnceWithNonDeterministicValidation,
+
     /// The WebAssembly code running through this VM is untrusted.
     Untrusted,
 
     /// Forces using the `wasmi` backend.
     ///
     /// This variant is useful for testing purposes.
-    ForceWasmi,
+    ForceWasmi {
+        /// If `true`, lazy validation is enabled. This leads to a faster initialization time,
+        /// but can also successfully validate invalid modules, which is an indesirable property
+        /// in some contexts.
+        lazy_validation: bool,
+    },
     /// Forces using the `wasmtime` backend.
     ///
     /// This variant is useful for testing purposes.
@@ -761,7 +808,10 @@ impl ExecHint {
     ///
     /// > **Note**: This function is most useful for testing purposes.
     pub fn available_engines() -> impl Iterator<Item = ExecHint> {
-        iter::once(ExecHint::ForceWasmi).chain(Self::force_wasmtime_if_available())
+        iter::once(ExecHint::ForceWasmi {
+            lazy_validation: false,
+        })
+        .chain(Self::force_wasmtime_if_available())
     }
 
     /// Returns `ForceWasmtime` if it is available on the current platform, and `None` otherwise.

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -66,6 +66,7 @@ impl InterpreterPrototype {
             config.wasm_mutable_global(false);
             config.wasm_saturating_float_to_int(false);
             config.wasm_tail_call(false);
+            config.compilation_mode(wasmi::CompilationMode::Lazy);
 
             wasmi::Engine::new(&config)
         };
@@ -129,7 +130,7 @@ impl InterpreterPrototype {
                         &mut store,
                         func_type.clone(),
                         move |_caller, parameters, _ret| {
-                            Err(wasmi::core::Trap::from(InterruptedTrap {
+                            Err(wasmi::Error::host(InterruptedTrap {
                                 function_index,
                                 parameters: parameters
                                     .iter()

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -25,6 +25,8 @@ use super::{
 use alloc::{borrow::ToOwned as _, string::ToString as _, sync::Arc, vec::Vec};
 use core::fmt;
 
+pub use wasmi::CompilationMode;
+
 /// See [`super::VirtualMachinePrototype`].
 pub struct InterpreterPrototype {
     /// Base components that can be used to recreate a prototype later if desired.
@@ -52,6 +54,7 @@ impl InterpreterPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
         module_bytes: &[u8],
+        compilation_mode: CompilationMode,
         symbols: &mut dyn FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         let engine = {
@@ -66,7 +69,7 @@ impl InterpreterPrototype {
             config.wasm_mutable_global(false);
             config.wasm_saturating_float_to_int(false);
             config.wasm_tail_call(false);
-            config.compilation_mode(wasmi::CompilationMode::Lazy);
+            config.compilation_mode(compilation_mode);
 
             wasmi::Engine::new(&config)
         };

--- a/lib/src/transactions/validate/tests.rs
+++ b/lib/src/transactions/validate/tests.rs
@@ -30,7 +30,7 @@ fn validate_from_proof() {
         module: hex::decode(&test.runtime_code).unwrap(),
         heap_pages: executor::DEFAULT_HEAP_PAGES,
         allow_unresolved_imports: true,
-        exec_hint: executor::vm::ExecHint::Oneshot,
+        exec_hint: executor::vm::ExecHint::ExecuteOnceWithNonDeterministicValidation,
     })
     .unwrap();
 

--- a/lib/src/verify/body_only.rs
+++ b/lib/src/verify/body_only.rs
@@ -776,7 +776,7 @@ impl RuntimeCompilation {
         let new_runtime = match host::HostVmPrototype::new(host::Config {
             module: code,
             heap_pages: self.heap_pages,
-            exec_hint: vm::ExecHint::CompileAheadOfTime,
+            exec_hint: vm::ExecHint::ValidateAndCompile, // TODO: let API user choose this
             allow_unresolved_imports: false,
         }) {
             Ok(vm) => vm,

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2533,13 +2533,16 @@ impl SuccessfulRuntime {
         let module = code.as_ref().ok_or(RuntimeError::CodeNotFound)?;
         let heap_pages = executor::storage_heap_pages_to_value(heap_pages.as_deref())
             .map_err(RuntimeError::InvalidHeapPages)?;
-        let exec_hint = executor::vm::ExecHint::CompileAheadOfTime;
+        // Because the runtime has been validated by at least the author of the block, we assume
+        // that it is valid. This significantly speeds up the compilation.
+        let exec_hint = executor::vm::ExecHint::CompileWithNonDeterministicValidation;
 
         // We try once with `allow_unresolved_imports: false`. If this fails due to unresolved
         // import, we try again but with `allowed_unresolved_imports: true`.
         // Having unresolved imports might cause errors later on, for example when validating
         // transactions or getting the parachain heads, but for now we continue the execution
         // and print a warning.
+        // TODO: should log the fact that we're compiling a runtime and the time it takes, as this is a heavy operation
         match executor::host::HostVmPrototype::new(executor::host::Config {
             module,
             heap_pages,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -960,7 +960,11 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 // Warp syncing compiles the runtime. The compiled runtime will later be yielded
                 // in the `WarpSyncFinished` variant, which is then provided as an event.
                 let before_instant = self.platform.now();
-                let (new_sync, error) = req.build(all::ExecHint::CompileAheadOfTime, true);
+                // Because the runtime being compiled has been validated by 2/3rds of the
+                // validators of the chain, we can assume that it is valid. Doing so significantly
+                // increases the compilation speed.
+                let (new_sync, error) =
+                    req.build(all::ExecHint::CompileWithNonDeterministicValidation, true);
                 let elapsed = self.platform.now() - before_instant;
                 match error {
                     Ok(()) => {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The WebAssembly runtime is now compiled lazily, meaning that only the code that is executed is validated and translated. Thanks to this, compiling a runtime is now four times faster and the time to head of the chain is around 200ms faster. ([#1488](https://github.com/smol-dot/smoldot/pull/1488))
+
 ## 2.0.14 - 2023-12-11
 
 ### Fixed


### PR DESCRIPTION
cc #864 

This PR shouldn't be merged as-is. The compilation mode should not always be `Lazy`. Instead, we should add a new `ExecHint`.

However I've done this change in order to measure how much faster it is.
To do so, I've measured three times how long it takes to compile the Westend runtime.

"Compile the Westend runtime" includes decoding the zstd-compressed runtime, parsing some custom Wasm sections, creating a `Module` (with wasmi), and creating an instance (with wasmi) but not executing it. So the times below are not just wasmi, but should still mainly be wasmi.

With wasmi v0.31:

264.161ms
195.032ms
210.432ms

With wasmi master branch (commit 86d097623592dc499852ea4bb01cace0097d70a4):

702.528ms
661.07ms
684.553ms

With wasmi master branch (commit 86d097623592dc499852ea4bb01cace0097d70a4) with compilation mode set to `Lazy` (this PR)

83.617ms
84.843ms
85.62ms

cc @Robbepop