### PR TITLE
Adjust log level of demo based on whether stdout is a TTY

### DIFF
--- a/wasm-node/javascript/demo/demo.mjs
+++ b/wasm-node/javascript/demo/demo.mjs
@@ -59,7 +59,7 @@ worker.postMessage(port2, [port2]);
 
 const client = smoldot.start({
     portToWorker: port1,
-    maxLogLevel: 3,  // Can be increased for more verbosity
+    maxLogLevel: process.stdout.isTTY ? 3 : 4,  // Can be modified manually for more verbosity
     forbidTcp: false,
     forbidWs: false,
     forbidNonLocalWs: false,


### PR DESCRIPTION
This PR concerns the small demo that I use for local development.

The log level is now automatically set to 4 if dumping the logs into a file, and remains at 3 if starting the demo in the terminal.
This is convenient.
