### PR TITLE
Add `SqliteFullDatabase::reset`

### DIFF
--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -1326,6 +1326,202 @@ impl SqliteFullDatabase {
 
         Ok(merkle_value)
     }
+
+    /// Inserts a block in the database and sets it as the finalized block.
+    ///
+    /// The parent of the block doesn't need to be present in the database.
+    ///
+    /// If the block is already in the database, it is replaced by the one provided.
+    pub fn reset<'a>(
+        &self,
+        chain_information: impl Into<chain_information::ChainInformationRef<'a>>,
+        finalized_block_body: impl ExactSizeIterator<Item = &'a [u8]>,
+        finalized_block_justification: Option<Vec<u8>>,
+    ) -> Result<(), CorruptedError> {
+        // Start a transaction to insert everything in one go.
+        let mut database = self.database.lock();
+        let transaction = database
+            .transaction()
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
+
+        // Temporarily disable foreign key checks in order to make the initial insertion easier,
+        // as we don't have to make sure that trie nodes are sorted.
+        // Note that this is immediately disabled again when we `COMMIT`.
+        transaction
+            .execute("PRAGMA defer_foreign_keys = ON", ())
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
+
+        let chain_information = chain_information.into();
+
+        let finalized_block_hash = chain_information
+            .finalized_block_header
+            .hash(self.block_number_bytes);
+
+        let scale_encoded_finalized_block_header = chain_information
+            .finalized_block_header
+            .scale_encoding(self.block_number_bytes)
+            .fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            });
+
+        transaction
+            .prepare_cached(
+                "INSERT OR REPLACE INTO blocks(hash, parent_hash, state_trie_root_hash, number, header, is_best_chain, justification) VALUES(?, ?, ?, ?, ?, TRUE, ?)",
+            )
+            .unwrap()
+            .execute((
+                &finalized_block_hash[..],
+                if chain_information.finalized_block_header.number != 0 {
+                    Some(&chain_information.finalized_block_header.parent_hash[..])
+                } else { None },
+                &chain_information.finalized_block_header.state_root[..],
+                i64::try_from(chain_information.finalized_block_header.number).unwrap(),
+                &scale_encoded_finalized_block_header[..],
+                finalized_block_justification.as_deref(),
+            ))
+            .unwrap();
+
+        transaction
+            .execute(
+                "DELETE FROM blocks_body WHERE hash = ?",
+                (&finalized_block_hash[..],),
+            )
+            .unwrap();
+
+        {
+            let mut statement = transaction
+                .prepare_cached(
+                    "INSERT OR IGNORE INTO blocks_body(hash, idx, extrinsic) VALUES(?, ?, ?)",
+                )
+                .unwrap();
+            for (index, item) in finalized_block_body.enumerate() {
+                statement
+                    .execute((
+                        &finalized_block_hash[..],
+                        i64::try_from(index).unwrap(),
+                        item,
+                    ))
+                    .unwrap();
+            }
+        }
+
+        meta_set_blob(&transaction, "best", &finalized_block_hash[..]).unwrap();
+        meta_set_number(
+            &transaction,
+            "finalized",
+            chain_information.finalized_block_header.number,
+        )?;
+
+        meta_clear(&transaction, "grandpa_authorities_set_id")?;
+        meta_clear(&transaction, "grandpa_scheduled_target")?;
+        transaction
+            .execute("DELETE FROM grandpa_triggered_authorities WHERE TRUE;", ())
+            .unwrap();
+        transaction
+            .execute("DELETE FROM grandpa_scheduled_authorities WHERE TRUE;", ())
+            .unwrap();
+
+        match &chain_information.finality {
+            chain_information::ChainInformationFinalityRef::Outsourced => {}
+            chain_information::ChainInformationFinalityRef::Grandpa {
+                finalized_triggered_authorities,
+                after_finalized_block_authorities_set_id,
+                finalized_scheduled_change,
+            } => {
+                meta_set_number(
+                    &transaction,
+                    "grandpa_authorities_set_id",
+                    *after_finalized_block_authorities_set_id,
+                )?;
+
+                let mut statement = transaction
+                    .prepare_cached("INSERT INTO grandpa_triggered_authorities(idx, public_key, weight) VALUES(?, ?, ?)")
+                    .unwrap();
+                for (index, item) in finalized_triggered_authorities.iter().enumerate() {
+                    statement
+                        .execute((
+                            i64::try_from(index).unwrap(),
+                            &item.public_key[..],
+                            i64::from_ne_bytes(item.weight.get().to_ne_bytes()),
+                        ))
+                        .unwrap();
+                }
+
+                if let Some((height, list)) = finalized_scheduled_change {
+                    meta_set_number(&transaction, "grandpa_scheduled_target", *height)?;
+
+                    let mut statement = transaction
+                        .prepare_cached("INSERT INTO grandpa_scheduled_authorities(idx, public_key, weight) VALUES(?, ?, ?)")
+                        .unwrap();
+                    for (index, item) in list.iter().enumerate() {
+                        statement
+                            .execute((
+                                i64::try_from(index).unwrap(),
+                                &item.public_key[..],
+                                i64::from_ne_bytes(item.weight.get().to_ne_bytes()),
+                            ))
+                            .unwrap();
+                    }
+                }
+            }
+        }
+
+        meta_clear(&transaction, "aura_slot_duration")?;
+        transaction
+            .execute("DELETE FROM aura_finalized_authorities WHERE TRUE;", ())
+            .unwrap();
+        meta_clear(&transaction, "babe_slots_per_epoch")?;
+        meta_clear(&transaction, "babe_finalized_next_epoch")?;
+        meta_clear(&transaction, "babe_finalized_epoch")?;
+
+        match &chain_information.consensus {
+            chain_information::ChainInformationConsensusRef::Unknown => {}
+            chain_information::ChainInformationConsensusRef::Aura {
+                finalized_authorities_list,
+                slot_duration,
+            } => {
+                meta_set_number(&transaction, "aura_slot_duration", slot_duration.get()).unwrap();
+
+                let mut statement = transaction
+                    .prepare_cached(
+                        "INSERT INTO aura_finalized_authorities(idx, public_key) VALUES(?, ?)",
+                    )
+                    .unwrap();
+                for (index, item) in finalized_authorities_list.clone().enumerate() {
+                    statement
+                        .execute((i64::try_from(index).unwrap(), &item.public_key[..]))
+                        .unwrap();
+                }
+            }
+            chain_information::ChainInformationConsensusRef::Babe {
+                slots_per_epoch,
+                finalized_next_epoch_transition,
+                finalized_block_epoch_information,
+            } => {
+                meta_set_number(&transaction, "babe_slots_per_epoch", slots_per_epoch.get())
+                    .unwrap();
+                meta_set_blob(
+                    &transaction,
+                    "babe_finalized_next_epoch",
+                    &encode_babe_epoch_information(finalized_next_epoch_transition.clone())[..],
+                )
+                .unwrap();
+
+                if let Some(finalized_block_epoch_information) = finalized_block_epoch_information {
+                    meta_set_blob(&transaction, "babe_finalized_epoch", &encode_babe_epoch_information(
+                    finalized_block_epoch_information.clone(),
+                    )[..]).unwrap();
+                }
+            }
+        }
+
+        transaction
+            .commit()
+            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
+
+        Ok(())
+    }
 }
 
 impl fmt::Debug for SqliteFullDatabase {
@@ -1462,6 +1658,15 @@ fn meta_get_number(
         .optional()
         .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
     Ok(value.map(|value| u64::from_ne_bytes(value.to_ne_bytes())))
+}
+
+fn meta_clear(database: &rusqlite::Connection, key: &str) -> Result<(), CorruptedError> {
+    database
+        .prepare_cached(r#"DELETE FROM meta WHERE key = ?"#)
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?
+        .execute((key,))
+        .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
+    Ok(())
 }
 
 fn meta_set_blob(

--- a/lib/src/database/full_sqlite/open.rs
+++ b/lib/src/database/full_sqlite/open.rs
@@ -21,7 +21,7 @@
 
 // TODO:remove all the unwraps in this module that shouldn't be there
 
-use super::{encode_babe_epoch_information, CorruptedError, InternalError, SqliteFullDatabase};
+use super::{CorruptedError, InternalError, SqliteFullDatabase};
 use crate::chain::chain_information;
 
 use std::path::Path;
@@ -198,8 +198,7 @@ CREATE TABLE blocks(
     header BLOB NOT NULL,
     justification BLOB,
     is_best_chain BOOLEAN NOT NULL,
-    UNIQUE(number, hash),
-    FOREIGN KEY (parent_hash) REFERENCES blocks(hash) ON UPDATE RESTRICT ON DELETE NO ACTION
+    UNIQUE(number, hash)
 );
 CREATE INDEX blocks_by_number ON blocks(number);
 CREATE INDEX blocks_by_parent ON blocks(parent_hash);
@@ -336,171 +335,22 @@ impl DatabaseEmpty {
     ///
     /// Must also pass the body and justification of the finalized block.
     pub fn initialize<'a>(
-        mut self,
+        self,
         chain_information: impl Into<chain_information::ChainInformationRef<'a>>,
         finalized_block_body: impl ExactSizeIterator<Item = &'a [u8]>,
         finalized_block_justification: Option<Vec<u8>>,
     ) -> Result<SqliteFullDatabase, CorruptedError> {
-        // Start a transaction to insert everything in one go.
-        let transaction = self
-            .database
-            .transaction()
-            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
-
-        // Temporarily disable foreign key checks in order to make the initial insertion easier,
-        // as we don't have to make sure that trie nodes are sorted.
-        // Note that this is immediately disabled again when we `COMMIT`.
-        transaction
-            .execute("PRAGMA defer_foreign_keys = ON", ())
-            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
-
-        let chain_information = chain_information.into();
-
-        let finalized_block_hash = chain_information
-            .finalized_block_header
-            .hash(self.block_number_bytes);
-
-        let scale_encoded_finalized_block_header = chain_information
-            .finalized_block_header
-            .scale_encoding(self.block_number_bytes)
-            .fold(Vec::new(), |mut a, b| {
-                a.extend_from_slice(b.as_ref());
-                a
-            });
-
-        transaction
-            .prepare_cached(
-                "INSERT INTO blocks(hash, parent_hash, state_trie_root_hash, number, header, is_best_chain, justification) VALUES(?, ?, ?, ?, ?, TRUE, ?)",
-            )
-            .unwrap()
-            .execute((
-                &finalized_block_hash[..],
-                if chain_information.finalized_block_header.number != 0 {
-                    Some(&chain_information.finalized_block_header.parent_hash[..])
-                } else { None },
-                &chain_information.finalized_block_header.state_root[..],
-                i64::try_from(chain_information.finalized_block_header.number).unwrap(),
-                &scale_encoded_finalized_block_header[..],
-                finalized_block_justification.as_deref(),
-            ))
-            .unwrap();
-
-        {
-            let mut statement = transaction
-                .prepare_cached("INSERT INTO blocks_body(hash, idx, extrinsic) VALUES(?, ?, ?)")
-                .unwrap();
-            for (index, item) in finalized_block_body.enumerate() {
-                statement
-                    .execute((
-                        &finalized_block_hash[..],
-                        i64::try_from(index).unwrap(),
-                        item,
-                    ))
-                    .unwrap();
-            }
-        }
-
-        super::meta_set_blob(&transaction, "best", &finalized_block_hash[..]).unwrap();
-        super::meta_set_number(
-            &transaction,
-            "finalized",
-            chain_information.finalized_block_header.number,
-        )?;
-
-        match &chain_information.finality {
-            chain_information::ChainInformationFinalityRef::Outsourced => {}
-            chain_information::ChainInformationFinalityRef::Grandpa {
-                finalized_triggered_authorities,
-                after_finalized_block_authorities_set_id,
-                finalized_scheduled_change,
-            } => {
-                super::meta_set_number(
-                    &transaction,
-                    "grandpa_authorities_set_id",
-                    *after_finalized_block_authorities_set_id,
-                )?;
-
-                let mut statement = transaction
-                    .prepare_cached("INSERT INTO grandpa_triggered_authorities(idx, public_key, weight) VALUES(?, ?, ?)")
-                    .unwrap();
-                for (index, item) in finalized_triggered_authorities.iter().enumerate() {
-                    statement
-                        .execute((
-                            i64::try_from(index).unwrap(),
-                            &item.public_key[..],
-                            i64::from_ne_bytes(item.weight.get().to_ne_bytes()),
-                        ))
-                        .unwrap();
-                }
-
-                if let Some((height, list)) = finalized_scheduled_change {
-                    super::meta_set_number(&transaction, "grandpa_scheduled_target", *height)?;
-
-                    let mut statement = transaction
-                        .prepare_cached("INSERT INTO grandpa_scheduled_authorities(idx, public_key, weight) VALUES(?, ?, ?)")
-                        .unwrap();
-                    for (index, item) in list.iter().enumerate() {
-                        statement
-                            .execute((
-                                i64::try_from(index).unwrap(),
-                                &item.public_key[..],
-                                i64::from_ne_bytes(item.weight.get().to_ne_bytes()),
-                            ))
-                            .unwrap();
-                    }
-                }
-            }
-        }
-
-        match &chain_information.consensus {
-            chain_information::ChainInformationConsensusRef::Unknown => {}
-            chain_information::ChainInformationConsensusRef::Aura {
-                finalized_authorities_list,
-                slot_duration,
-            } => {
-                super::meta_set_number(&transaction, "aura_slot_duration", slot_duration.get())
-                    .unwrap();
-
-                let mut statement = transaction
-                    .prepare_cached(
-                        "INSERT INTO aura_finalized_authorities(idx, public_key) VALUES(?, ?)",
-                    )
-                    .unwrap();
-                for (index, item) in finalized_authorities_list.clone().enumerate() {
-                    statement
-                        .execute((i64::try_from(index).unwrap(), &item.public_key[..]))
-                        .unwrap();
-                }
-            }
-            chain_information::ChainInformationConsensusRef::Babe {
-                slots_per_epoch,
-                finalized_next_epoch_transition,
-                finalized_block_epoch_information,
-            } => {
-                super::meta_set_number(&transaction, "babe_slots_per_epoch", slots_per_epoch.get())
-                    .unwrap();
-                super::meta_set_blob(
-                    &transaction,
-                    "babe_finalized_next_epoch",
-                    &encode_babe_epoch_information(finalized_next_epoch_transition.clone())[..],
-                )
-                .unwrap();
-
-                if let Some(finalized_block_epoch_information) = finalized_block_epoch_information {
-                    super::meta_set_blob(&transaction, "babe_finalized_epoch", &encode_babe_epoch_information(
-            finalized_block_epoch_information.clone(),
-        )[..]).unwrap();
-                }
-            }
-        }
-
-        transaction
-            .commit()
-            .map_err(|err| CorruptedError::Internal(InternalError(err)))?;
-
-        Ok(SqliteFullDatabase {
+        let database = SqliteFullDatabase {
             database: parking_lot::Mutex::new(self.database),
             block_number_bytes: self.block_number_bytes,
-        })
+        };
+
+        database.reset(
+            chain_information,
+            finalized_block_body,
+            finalized_block_justification,
+        )?;
+
+        Ok(database)
     }
 }


### PR DESCRIPTION
Change extracted from https://github.com/smol-dot/smoldot/pull/1483
cc #131 

This is more or less a revival of https://github.com/smol-dot/smoldot/pull/1480, but done properly this time.
The database still enforces that parents must be present in the database, but only through code and not through a foreign key.
