### PR TITLE
Make warp sync state machine download block body

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1288,7 +1288,7 @@ impl SyncBackground {
                                 network::codec::BlocksRequestDirection::Descending
                             },
                             fields: network::codec::BlocksRequestFields {
-                                header: request_headers,
+                                header: true, // TODO: always set to true due to unwrapping the header when the response comes
                                 body: request_bodies,
                                 justifications: request_justification,
                             },

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1288,7 +1288,7 @@ impl SyncBackground {
                                 network::codec::BlocksRequestDirection::Descending
                             },
                             fields: network::codec::BlocksRequestFields {
-                                header: true, // TODO: always set to true due to unwrapping the header when the response comes
+                                header: request_headers,
                                 body: request_bodies,
                                 justifications: request_justification,
                             },

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1058,6 +1058,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 finalized_storage_code_closest_ancestor_excluding,
                 finalized_storage_heap_pages,
                 finalized_storage_code_merkle_value,
+                finalized_body: _,
             } => {
                 self.sync = sync;
 


### PR DESCRIPTION
Change extracted from https://github.com/smol-dot/smoldot/pull/1483
cc #1483 

When warp syncing in the full node, we must download the body of the block we warp sync to. This is what this PR implements.
