### PR TITLE
Rename request finishing functions to be more clear

### DIFF
--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -813,10 +813,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`RequestId`] is invalid.
     ///
-    pub fn finish_request(
-        mut self,
-        request_id: RequestId,
-    ) -> (TRq, FinishRequest<TBl, TRq, TSrc>) {
+    pub fn finish_request(mut self, request_id: RequestId) -> (TRq, FinishRequest<TBl, TRq, TSrc>) {
         // Sets the `occupation` of `source_id` back to `AllSync`.
         let (
             pending_blocks::RequestParams {

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -662,7 +662,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// The block does not need to be known by the data structure.
     ///
     /// This is automatically done for the blocks added through [`AllForksSync::block_announce`],
-    /// [`AllForksSync::prepare_add_source`] or [`FinishAncestrySearch::add_block`].
+    /// [`AllForksSync::prepare_add_source`] or [`FinishRequest::add_block`].
     ///
     /// # Panic
     ///
@@ -775,7 +775,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     }
 
     /// Returns a list of requests that are considered obsolete and can be removed using
-    /// [`AllForksSync::finish_ancestry_search`] or similar.
+    /// [`AllForksSync::finish_request`].
     ///
     /// A request becomes obsolete if the state of the request blocks changes in such a way that
     /// they don't need to be requested anymore. The response to the request will be useless.
@@ -797,7 +797,10 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         self.inner.blocks.request_source_id(request_id)
     }
 
-    /// Call in response to a blocks request being successful.
+    /// Call in response to a request being successful or failing.
+    ///
+    /// This state machine doesn't differentiate between successful or failed requests. If a
+    /// request has failed, call this function and immediately call [`FinishRequest::finish`].
     ///
     /// This method takes ownership of the [`AllForksSync`] and puts it in a mode where the blocks
     /// of the response can be added one by one.
@@ -810,10 +813,10 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// Panics if the [`RequestId`] is invalid.
     ///
-    pub fn finish_ancestry_search(
+    pub fn finish_request(
         mut self,
         request_id: RequestId,
-    ) -> (TRq, FinishAncestrySearch<TBl, TRq, TSrc>) {
+    ) -> (TRq, FinishRequest<TBl, TRq, TSrc>) {
         // Sets the `occupation` of `source_id` back to `AllSync`.
         let (
             pending_blocks::RequestParams {
@@ -823,11 +826,11 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             },
             source_id,
             request_user_data,
-        ) = self.inner.blocks.finish_request(request_id);
+        ) = self.inner.blocks.remove_request(request_id);
 
         (
             request_user_data,
-            FinishAncestrySearch {
+            FinishRequest {
                 inner: self,
                 source_id,
                 any_progress: false,
@@ -838,23 +841,6 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                 expected_next_height: requested_block_height,
             },
         )
-    }
-
-    /// Call in response to a blocks request having failed.
-    ///
-    /// This removes the request from the state machine and returns its user data.
-    ///
-    /// # Panic
-    ///
-    /// Panics if the [`RequestId`] is invalid.
-    ///
-    // TODO: taking a `&mut self` instead of a `self` would be more correct, however this doesn't give any benefit and complicates the implementation at the moment, so it might not be worth doing
-    pub fn ancestry_search_failed(
-        self,
-        request_id: RequestId,
-    ) -> (TRq, AllForksSync<TBl, TRq, TSrc>) {
-        let (user_data, inner) = self.finish_ancestry_search(request_id);
-        (user_data, inner.finish())
     }
 
     /// Update the source with a newly-announced block.
@@ -1089,8 +1075,8 @@ impl<'a, TBl, TRq, TSrc> ops::IndexMut<(u64, &'a [u8; 32])> for AllForksSync<TBl
     }
 }
 
-/// See [`AllForksSync::finish_ancestry_search`].
-pub struct FinishAncestrySearch<TBl, TRq, TSrc> {
+/// See [`AllForksSync::finish_request`].
+pub struct FinishRequest<TBl, TRq, TSrc> {
     inner: AllForksSync<TBl, TRq, TSrc>,
 
     /// Source that has sent the request that is being answered.
@@ -1113,13 +1099,13 @@ pub struct FinishAncestrySearch<TBl, TRq, TSrc> {
     expected_next_height: u64,
 }
 
-impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
+impl<TBl, TRq, TSrc> FinishRequest<TBl, TRq, TSrc> {
     /// Adds a block coming from the response that the source has provided.
     ///
-    /// On success, the [`FinishAncestrySearch`] is turned into an [`AddBlock`]. The block is
+    /// On success, the [`FinishRequest`] is turned into an [`AddBlock`]. The block is
     /// inserted in the state machine only after one of the methods in [`AddBlock`] is added.
     ///
-    /// If an error is returned, the [`FinishAncestrySearch`] is turned back again into a
+    /// If an error is returned, the [`FinishRequest`] is turned back again into a
     /// [`AllForksSync`], but all the blocks that have already been added are retained.
     ///
     /// If [`Config::download_bodies`] was `false`, the content of `scale_encoded_extrinsics`
@@ -1306,7 +1292,7 @@ impl<TBl, TRq, TSrc> FinishAncestrySearch<TBl, TRq, TSrc> {
     }
 }
 
-/// Result of calling [`FinishAncestrySearch::add_block`].
+/// Result of calling [`FinishRequest::add_block`].
 pub enum AddBlock<TBl, TRq, TSrc> {
     /// The block is already in the list of unverified blocks.
     AlreadyPending(AddBlockOccupied<TBl, TRq, TSrc>),
@@ -1321,9 +1307,9 @@ pub enum AddBlock<TBl, TRq, TSrc> {
     AlreadyInChain(AddBlockOccupied<TBl, TRq, TSrc>),
 }
 
-/// See [`FinishAncestrySearch::add_block`] and [`AddBlock`].
+/// See [`FinishRequest::add_block`] and [`AddBlock`].
 pub struct AddBlockOccupied<TBl, TRq, TSrc> {
-    inner: FinishAncestrySearch<TBl, TRq, TSrc>,
+    inner: FinishRequest<TBl, TRq, TSrc>,
     decoded_header: header::Header,
     is_verified: bool,
 }
@@ -1356,7 +1342,7 @@ impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
     ///
     /// Returns an object that allows continuing inserting blocks, plus the former user data that
     /// was overwritten by the new one.
-    pub fn replace(mut self, user_data: TBl) -> (FinishAncestrySearch<TBl, TRq, TSrc>, TBl) {
+    pub fn replace(mut self, user_data: TBl) -> (FinishRequest<TBl, TRq, TSrc>, TBl) {
         // Update the view the state machine maintains for this source.
         self.inner.inner.inner.blocks.add_known_block_to_source(
             self.inner.source_id,
@@ -1420,15 +1406,15 @@ impl<TBl, TRq, TSrc> AddBlockOccupied<TBl, TRq, TSrc> {
     }
 
     /// Do not update the state machine with this block. Equivalent to calling
-    /// [`FinishAncestrySearch::finish`].
+    /// [`FinishRequest::finish`].
     pub fn cancel(self) -> AllForksSync<TBl, TRq, TSrc> {
         self.inner.inner
     }
 }
 
-/// See [`FinishAncestrySearch::add_block`] and [`AddBlock`].
+/// See [`FinishRequest::add_block`] and [`AddBlock`].
 pub struct AddBlockVacant<TBl, TRq, TSrc> {
-    inner: FinishAncestrySearch<TBl, TRq, TSrc>,
+    inner: FinishRequest<TBl, TRq, TSrc>,
     decoded_header: header::Header,
     justifications: Vec<([u8; 4], Vec<u8>)>,
     scale_encoded_extrinsics: Vec<Vec<u8>>,
@@ -1436,7 +1422,7 @@ pub struct AddBlockVacant<TBl, TRq, TSrc> {
 
 impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
     /// Insert the block in the state machine, with the given user data.
-    pub fn insert(mut self, user_data: TBl) -> FinishAncestrySearch<TBl, TRq, TSrc> {
+    pub fn insert(mut self, user_data: TBl) -> FinishRequest<TBl, TRq, TSrc> {
         // Update the view the state machine maintains for this source.
         self.inner.inner.inner.blocks.add_known_block_to_source(
             self.inner.source_id,
@@ -1520,7 +1506,7 @@ impl<TBl, TRq, TSrc> AddBlockVacant<TBl, TRq, TSrc> {
     }
 
     /// Do not update the state machine with this block. Equivalent to calling
-    /// [`FinishAncestrySearch::finish`].
+    /// [`FinishRequest::finish`].
     pub fn cancel(self) -> AllForksSync<TBl, TRq, TSrc> {
         self.inner.inner
     }
@@ -1741,7 +1727,7 @@ impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
     }
 }
 
-/// Error when adding a block using [`FinishAncestrySearch::add_block`].
+/// Error when adding a block using [`FinishRequest::add_block`].
 pub enum AncestrySearchResponseError {
     /// Failed to decode block header.
     InvalidHeader(header::Error),

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -80,7 +80,7 @@
 //! obtain the list of requests that should be started.
 //!
 //! Call [`PendingBlocks::add_request`] to allocate a new [`RequestId`] and add a new request.
-//! Call [`PendingBlocks::finish_request`] to destroy a request after it has finished or been
+//! Call [`PendingBlocks::remove_request`] to destroy a request after it has finished or been
 //! canceled. Note that this method doesn't require to be passed the response to that request.
 //! The user is encouraged to update the state machine according to the response, but this must
 //! be done manually.
@@ -813,7 +813,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         request_id
     }
 
-    /// Marks a request as finished.
+    /// Removes a request from the state machine.
     ///
     /// Returns the parameters that were passed to [`PendingBlocks::add_request`].
     ///
@@ -829,7 +829,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// Panics if the [`RequestId`] is invalid.
     ///
     #[track_caller]
-    pub fn finish_request(&mut self, request_id: RequestId) -> (RequestParams, SourceId, TRq) {
+    pub fn remove_request(&mut self, request_id: RequestId) -> (RequestParams, SourceId, TRq) {
         assert!(self.requests.contains(request_id.0));
         let request = self.requests.remove(request_id.0);
 
@@ -878,7 +878,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     }
 
     /// Returns a list of requests that are considered obsolete and can be removed using
-    /// [`PendingBlocks::finish_request`].
+    /// [`PendingBlocks::remove_request`].
     ///
     /// A request is considered obsolete if the state of the requested blocks changes in such a
     /// way that they don't need to be requested anymore. The request wouldn't be returned by

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -1102,8 +1102,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     ///
     /// Panics if the [`RequestId`] is invalid.
     ///
-    // TODO: rename to `cancel_request` to convey the meaning that nothing negative will happen to the source
-    pub fn fail_request(&mut self, id: RequestId) -> TRq {
+    pub fn remove_request(&mut self, id: RequestId) -> TRq {
         if self.warp_sync_fragments_download == Some(id) {
             self.warp_sync_fragments_download = None;
         }


### PR DESCRIPTION
This PR is a simple clean-up that renames a bunch of functions and struct in order to better match their context.