### PR TITLE
make network-service public

### DIFF
--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -97,13 +97,13 @@ use smoldot::{
 
 mod database;
 mod json_rpc_service;
-mod network_service;
 mod runtime_service;
 mod sync_service;
 mod transactions_service;
 mod util;
 
 pub mod platform;
+pub mod network_service;
 
 pub use json_rpc_service::HandleRpcError;
 

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -102,8 +102,8 @@ mod sync_service;
 mod transactions_service;
 mod util;
 
-pub mod platform;
 pub mod network_service;
+pub mod platform;
 
 pub use json_rpc_service::HandleRpcError;
 


### PR DESCRIPTION
can we make network-service public so we can use on chopsticks?