### PR TITLE
Yield the chain and peerid on request result

### DIFF
--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -316,9 +316,6 @@ struct Inner {
 
     /// Time between [`Inner::next_discovery`] and the follow-up discovery.
     next_discovery_period: Duration,
-
-    /// List of Kademlia discovery operations that have been started but not finished yet.
-    kademlia_find_nodes_requests: HashMap<service::SubstreamId, ChainId, fnv::FnvBuildHasher>,
 }
 
 /// Extra information of a chain.
@@ -505,10 +502,6 @@ impl NetworkService {
             ),
             call_proof_requests: hashbrown::HashMap::with_capacity_and_hasher(
                 5, // TODO: ?
-                Default::default(),
-            ),
-            kademlia_find_nodes_requests: hashbrown::HashMap::with_capacity_and_hasher(
-                4,
                 Default::default(),
             ),
             jaeger_service: config.jaeger_service.clone(),
@@ -1036,20 +1029,15 @@ async fn background_task(mut inner: Inner) {
                         .cloned();
 
                     if let Some(target) = target {
-                        let substream_id = match inner.network.start_kademlia_find_node_request(
+                        match inner.network.start_kademlia_find_node_request(
                             &target,
                             chain_id,
                             &random_peer_id,
                             Duration::from_secs(20),
                         ) {
-                            Ok(s) => s,
+                            Ok(_) => {}
                             Err(service::StartRequestError::NoConnection) => unreachable!(),
                         };
-
-                        let _prev_value = inner
-                            .kademlia_find_nodes_requests
-                            .insert(substream_id, chain_id);
-                        debug_assert!(_prev_value.is_none());
                     } else {
                         // TODO: log message
                     }
@@ -1684,15 +1672,17 @@ async fn background_task(mut inner: Inner) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::Blocks(response),
             }) => {
-                // TODO: print PeerId and chain name
                 match &response {
                     Ok(success) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
                             format!(
-                                "blocks-request-ended; outcome=success; response-blocks={}",
+                                "blocks-request-ended; outcome=success; peer_id={peer_id}; chain={}; response-blocks={}",
+                                inner.network[chain_id].log_name,
                                 success.len()
                             ),
                         );
@@ -1700,7 +1690,8 @@ async fn background_task(mut inner: Inner) {
                     Err(err) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
-                            format!("blocks-request-ended; outcome=failure; error={}", err),
+                            format!("blocks-request-ended; outcome=failure; peer_id={peer_id}; chain={}; error={}",
+                            inner.network[chain_id].log_name, err),
                         );
                     }
                 }
@@ -1713,16 +1704,18 @@ async fn background_task(mut inner: Inner) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::GrandpaWarpSync(response),
             }) => {
-                // TODO: print PeerId and chain name
                 match &response {
                     Ok(success) => {
                         let decoded = success.decode();
                         inner.log_callback.log(
                             LogLevel::Debug,
                             format!(
-                                "warp-sync-request-ended; outcome=success; num-fragments={}; is-finished={:?}",
+                                "warp-sync-request-ended; outcome=success; peer_id={peer_id}; chain={}; num-fragments={}; is-finished={:?}",
+                                inner.network[chain_id].log_name,
                                 decoded.fragments.len(), decoded.is_finished,
                             ),
                         );
@@ -1730,7 +1723,8 @@ async fn background_task(mut inner: Inner) {
                     Err(err) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
-                            format!("warp-sync-request-ended; outcome=failure; error={}", err),
+                            format!("warp-sync-request-ended; outcome=failure; peer_id={peer_id}; chain={}; error={}",
+                            inner.network[chain_id].log_name, err),
                         );
                     }
                 }
@@ -1743,15 +1737,17 @@ async fn background_task(mut inner: Inner) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::StorageProof(response),
             }) => {
-                // TODO: print PeerId and chain name
                 match &response {
                     Ok(success) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
                             format!(
-                                "storage-request-ended; outcome=success; proof-size={}",
+                                "storage-request-ended; outcome=success; peer_id={peer_id}; chain={}; proof-size={}",
+                                inner.network[chain_id].log_name,
                                 BytesDisplay(u64::try_from(success.decode().len()).unwrap()),
                             ),
                         );
@@ -1759,7 +1755,10 @@ async fn background_task(mut inner: Inner) {
                     Err(err) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
-                            format!("storage-request-ended; outcome=failure; error={}", err),
+                            format!(
+                                "storage-request-ended; outcome=failure; peer_id={peer_id}; chain={}; error={}",
+                                inner.network[chain_id].log_name, err
+                            ),
                         );
                     }
                 }
@@ -1772,15 +1771,17 @@ async fn background_task(mut inner: Inner) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::CallProof(response),
             }) => {
-                // TODO: print PeerId and chain name
                 match &response {
                     Ok(success) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
                             format!(
-                                "call-proof-request-ended; outcome=success; proof-size={}",
+                                "call-proof-request-ended; outcome=success; peer_id={peer_id}; chain={}; proof-size={}",
+                                inner.network[chain_id].log_name,
                                 BytesDisplay(u64::try_from(success.decode().len()).unwrap()),
                             ),
                         );
@@ -1788,7 +1789,11 @@ async fn background_task(mut inner: Inner) {
                     Err(err) => {
                         inner.log_callback.log(
                             LogLevel::Debug,
-                            format!("call-proof-request-ended; outcome=failure; error={}", err),
+                            format!(
+                                "call-proof-request-ended; outcome=failure; peer_id={peer_id}; chain={}; error={}",
+                                inner.network[chain_id].log_name,
+                                err
+                            ),
                         );
                     }
                 }
@@ -1800,14 +1805,11 @@ async fn background_task(mut inner: Inner) {
                     .send(response.map_err(|_| ()));
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
-                substream_id,
+                peer_id: kademlia_request_target,
+                chain_id,
                 response: service::RequestResult::KademliaFindNode(Ok(nodes)),
+                ..
             }) => {
-                let chain_id = inner
-                    .kademlia_find_nodes_requests
-                    .remove(&substream_id)
-                    .unwrap();
-
                 for (peer_id, addrs) in nodes {
                     let mut valid_addrs = Vec::with_capacity(addrs.len());
                     for addr in addrs {
@@ -1817,7 +1819,7 @@ async fn background_task(mut inner: Inner) {
                                 inner.log_callback.log(
                                     LogLevel::Debug,
                                     format!(
-                                        "discovery-invalid-address; error={error}, addr={}",
+                                        "discovery-invalid-address; error={error}, addr={}, discovered_from={kademlia_request_target}",
                                         hex::encode(&addr)
                                     ),
                                 );
@@ -1850,7 +1852,7 @@ async fn background_task(mut inner: Inner) {
                         inner.log_callback.log(
                             LogLevel::Debug,
                             format!(
-                                "discovered; chain={}; peer_id={peer_id}; address={addr}",
+                                "discovered; chain={}; peer_id={peer_id}; address={addr}; discovered_from={kademlia_request_target}",
                                 inner.network[chain_id].log_name
                             ),
                         );
@@ -1872,18 +1874,16 @@ async fn background_task(mut inner: Inner) {
                 }
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
-                substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::KademliaFindNode(Err(error)),
+                ..
             }) => {
-                let chain_id = inner
-                    .kademlia_find_nodes_requests
-                    .remove(&substream_id)
-                    .unwrap();
                 inner.log_callback.log(
                     LogLevel::Debug,
                     format!(
-                        "discovery-error; chain={}; error={}",
-                        inner.network[chain_id].log_name, error
+                        "discovery-error; chain={}; peer_id={peer_id}; error={error}",
+                        inner.network[chain_id].log_name
                     ),
                 );
             }

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -1523,40 +1523,50 @@ where
                         .substreams
                         .remove(&substream_id)
                         .unwrap_or_else(|| unreachable!());
+                    let peer_index = *self.inner[substream_info.connection_id]
+                        .peer_index
+                        .as_ref()
+                        .unwrap_or_else(|| unreachable!());
 
                     // Decode/verify the response.
-                    let response = match substream_info.protocol {
+                    let (response, chain_index) = match substream_info.protocol {
                         None => continue,
                         Some(Protocol::Identify) => todo!(), // TODO: we don't send identify requests yet, so it's fine to leave this unimplemented
-                        Some(Protocol::Sync { .. }) => RequestResult::Blocks(
-                            response
-                                .map_err(BlocksRequestError::Request)
-                                .and_then(|response| {
-                                    codec::decode_block_response(&response)
-                                        .map_err(BlocksRequestError::Decode)
-                                }),
+                        Some(Protocol::Sync { chain_index, .. }) => (
+                            RequestResult::Blocks(
+                                response.map_err(BlocksRequestError::Request).and_then(
+                                    |response| {
+                                        codec::decode_block_response(&response)
+                                            .map_err(BlocksRequestError::Decode)
+                                    },
+                                ),
+                            ),
+                            chain_index,
                         ),
                         Some(Protocol::LightUnknown { .. }) => unreachable!(),
-                        Some(Protocol::LightStorage { .. }) => RequestResult::StorageProof(
-                            response
-                                .map_err(StorageProofRequestError::Request)
-                                .and_then(|payload| {
-                                    match codec::decode_storage_or_call_proof_response(
-                                        codec::StorageOrCallProof::StorageProof,
-                                        &payload,
-                                    ) {
-                                        Err(err) => Err(StorageProofRequestError::Decode(err)),
-                                        Ok(None) => {
-                                            Err(StorageProofRequestError::RemoteCouldntAnswer)
-                                        }
-                                        Ok(Some(_)) => Ok(EncodedMerkleProof(
-                                            payload,
+                        Some(Protocol::LightStorage { chain_index, .. }) => (
+                            RequestResult::StorageProof(
+                                response
+                                    .map_err(StorageProofRequestError::Request)
+                                    .and_then(|payload| {
+                                        match codec::decode_storage_or_call_proof_response(
                                             codec::StorageOrCallProof::StorageProof,
-                                        )),
-                                    }
-                                }),
+                                            &payload,
+                                        ) {
+                                            Err(err) => Err(StorageProofRequestError::Decode(err)),
+                                            Ok(None) => {
+                                                Err(StorageProofRequestError::RemoteCouldntAnswer)
+                                            }
+                                            Ok(Some(_)) => Ok(EncodedMerkleProof(
+                                                payload,
+                                                codec::StorageOrCallProof::StorageProof,
+                                            )),
+                                        }
+                                    }),
+                            ),
+                            chain_index,
                         ),
-                        Some(Protocol::LightCall { .. }) => {
+                        Some(Protocol::LightCall { chain_index, .. }) => (
                             RequestResult::CallProof(
                                 response.map_err(CallProofRequestError::Request).and_then(
                                     |payload| match codec::decode_storage_or_call_proof_response(
@@ -1571,46 +1581,58 @@ where
                                         )),
                                     },
                                 ),
-                            )
-                        }
-                        Some(Protocol::Kad { .. }) => RequestResult::KademliaFindNode(
-                            response
-                                .map_err(KademliaFindNodeError::RequestFailed)
-                                .and_then(|payload| {
-                                    match codec::decode_find_node_response(&payload) {
-                                        Err(err) => Err(KademliaFindNodeError::DecodeError(err)),
-                                        Ok(nodes) => Ok(nodes),
-                                    }
-                                }),
+                            ),
+                            chain_index,
                         ),
-                        Some(Protocol::SyncWarp { chain_index }) => RequestResult::GrandpaWarpSync(
-                            response
-                                .map_err(GrandpaWarpSyncRequestError::Request)
-                                .and_then(|message| {
-                                    if let Err(err) = codec::decode_grandpa_warp_sync_response(
-                                        &message,
-                                        self.chains[chain_index].block_number_bytes,
-                                    ) {
-                                        Err(GrandpaWarpSyncRequestError::Decode(err))
-                                    } else {
-                                        Ok(EncodedGrandpaWarpSyncResponse {
-                                            message,
-                                            block_number_bytes: self.chains[chain_index]
-                                                .block_number_bytes,
-                                        })
-                                    }
-                                }),
+                        Some(Protocol::Kad { chain_index, .. }) => (
+                            RequestResult::KademliaFindNode(
+                                response
+                                    .map_err(KademliaFindNodeError::RequestFailed)
+                                    .and_then(|payload| {
+                                        match codec::decode_find_node_response(&payload) {
+                                            Err(err) => {
+                                                Err(KademliaFindNodeError::DecodeError(err))
+                                            }
+                                            Ok(nodes) => Ok(nodes),
+                                        }
+                                    }),
+                            ),
+                            chain_index,
                         ),
-                        Some(Protocol::State { .. }) => RequestResult::State(
-                            response
-                                .map_err(StateRequestError::Request)
-                                .and_then(|payload| {
-                                    if let Err(err) = codec::decode_state_response(&payload) {
-                                        Err(StateRequestError::Decode(err))
-                                    } else {
-                                        Ok(EncodedStateResponse(payload))
-                                    }
-                                }),
+                        Some(Protocol::SyncWarp { chain_index }) => (
+                            RequestResult::GrandpaWarpSync(
+                                response
+                                    .map_err(GrandpaWarpSyncRequestError::Request)
+                                    .and_then(|message| {
+                                        if let Err(err) = codec::decode_grandpa_warp_sync_response(
+                                            &message,
+                                            self.chains[chain_index].block_number_bytes,
+                                        ) {
+                                            Err(GrandpaWarpSyncRequestError::Decode(err))
+                                        } else {
+                                            Ok(EncodedGrandpaWarpSyncResponse {
+                                                message,
+                                                block_number_bytes: self.chains[chain_index]
+                                                    .block_number_bytes,
+                                            })
+                                        }
+                                    }),
+                            ),
+                            chain_index,
+                        ),
+                        Some(Protocol::State { chain_index, .. }) => (
+                            RequestResult::State(
+                                response
+                                    .map_err(StateRequestError::Request)
+                                    .and_then(|payload| {
+                                        if let Err(err) = codec::decode_state_response(&payload) {
+                                            Err(StateRequestError::Decode(err))
+                                        } else {
+                                            Ok(EncodedStateResponse(payload))
+                                        }
+                                    }),
+                            ),
+                            chain_index,
                         ),
 
                         // The protocols below aren't request-response protocols.
@@ -1618,6 +1640,8 @@ where
                     };
 
                     return Some(Event::RequestResult {
+                        peer_id: self.peers[peer_index.0].clone(),
+                        chain_id: ChainId(chain_index),
                         substream_id,
                         response,
                     });
@@ -4263,6 +4287,10 @@ pub enum Event<TConn> {
 
     /// An outgoing request has finished, either successfully or not.
     RequestResult {
+        /// Peer that has answered the request.
+        peer_id: PeerId,
+        /// Index of the chain the request relates to.
+        chain_id: ChainId,
         /// Identifier of the request that was returned by the function that started the request.
         substream_id: SubstreamId,
         /// Outcome of the request.

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -199,7 +199,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
             call_proof_requests: HashMap::with_capacity_and_hasher(8, Default::default()),
             next_discovery_period: Duration::from_secs(5),
             next_discovery: Box::pin(config.platform.sleep(Duration::from_secs(5))),
-            kademlia_find_node_requests: HashMap::with_capacity_and_hasher(2, Default::default()),
         }));
 
         config
@@ -221,8 +220,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
     /// references to [`NetworkServiceChain`] are destroyed, the network service automatically
     /// purges that chain.
     pub fn add_chain(&self, config: ConfigChain) -> Arc<NetworkServiceChain<TPlat>> {
-        let log_name = config.log_name.clone();
-
         let (messages_tx, messages_rx) = async_channel::bounded(32);
 
         // TODO: this code is hacky because we don't want to make `add_chain` async at the moment, because it's not convenient for lib.rs
@@ -243,7 +240,7 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
                 role: Role::Light,
                 allow_inbound_block_requests: false,
                 user_data: Chain {
-                    log_name: config.log_name.clone(),
+                    log_name: config.log_name,
                     block_number_bytes: config.block_number_bytes,
                     num_out_slots: config.num_out_slots,
                     num_references: NonZeroUsize::new(1).unwrap(),
@@ -263,7 +260,6 @@ impl<TPlat: PlatformRef> NetworkService<TPlat> {
 
         Arc::new(NetworkServiceChain {
             _keep_alive_messages_tx: self.messages_tx.clone(),
-            log_name,
             messages_tx,
             marker: core::marker::PhantomData,
         })
@@ -274,9 +270,6 @@ pub struct NetworkServiceChain<TPlat: PlatformRef> {
     /// Copy of [`NetworkService::messages_tx`]. Used in order to maintain the network service
     /// background task alive.
     _keep_alive_messages_tx: async_channel::Sender<ToBackground>,
-
-    /// Logging name of the chain.
-    log_name: String,
 
     /// Channel to send messages to the background task.
     messages_tx: async_channel::Sender<ToBackgroundChain>,
@@ -338,52 +331,7 @@ impl<TPlat: PlatformRef> NetworkServiceChain<TPlat> {
             .await
             .unwrap();
 
-        let result = rx.await.unwrap();
-
-        match &result {
-            Ok(blocks) => {
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => BlocksRequest(chain={}, num_blocks={}, block_data_total_size={})",
-                    target,
-                    self.log_name,
-                    blocks.len(),
-                    BytesDisplay(blocks.iter().fold(0, |sum, block| {
-                        let block_size = block.header.as_ref().map_or(0, |h| h.len()) +
-                            block.body.as_ref().map_or(0, |b| b.iter().fold(0, |s, e| s + e.len())) +
-                            block.justifications.as_ref().into_iter().flat_map(|l| l.iter()).fold(0, |s, j| s + j.justification.len());
-                        sum + u64::try_from(block_size).unwrap()
-                    }))
-                );
-            }
-            Err(err) => {
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => BlocksRequest(chain={}, error={:?})",
-                    target,
-                    self.log_name,
-                    err
-                );
-            }
-        }
-
-        if !log::log_enabled!(log::Level::Debug) {
-            match &result {
-                Ok(_) | Err(BlocksRequestError::NoConnection) => {}
-                Err(BlocksRequestError::Request(service::BlocksRequestError::Request(err)))
-                    if !err.is_protocol_error() => {}
-                Err(err) => {
-                    log::warn!(
-                        target: "network",
-                        "Error in block request with {}. This might indicate an incompatibility. Error: {}",
-                        target,
-                        err
-                    );
-                }
-            }
-        }
-
-        result
+        rx.await.unwrap()
     }
 
     /// Sends a grandpa warp sync request to the given peer.
@@ -406,33 +354,7 @@ impl<TPlat: PlatformRef> NetworkServiceChain<TPlat> {
             .await
             .unwrap();
 
-        let result = rx.await.unwrap();
-
-        match &result {
-            Ok(response) => {
-                // TODO: print total bytes size
-                let decoded = response.decode();
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => WarpSyncRequest(chain={}, num_fragments={}, finished={:?})",
-                    target,
-                    self.log_name,
-                    decoded.fragments.len(),
-                    decoded.is_finished,
-                );
-            }
-            Err(err) => {
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => WarpSyncRequest(chain={}, error={:?})",
-                    target,
-                    self.log_name,
-                    err,
-                );
-            }
-        }
-
-        result
+        rx.await.unwrap()
     }
 
     pub async fn set_local_best_block(&self, best_hash: [u8; 32], best_number: u64) {
@@ -479,31 +401,7 @@ impl<TPlat: PlatformRef> NetworkServiceChain<TPlat> {
             .await
             .unwrap();
 
-        let result = rx.await.unwrap();
-
-        match &result {
-            Ok(items) => {
-                let decoded = items.decode();
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => StorageProofRequest(chain={}, total_size={})",
-                    target,
-                    self.log_name,
-                    BytesDisplay(u64::try_from(decoded.len()).unwrap()),
-                );
-            }
-            Err(err) => {
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => StorageProofRequest(chain={}, error={:?})",
-                    target,
-                    self.log_name,
-                    err
-                );
-            }
-        }
-
-        result
+        rx.await.unwrap()
     }
 
     /// Sends a call proof request to the given peer.
@@ -536,31 +434,7 @@ impl<TPlat: PlatformRef> NetworkServiceChain<TPlat> {
             .await
             .unwrap();
 
-        let result = rx.await.unwrap();
-
-        match &result {
-            Ok(items) => {
-                let decoded = items.decode();
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => CallProofRequest({}, total_size: {})",
-                    target,
-                    self.log_name,
-                    BytesDisplay(u64::try_from(decoded.len()).unwrap())
-                );
-            }
-            Err(err) => {
-                log::debug!(
-                    target: "network",
-                    "Connections({}) => CallProofRequest({}, {})",
-                    target,
-                    self.log_name,
-                    err
-                );
-            }
-        }
-
-        result
+        rx.await.unwrap()
     }
 
     /// Announces transaction to the peers we are connected to.
@@ -921,8 +795,6 @@ struct BackgroundTask<TPlat: PlatformRef> {
     next_discovery_period: Duration,
 
     next_discovery: Pin<Box<TPlat::Delay>>,
-
-    kademlia_find_node_requests: HashMap<service::SubstreamId, ChainId, fnv::FnvBuildHasher>,
 }
 
 struct Chain {
@@ -1253,10 +1125,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     debug_assert!(_was_in.is_some());
                 }
 
-                // TODO: this is O(n)
-                task.kademlia_find_node_requests
-                    .retain(|_, c| *c != chain_id);
-
                 log::debug!(target: "network", "Chains <= RemoveChain(id={})", task.network[chain_id].log_name);
                 task.network.remove_chain(chain_id).unwrap();
                 task.peering_strategy.remove_chain_peers(&chain_id);
@@ -1273,37 +1141,43 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     result,
                 },
             ) => {
+                match &config.start {
+                    codec::BlocksRequestConfigStart::Hash(hash) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) <= BlocksRequest(chain={}, start={}, num={}, descending={:?}, header={:?}, body={:?}, justifications={:?})",
+                            target, task.network[chain_id].log_name, HashDisplay(hash),
+                            config.desired_count.get(),
+                            matches!(config.direction, codec::BlocksRequestDirection::Descending),
+                            config.fields.header, config.fields.body, config.fields.justifications
+                        );
+                    }
+                    codec::BlocksRequestConfigStart::Number(number) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) <= BlocksRequest(chain={}, start=#{}, num={}, descending={:?}, header={:?}, body={:?}, justifications={:?})",
+                            target, task.network[chain_id].log_name, number,
+                            config.desired_count.get(),
+                            matches!(config.direction, codec::BlocksRequestDirection::Descending),
+                            config.fields.header, config.fields.body, config.fields.justifications
+                        );
+                    }
+                }
+
                 match task
                     .network
                     .start_blocks_request(&target, chain_id, config.clone(), timeout)
                 {
                     Ok(substream_id) => {
-                        match &config.start {
-                            codec::BlocksRequestConfigStart::Hash(hash) => {
-                                log::debug!(
-                                    target: "network",
-                                    "Connections({}) <= BlocksRequest(chain={}, start={}, num={}, descending={:?}, header={:?}, body={:?}, justifications={:?})",
-                                    target, task.network[chain_id].log_name, HashDisplay(hash),
-                                    config.desired_count.get(),
-                                    matches!(config.direction, codec::BlocksRequestDirection::Descending),
-                                    config.fields.header, config.fields.body, config.fields.justifications
-                                );
-                            }
-                            codec::BlocksRequestConfigStart::Number(number) => {
-                                log::debug!(
-                                    target: "network",
-                                    "Connections({}) <= BlocksRequest(chain={}, start=#{}, num={}, descending={:?}, header={:?}, body={:?}, justifications={:?})",
-                                    target, task.network[chain_id].log_name, number,
-                                    config.desired_count.get(),
-                                    matches!(config.direction, codec::BlocksRequestDirection::Descending),
-                                    config.fields.header, config.fields.body, config.fields.justifications
-                                );
-                            }
-                        }
-
                         task.blocks_requests.insert(substream_id, result);
                     }
                     Err(service::StartRequestError::NoConnection) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => BlocksRequest(chain={}, error=NoConnection)",
+                            target,
+                            task.network[chain_id].log_name,
+                        );
                         let _ = result.send(Err(BlocksRequestError::NoConnection));
                     }
                 }
@@ -1317,19 +1191,25 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     result,
                 },
             ) => {
+                log::debug!(
+                    target: "network", "Connections({}) <= WarpSyncRequest(chain={}, start={})",
+                    target, task.network[chain_id].log_name, HashDisplay(&begin_hash)
+                );
+
                 match task
                     .network
                     .start_grandpa_warp_sync_request(&target, chain_id, begin_hash, timeout)
                 {
                     Ok(substream_id) => {
-                        log::debug!(
-                            target: "network", "Connections({}) <= WarpSyncRequest(chain={}, start={})",
-                            target, task.network[chain_id].log_name, HashDisplay(&begin_hash)
-                        );
-
                         task.grandpa_warp_sync_requests.insert(substream_id, result);
                     }
                     Err(service::StartRequestError::NoConnection) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => WarpSyncRequest(chain={}, error=NoConnection)",
+                            target,
+                            task.network[chain_id].log_name,
+                        );
                         let _ = result.send(Err(WarpSyncRequestError::NoConnection));
                     }
                 }
@@ -1343,6 +1223,14 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     result,
                 },
             ) => {
+                log::debug!(
+                    target: "network",
+                    "Connections({}) <= StorageProofRequest(chain={}, block={})",
+                    target,
+                    task.network[chain_id].log_name,
+                    HashDisplay(&config.block_hash)
+                );
+
                 match task.network.start_storage_proof_request(
                     &target,
                     chain_id,
@@ -1350,20 +1238,22 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     timeout,
                 ) {
                     Ok(substream_id) => {
-                        log::debug!(
-                            target: "network",
-                            "Connections({}) <= StorageProofRequest(chain={}, block={})",
-                            target,
-                            task.network[chain_id].log_name,
-                            HashDisplay(&config.block_hash)
-                        );
-
                         task.storage_proof_requests.insert(substream_id, result);
                     }
                     Err(service::StartRequestMaybeTooLargeError::NoConnection) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({target}) => StorageProofRequest(chain={}, error=NoConnection)",
+                            task.network[chain_id].log_name,
+                        );
                         let _ = result.send(Err(StorageProofRequestError::NoConnection));
                     }
                     Err(service::StartRequestMaybeTooLargeError::RequestTooLarge) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({target}) => StorageProofRequest(chain={}, error=RequestTooLarge)",
+                            task.network[chain_id].log_name,
+                        );
                         let _ = result.send(Err(StorageProofRequestError::RequestTooLarge));
                     }
                 };
@@ -1377,6 +1267,15 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     result,
                 },
             ) => {
+                log::debug!(
+                    target: "network",
+                    "Connections({}) <= CallProofRequest({}, {}, {})",
+                    target,
+                    task.network[chain_id].log_name,
+                    HashDisplay(&config.block_hash),
+                    config.method
+                );
+
                 match task.network.start_call_proof_request(
                     &target,
                     chain_id,
@@ -1384,21 +1283,22 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     timeout,
                 ) {
                     Ok(substream_id) => {
-                        log::debug!(
-                            target: "network",
-                            "Connections({}) <= CallProofRequest({}, {}, {})",
-                            target,
-                            task.network[chain_id].log_name,
-                            HashDisplay(&config.block_hash),
-                            config.method
-                        );
-
                         task.call_proof_requests.insert(substream_id, result);
                     }
                     Err(service::StartRequestMaybeTooLargeError::NoConnection) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({target}) => CallProofRequest({}, NoConnection)",
+                            task.network[chain_id].log_name
+                        );
                         let _ = result.send(Err(CallProofRequestError::NoConnection));
                     }
                     Err(service::StartRequestMaybeTooLargeError::RequestTooLarge) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({target}) => CallProofRequest({}, RequestTooLarge)",
+                            task.network[chain_id].log_name
+                        );
                         let _ = result.send(Err(CallProofRequestError::RequestTooLarge));
                     }
                 };
@@ -1566,13 +1466,13 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                         .cloned();
 
                     if let Some(target) = target {
-                        let substream_id = match task.network.start_kademlia_find_node_request(
+                        match task.network.start_kademlia_find_node_request(
                             &target,
                             chain_id,
                             &random_peer_id,
                             Duration::from_secs(20),
                         ) {
-                            Ok(s) => s,
+                            Ok(_) => {}
                             Err(service::StartRequestError::NoConnection) => unreachable!(),
                         };
 
@@ -1583,11 +1483,6 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             target,
                             random_peer_id
                         );
-
-                        let _prev_value = task
-                            .kademlia_find_node_requests
-                            .insert(substream_id, chain_id);
-                        debug_assert!(_prev_value.is_none());
                     } else {
                         log::debug!(
                             target: "network",
@@ -1863,8 +1758,53 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::Blocks(response),
             }) => {
+                match &response {
+                    Ok(blocks) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => BlocksRequest(chain={}, num_blocks={}, block_data_total_size={})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            blocks.len(),
+                            BytesDisplay(blocks.iter().fold(0, |sum, block| {
+                                let block_size = block.header.as_ref().map_or(0, |h| h.len()) +
+                                    block.body.as_ref().map_or(0, |b| b.iter().fold(0, |s, e| s + e.len())) +
+                                    block.justifications.as_ref().into_iter().flat_map(|l| l.iter()).fold(0, |s, j| s + j.justification.len());
+                                sum + u64::try_from(block_size).unwrap()
+                            }))
+                        );
+                    }
+                    Err(err) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => BlocksRequest(chain={}, error={:?})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            err
+                        );
+                    }
+                }
+
+                if !log::log_enabled!(log::Level::Debug) {
+                    match &response {
+                        Ok(_) => {}
+                        Err(service::BlocksRequestError::Request(err))
+                            if !err.is_protocol_error() => {}
+                        Err(err) => {
+                            log::warn!(
+                                target: "network",
+                                "Error in block request with {}. This might indicate an incompatibility. Error: {}",
+                                peer_id,
+                                err
+                            );
+                        }
+                    }
+                }
+
                 let _ = task
                     .blocks_requests
                     .remove(&substream_id)
@@ -1873,8 +1813,34 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::GrandpaWarpSync(response),
             }) => {
+                match &response {
+                    Ok(response) => {
+                        // TODO: print total bytes size
+                        let decoded = response.decode();
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => WarpSyncRequest(chain={}, num_fragments={}, finished={:?})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            decoded.fragments.len(),
+                            decoded.is_finished,
+                        );
+                    }
+                    Err(err) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => WarpSyncRequest(chain={}, error={:?})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            err,
+                        );
+                    }
+                }
+
                 let _ = task
                     .grandpa_warp_sync_requests
                     .remove(&substream_id)
@@ -1883,8 +1849,30 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::StorageProof(response),
             }) => {
+                match &response {
+                    Ok(items) => {
+                        let decoded = items.decode();
+                        log::debug!(
+                            target: "network",
+                            "Connections({peer_id}) => StorageProofRequest(chain={}, total_size={})",
+                            task.network[chain_id].log_name,
+                            BytesDisplay(u64::try_from(decoded.len()).unwrap()),
+                        );
+                    }
+                    Err(err) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({peer_id}) => StorageProofRequest(chain={}, error={:?})",
+                            task.network[chain_id].log_name,
+                            err
+                        );
+                    }
+                }
+
                 let _ = task
                     .storage_proof_requests
                     .remove(&substream_id)
@@ -1893,8 +1881,32 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
                 substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::CallProof(response),
             }) => {
+                match &response {
+                    Ok(items) => {
+                        let decoded = items.decode();
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => CallProofRequest({}, total_size: {})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            BytesDisplay(u64::try_from(decoded.len()).unwrap())
+                        );
+                    }
+                    Err(err) => {
+                        log::debug!(
+                            target: "network",
+                            "Connections({}) => CallProofRequest({}, {})",
+                            peer_id,
+                            task.network[chain_id].log_name,
+                            err
+                        );
+                    }
+                }
+
                 let _ = task
                     .call_proof_requests
                     .remove(&substream_id)
@@ -1902,14 +1914,11 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                     .send(response.map_err(CallProofRequestError::Request));
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
-                substream_id,
+                peer_id: requestee_peer_id,
+                chain_id,
                 response: service::RequestResult::KademliaFindNode(Ok(nodes)),
+                ..
             }) => {
-                let chain_id = task
-                    .kademlia_find_node_requests
-                    .remove(&substream_id)
-                    .unwrap();
-
                 for (peer_id, mut addrs) in nodes {
                     // Make sure to not insert too many address for a single peer.
                     // While the .
@@ -1931,7 +1940,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                 } else {
                                     log::debug!(
                                         target: "network",
-                                        "Discovery({}) => UnsupportedAddress(peer_id={}, addr={})",
+                                        "Discovery({}) => UnsupportedAddress(peer_id={}, addr={}, obtained_from={requestee_peer_id})",
                                         &task.network[chain_id].log_name,
                                         peer_id,
                                         &a
@@ -1941,7 +1950,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             Err((err, addr)) => {
                                 log::debug!(
                                     target: "network",
-                                    "Discovery({}) => InvalidAddress(peer_id={}, error={}, addr={})",
+                                    "Discovery({}) => InvalidAddress(peer_id={}, error={}, addr={}, obtained_from={requestee_peer_id})",
                                     &task.network[chain_id].log_name,
                                     peer_id,
                                     err,
@@ -1971,7 +1980,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             }
 
                             log::debug!(
-                                target: "network", "Discovery({}) => NewPeer(peer_id={}, addr={})",
+                                target: "network", "Discovery({}) => NewPeer(peer_id={}, addr={}, obtained_from={requestee_peer_id})",
                                 &task.network[chain_id].log_name,
                                 peer_id,
                                 valid_addrs.iter().map(|a| a.to_string()).join(", addr=")
@@ -1991,17 +2000,14 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                 }
             }
             WakeUpReason::NetworkEvent(service::Event::RequestResult {
-                substream_id,
+                peer_id,
+                chain_id,
                 response: service::RequestResult::KademliaFindNode(Err(error)),
+                ..
             }) => {
-                let chain_id = task
-                    .kademlia_find_node_requests
-                    .remove(&substream_id)
-                    .unwrap();
-
                 log::debug!(
                     target: "network",
-                    "Discovery({}) => FindNodeError(error={:?})",
+                    "Discovery({}) => FindNodeError(error={:?}, find_node_target={peer_id})",
                     &task.network[chain_id].log_name,
                     error
                 );


### PR DESCRIPTION
The networking state machine now yields back the `PeerId` and `ChainId` when a request is over.

This makes it possible to better log the requests responses. In the light client, we now print the logging in the background service rather than in the foreground, which properly accounts for request cancellations.
It also allows getting rid of the `kademlia_find_nodes_requests` field.
