### PR TITLE
Download all chain info calls proofs during warp syncing

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -313,6 +313,10 @@ impl ConsensusService {
                 NonZeroU32::new(2000).unwrap()
             },
             download_bodies: true,
+            // We ask for all the chain-information-related storage proofs and call proofs to be
+            // downloaded during the warp syncing in order to guarantee that the necessary
+            // information will be found in the database at the next reload.
+            download_all_chain_information_storage_proofs: true,
             code_trie_node_hint: None,
         });
 

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -116,6 +116,12 @@ pub struct Config {
     /// [`ProcessOne::VerifyBlock`] is generated.
     pub download_bodies: bool,
 
+    /// If `true`, all the storage proofs and call proofs necessary in order to compute the chain
+    /// information of the warp synced block will be downloaded during the warp syncing process.
+    /// If `false`, the finality information of the warp synced block is inferred from the warp
+    /// sync fragments instead.
+    pub download_all_chain_information_storage_proofs: bool,
+
     /// Known valid Merkle value and storage value combination for the `:code` key.
     ///
     /// If provided, the warp syncing algorithm will first fetch the Merkle value of `:code`, and
@@ -186,6 +192,8 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 block_number_bytes: config.block_number_bytes,
                 sources_capacity: config.sources_capacity,
                 requests_capacity: config.sources_capacity, // TODO: ?! add as config?
+                download_all_chain_information_storage_proofs: config
+                    .download_all_chain_information_storage_proofs,
                 code_trie_node_hint: config.code_trie_node_hint,
                 num_download_ahead_fragments: 128, // TODO: make configurable?
                 // TODO: make configurable?

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -91,6 +91,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                 NonZeroU32::new(5000).unwrap()
             },
             download_bodies: false,
+            download_all_chain_information_storage_proofs: false,
             code_trie_node_hint: runtime_code_hint.map(|hint| all::ConfigCodeTrieNodeHint {
                 merkle_value: hint.merkle_value,
                 storage_value: hint.storage_value,


### PR DESCRIPTION
The full node warp syncing has a small flaw at the moment: since the warp syncing algorithm doesn't download the call proofs to obtain the list of GrandPa authorities, the database consequently doesn't contain the list of GrandPa authorities.

While this is not a problem at the moment, as we provide this list in the call to `reset`, it is a blocker for #93.

This PR adds an option to force the warp syncing code to download all the necessary call proofs no matter what.
