### PR TITLE
Revert "Update to wasmi v0.32 and add lazy validation (#1488)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,12 +1635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multi-stash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
-
-[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,17 +1676,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.43",
 ]
 
 [[package]]
@@ -2857,13 +2840,10 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.0-beta.2"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab06f5b4dadd225f47efe41308550ab01f0b6aa2585d7823c3f215e5777ebd"
+checksum = "acfc1e384a36ca532d070a315925887247f3c7e23567e23e0ac9b1c5d6b8bf76"
 dependencies = [
- "multi-stash",
- "num-derive",
- "num-traits",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -2879,9 +2859,9 @@ checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
 
 [[package]]
 name = "wasmi_core"
-version = "0.15.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac482df6761020b2b75c9aade41c105993c5b9f64156c349bb7ccad226a6ecd"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -323,7 +323,7 @@ impl ConsensusService {
             executor::host::HostVmPrototype::new(executor::host::Config {
                 module: finalized_code,
                 heap_pages,
-                exec_hint: executor::vm::ExecHint::ValidateAndCompile, // TODO: probably should be decided by the optimisticsync
+                exec_hint: executor::vm::ExecHint::CompileAheadOfTime, // TODO: probably should be decided by the optimisticsync
                 allow_unresolved_imports: false,
             })
             .map_err(InitError::FinalizedRuntimeInit)?
@@ -2061,7 +2061,7 @@ impl SyncBackground {
             }
             all::ProcessOne::WarpSyncBuildRuntime(build_runtime) => {
                 let (new_sync, outcome) =
-                    build_runtime.build(all::ExecHint::ValidateAndCompile, true);
+                    build_runtime.build(all::ExecHint::CompileAheadOfTime, true);
                 self.sync = new_sync;
                 if let Err(err) = outcome {
                     self.log_callback.log(

--- a/full-node/src/json_rpc_service/runtime_caches_service.rs
+++ b/full-node/src/json_rpc_service/runtime_caches_service.rs
@@ -105,7 +105,7 @@ impl RuntimeCachesService {
                                         executor::host::Config {
                                             module: &code,
                                             heap_pages,
-                                            exec_hint: executor::vm::ExecHint::ValidateAndCompile,
+                                            exec_hint: executor::vm::ExecHint::CompileAheadOfTime,
                                             allow_unresolved_imports: true, // TODO: configurable? or if not, document
                                         },
                                     )

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -853,7 +853,7 @@ async fn open_database(
                     genesis_storage.value(b":heappages"),
                 )
                 .unwrap(),
-                exec_hint: executor::vm::ExecHint::ValidateAndExecuteOnce,
+                exec_hint: executor::vm::ExecHint::Oneshot,
                 allow_unresolved_imports: true,
             })
             .unwrap()

--- a/fuzz/fuzz_targets/wasm-module-wasmi.rs
+++ b/fuzz/fuzz_targets/wasm-module-wasmi.rs
@@ -21,9 +21,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     let _ = smoldot::executor::host::HostVmPrototype::new(smoldot::executor::host::Config {
         module: data,
         heap_pages: smoldot::executor::DEFAULT_HEAP_PAGES,
-        exec_hint: smoldot::executor::vm::ExecHint::ForceWasmi {
-            lazy_validation: false,
-        },
+        exec_hint: smoldot::executor::vm::ExecHint::ForceWasmi,
         allow_unresolved_imports: true,
     });
 });

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.11.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { version = "0.32.0-beta.2", default-features = false }
+wasmi = { version = "0.31.0", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -116,7 +116,7 @@ impl ChainSpec {
         let vm_prototype = executor::host::HostVmPrototype::new(executor::host::Config {
             module: &wasm_code,
             heap_pages,
-            exec_hint: executor::vm::ExecHint::ValidateAndExecuteOnce,
+            exec_hint: executor::vm::ExecHint::Oneshot,
             allow_unresolved_imports: true,
         })
         .map_err(FromGenesisStorageError::VmInitialization)?;

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -152,7 +152,7 @@
 //!     let prototype = HostVmPrototype::new(Config {
 //!         module: &wasm_binary_code,
 //!         heap_pages: HeapPages::from(2048),
-//!         exec_hint: smoldot::executor::vm::ExecHint::ValidateAndExecuteOnce,
+//!         exec_hint: smoldot::executor::vm::ExecHint::Oneshot,
 //!         allow_unresolved_imports: false
 //!     }).unwrap();
 //!     prototype.run_no_param("Core_version").unwrap().into()

--- a/lib/src/executor/runtime_host.rs
+++ b/lib/src/executor/runtime_host.rs
@@ -1775,7 +1775,7 @@ impl Inner {
                     let vm_prototype = match host::HostVmPrototype::new(host::Config {
                         module: req.wasm_code(),
                         heap_pages: executor::DEFAULT_HEAP_PAGES,
-                        exec_hint: vm::ExecHint::ValidateAndExecuteOnce,
+                        exec_hint: vm::ExecHint::Oneshot,
                         allow_unresolved_imports: false, // TODO: what is a correct value here?
                     }) {
                         Ok(w) => w,

--- a/lib/src/executor/runtime_host/tests.rs
+++ b/lib/src/executor/runtime_host/tests.rs
@@ -74,7 +74,7 @@ fn execute_blocks() {
             host::HostVmPrototype::new(host::Config {
                 module: code,
                 heap_pages,
-                exec_hint: crate::executor::vm::ExecHint::ExecuteOnceWithNonDeterministicValidation,
+                exec_hint: crate::executor::vm::ExecHint::Oneshot,
                 allow_unresolved_imports: false,
             })
             .unwrap()

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -145,7 +145,7 @@ impl VirtualMachinePrototype {
                     ),
                     feature = "wasmtime"
                 ))]
-                ExecHint::ValidateAndCompile => VirtualMachinePrototypeInner::Jit(
+                ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Jit(
                     jit::JitPrototype::new(config.module_bytes, config.symbols)?,
                 ),
                 #[cfg(not(all(
@@ -159,41 +159,13 @@ impl VirtualMachinePrototype {
                     ),
                     feature = "wasmtime"
                 )))]
-                ExecHint::ValidateAndCompile => VirtualMachinePrototypeInner::Interpreter(
-                    interpreter::InterpreterPrototype::new(
-                        config.module_bytes,
-                        interpreter::CompilationMode::Eager,
-                        config.symbols,
-                    )?,
+                ExecHint::CompileAheadOfTime => VirtualMachinePrototypeInner::Interpreter(
+                    interpreter::InterpreterPrototype::new(config.module_bytes, config.symbols)?,
                 ),
-                ExecHint::ValidateAndExecuteOnce | ExecHint::Untrusted => {
+                ExecHint::Oneshot | ExecHint::Untrusted | ExecHint::ForceWasmi => {
                     VirtualMachinePrototypeInner::Interpreter(
                         interpreter::InterpreterPrototype::new(
                             config.module_bytes,
-                            interpreter::CompilationMode::Eager,
-                            config.symbols,
-                        )?,
-                    )
-                }
-                ExecHint::CompileWithNonDeterministicValidation
-                | ExecHint::ExecuteOnceWithNonDeterministicValidation => {
-                    VirtualMachinePrototypeInner::Interpreter(
-                        interpreter::InterpreterPrototype::new(
-                            config.module_bytes,
-                            interpreter::CompilationMode::Lazy,
-                            config.symbols,
-                        )?,
-                    )
-                }
-                ExecHint::ForceWasmi { lazy_validation } => {
-                    VirtualMachinePrototypeInner::Interpreter(
-                        interpreter::InterpreterPrototype::new(
-                            config.module_bytes,
-                            if lazy_validation {
-                                interpreter::CompilationMode::Lazy
-                            } else {
-                                interpreter::CompilationMode::Eager
-                            },
                             config.symbols,
                         )?,
                     )
@@ -741,37 +713,18 @@ impl fmt::Debug for VirtualMachine {
 pub enum ExecHint {
     /// The WebAssembly code will be instantiated once and run many times.
     /// If possible, compile this WebAssembly code ahead of time.
-    ValidateAndCompile,
-
-    /// The WebAssembly code will be instantiated once and run many times.
-    /// Contrary to [`ExecHint::ValidateAndCompile`], the WebAssembly code isn't fully validated
-    /// ahead of time, meaning that invalid WebAssembly modules might successfully be compiled,
-    /// which is an indesirable property in some contexts.
-    CompileWithNonDeterministicValidation,
-
+    CompileAheadOfTime,
     /// The WebAssembly code is expected to be only run once.
     ///
     /// > **Note**: This isn't a hard requirement but a hint.
-    ValidateAndExecuteOnce,
-
-    /// The WebAssembly code will be instantiated once and run many times.
-    /// Contrary to [`ExecHint::ValidateAndExecuteOnce`], the WebAssembly code isn't fully
-    /// validated ahead of time, meaning that invalid WebAssembly modules might successfully be
-    /// compiled, which is an indesirable property in some contexts.
-    ExecuteOnceWithNonDeterministicValidation,
-
+    Oneshot,
     /// The WebAssembly code running through this VM is untrusted.
     Untrusted,
 
     /// Forces using the `wasmi` backend.
     ///
     /// This variant is useful for testing purposes.
-    ForceWasmi {
-        /// If `true`, lazy validation is enabled. This leads to a faster initialization time,
-        /// but can also successfully validate invalid modules, which is an indesirable property
-        /// in some contexts.
-        lazy_validation: bool,
-    },
+    ForceWasmi,
     /// Forces using the `wasmtime` backend.
     ///
     /// This variant is useful for testing purposes.
@@ -808,10 +761,7 @@ impl ExecHint {
     ///
     /// > **Note**: This function is most useful for testing purposes.
     pub fn available_engines() -> impl Iterator<Item = ExecHint> {
-        iter::once(ExecHint::ForceWasmi {
-            lazy_validation: false,
-        })
-        .chain(Self::force_wasmtime_if_available())
+        iter::once(ExecHint::ForceWasmi).chain(Self::force_wasmtime_if_available())
     }
 
     /// Returns `ForceWasmtime` if it is available on the current platform, and `None` otherwise.

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -25,8 +25,6 @@ use super::{
 use alloc::{borrow::ToOwned as _, string::ToString as _, sync::Arc, vec::Vec};
 use core::fmt;
 
-pub use wasmi::CompilationMode;
-
 /// See [`super::VirtualMachinePrototype`].
 pub struct InterpreterPrototype {
     /// Base components that can be used to recreate a prototype later if desired.
@@ -54,7 +52,6 @@ impl InterpreterPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
         module_bytes: &[u8],
-        compilation_mode: CompilationMode,
         symbols: &mut dyn FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         let engine = {
@@ -69,7 +66,6 @@ impl InterpreterPrototype {
             config.wasm_mutable_global(false);
             config.wasm_saturating_float_to_int(false);
             config.wasm_tail_call(false);
-            config.compilation_mode(compilation_mode);
 
             wasmi::Engine::new(&config)
         };
@@ -133,7 +129,7 @@ impl InterpreterPrototype {
                         &mut store,
                         func_type.clone(),
                         move |_caller, parameters, _ret| {
-                            Err(wasmi::Error::host(InterruptedTrap {
+                            Err(wasmi::core::Trap::from(InterruptedTrap {
                                 function_index,
                                 parameters: parameters
                                     .iter()

--- a/lib/src/transactions/validate/tests.rs
+++ b/lib/src/transactions/validate/tests.rs
@@ -34,7 +34,7 @@ fn validate_from_proof() {
         module: hex::decode(&test.runtime_code).unwrap(),
         heap_pages: executor::DEFAULT_HEAP_PAGES,
         allow_unresolved_imports: true,
-        exec_hint: executor::vm::ExecHint::ExecuteOnceWithNonDeterministicValidation,
+        exec_hint: executor::vm::ExecHint::Oneshot,
     })
     .unwrap();
 

--- a/lib/src/verify/body_only.rs
+++ b/lib/src/verify/body_only.rs
@@ -709,7 +709,7 @@ impl RuntimeCompilation {
         let new_runtime = match host::HostVmPrototype::new(host::Config {
             module: code,
             heap_pages: self.heap_pages,
-            exec_hint: vm::ExecHint::ValidateAndCompile, // TODO: let API user choose this
+            exec_hint: vm::ExecHint::CompileAheadOfTime,
             allow_unresolved_imports: false,
         }) {
             Ok(vm) => vm,

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2533,16 +2533,13 @@ impl SuccessfulRuntime {
         let module = code.as_ref().ok_or(RuntimeError::CodeNotFound)?;
         let heap_pages = executor::storage_heap_pages_to_value(heap_pages.as_deref())
             .map_err(RuntimeError::InvalidHeapPages)?;
-        // Because the runtime has been validated by at least the author of the block, we assume
-        // that it is valid. This significantly speeds up the compilation.
-        let exec_hint = executor::vm::ExecHint::CompileWithNonDeterministicValidation;
+        let exec_hint = executor::vm::ExecHint::CompileAheadOfTime;
 
         // We try once with `allow_unresolved_imports: false`. If this fails due to unresolved
         // import, we try again but with `allowed_unresolved_imports: true`.
         // Having unresolved imports might cause errors later on, for example when validating
         // transactions or getting the parachain heads, but for now we continue the execution
         // and print a warning.
-        // TODO: should log the fact that we're compiling a runtime and the time it takes, as this is a heavy operation
         match executor::host::HostVmPrototype::new(executor::host::Config {
             module,
             heap_pages,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1008,11 +1008,7 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                 // Warp syncing compiles the runtime. The compiled runtime will later be yielded
                 // in the `WarpSyncFinished` variant, which is then provided as an event.
                 let before_instant = self.platform.now();
-                // Because the runtime being compiled has been validated by 2/3rds of the
-                // validators of the chain, we can assume that it is valid. Doing so significantly
-                // increases the compilation speed.
-                let (new_sync, error) =
-                    req.build(all::ExecHint::CompileWithNonDeterministicValidation, true);
+                let (new_sync, error) = req.build(all::ExecHint::CompileAheadOfTime, true);
                 let elapsed = self.platform.now() - before_instant;
                 match error {
                     Ok(()) => {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changed
 
-- The WebAssembly runtime is now compiled lazily, meaning that only the code that is executed is validated and translated. Thanks to this, compiling a runtime is now four times faster and the time to head of the chain is around 200ms faster. ([#1488](https://github.com/smol-dot/smoldot/pull/1488))
 - Decoding and analyzing a Merkle proof is now around 10% to 50% faster. ([#1462](https://github.com/smol-dot/smoldot/pull/1462))
 
 ### Fixed


### PR DESCRIPTION
Reverts https://github.com/smol-dot/smoldot/pull/1488

cc @robbepop

While working on https://github.com/smol-dot/smoldot/pull/1483, I noticed that some Wasm runtime calls fail with:

> panicked at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/alloc/src/collections/btree/navigate.rs:535:47:\ncalled Option::unwrap() on a None value

Reverting #1488 fixes this issue, so I'm going to revert for now.

The code that is panicking is very low-level, so I'm suspecting some kind of memory corruption or miscompilation or something like that.
