### PR TITLE
No longer use the `log` crate in the light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,7 +2355,6 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "hashbrown 0.14.3",
- "log",
  "no-std-net",
  "nom",
  "pin-project",

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -27,7 +27,6 @@ futures-util = { version = "0.3.27", default-features = false, features = ["allo
 hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"] }
-log = { version = "0.4.18", default-features = false }
 lru = { version = "0.12.0", default-features = false, features = ["hashbrown"] } # The `hashbrown` feature brings no-std compatibility.
 no-std-net = { version = "0.6.0", default-features = false }
 pin-project = "1.1.3"
@@ -43,11 +42,12 @@ zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 # `std` feature
 # Add here the crates that cannot function without the help of the operating system or environment.
 parking_lot = { version = "0.12.1", optional = true }
+log = { version = "0.4.18", default-features = false, optional = true }
 smol = { version = "2.0.0", optional = true }
 
 [features]
 default = ["std", "wasmtime"]
-std = ["dep:parking_lot", "dep:smol", "rand/std", "rand/std_rng", "smoldot/std"]
+std = ["dep:parking_lot", "dep:log", "dep:smol", "rand/std", "rand/std_rng", "smoldot/std"]
 wasmtime = ["smoldot/wasmtime"]
 
 [dev-dependencies]

--- a/light-base/examples/basic.rs
+++ b/light-base/examples/basic.rs
@@ -19,7 +19,7 @@ use core::{iter, num::NonZeroU32};
 use futures_lite::FutureExt as _;
 
 fn main() {
-    // The `smoldot_light` library uses the `log` crate to emit logs.
+    // The `DefaultPlatform` that we use below uses the `log` crate to emit logs.
     // We need to register some kind of logs listener, in this example `env_logger`.
     // See also <https://docs.rs/log>.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();

--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -40,7 +40,8 @@
 mod background;
 
 use crate::{
-    network_service, platform::PlatformRef, runtime_service, sync_service, transactions_service,
+    log, network_service, platform::PlatformRef, runtime_service, sync_service,
+    transactions_service,
 };
 
 use alloc::{

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -16,8 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    network_service, platform::PlatformRef, runtime_service, sync_service, transactions_service,
-    util,
+    log, network_service, platform::PlatformRef, runtime_service, sync_service,
+    transactions_service, util,
 };
 
 use super::StartConfig;

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -325,16 +325,20 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     .printed_legacy_json_rpc_warning
                     .swap(true, atomic::Ordering::Relaxed)
                 {
-                    log::warn!(
-                        target: &self.log_target,
-                        "The JSON-RPC client has just called a JSON-RPC function from the legacy \
-                        JSON-RPC API ({}). Legacy JSON-RPC functions have loose semantics and \
-                        cannot be properly implemented on a light client. You are encouraged to \
-                        use the new JSON-RPC API \
-                        <https://github.com/paritytech/json-rpc-interface-spec/> instead. The \
-                        legacy JSON-RPC API functions will be deprecated and removed in the \
-                        distant future.",
-                        request.request().name()
+                    log!(
+                        &self.platform,
+                        Warn,
+                        &self.log_target,
+                        format!(
+                            "The JSON-RPC client has just called a JSON-RPC function from \
+                            the legacy JSON-RPC API ({}). Legacy JSON-RPC functions have \
+                            loose semantics and cannot be properly implemented on a light \
+                            client. You are encouraged to use the new JSON-RPC API \
+                            <https://github.com/paritytech/json-rpc-interface-spec/> instead. The \
+                            legacy JSON-RPC API functions will be deprecated and removed in the \
+                            distant future.",
+                            request.request().name()
+                        )
                     )
                 }
             }
@@ -503,7 +507,12 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             | methods::MethodCall::system_networkState { .. }
             | methods::MethodCall::system_removeReservedPeer { .. }) => {
                 // TODO: implement the ones that make sense to implement ^
-                log::error!(target: &self.log_target, "JSON-RPC call not supported yet: {:?}", _method);
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
+                    format!("JSON-RPC call not supported yet: {:?}", _method)
+                );
                 request.fail(json_rpc::parse::ErrorResponse::ServerError(
                     -32000,
                     "Not implemented in smoldot yet",
@@ -520,12 +529,6 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         request: service::SubscriptionStartProcess,
     ) {
         // TODO: restore some form of logging
-        /*log::debug!(target: &self.log_target, "PendingRequestsQueue => {}",
-            crate::util::truncated_str(
-                json_rpc_request.chars().filter(|c| !c.is_control()),
-                100,
-            )
-        );*/
 
         // Print a warning for legacy JSON-RPC functions.
         match request.request() {
@@ -593,16 +596,20 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     .printed_legacy_json_rpc_warning
                     .swap(true, atomic::Ordering::Relaxed)
                 {
-                    log::warn!(
-                        target: &self.log_target,
-                        "The JSON-RPC client has just called a JSON-RPC function from the legacy \
-                        JSON-RPC API ({}). Legacy JSON-RPC functions have loose semantics and \
-                        cannot be properly implemented on a light client. You are encouraged to \
-                        use the new JSON-RPC API \
-                        <https://github.com/paritytech/json-rpc-interface-spec/> instead. The \
-                        legacy JSON-RPC API functions will be deprecated and removed in the \
-                        distant future.",
-                        request.request().name()
+                    log!(
+                        &self.platform,
+                        Warn,
+                        &self.log_target,
+                        format!(
+                            "The JSON-RPC client has just called a JSON-RPC function from \
+                            the legacy JSON-RPC API ({}). Legacy JSON-RPC functions have \
+                            loose semantics and cannot be properly implemented on a light \
+                            client. You are encouraged to use the new JSON-RPC API \
+                            <https://github.com/paritytech/json-rpc-interface-spec/> instead. The \
+                            legacy JSON-RPC API functions will be deprecated and removed in the \
+                            distant future.",
+                            request.request().name()
+                        )
                     )
                 }
             }
@@ -650,7 +657,12 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
             _method @ methods::MethodCall::network_unstable_subscribeEvents { .. } => {
                 // TODO: implement the ones that make sense to implement ^
-                log::error!(target: &self.log_target, "JSON-RPC call not supported yet: {:?}", _method);
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
+                    format!("JSON-RPC call not supported yet: {:?}", _method)
+                );
                 request.fail(json_rpc::parse::ErrorResponse::ServerError(
                     -32000,
                     "Not implemented in smoldot yet",

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -93,8 +93,10 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             // JSON-RPC client implementations are made aware of this limit. This number of 2 might
             // be relaxed and/or configurable in the future.
             if lock.len() >= 2 {
-                log::warn!(
-                    target: &self.log_target,
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
                     "Rejected `chainHead_unstable_follow` subscription due to limit reached."
                 );
                 request.fail(json_rpc::parse::ErrorResponse::ApplicationDefined(
@@ -1031,8 +1033,10 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                 -32000,
                 "Child key storage queries not supported yet",
             ));
-            log::warn!(
-                target: &self.log_target,
+            log!(
+                &self.platform,
+                Warn,
+                &self.log_target,
                 "chainHead_unstable_storage has been called with a non-null childTrie. \
                 This isn't supported by smoldot yet."
             );

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -19,7 +19,7 @@
 
 use super::Background;
 
-use crate::{platform::PlatformRef, runtime_service, sync_service};
+use crate::{log, platform::PlatformRef, runtime_service, sync_service};
 
 use alloc::{
     borrow::ToOwned as _,

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::log;
+
 use core::{
     future::Future,
     iter,

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -376,12 +376,16 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                     ) {
                         Ok(h) => h,
                         Err(error) => {
-                            log::warn!(
-                                target: &task.log_target,
-                                "`chain_subscribeFinalizedHeads` subscription has skipped block \
-                                due to undecodable header. Hash: {}. Error: {}",
-                                HashDisplay(current_finalized_block),
-                                error,
+                            log!(
+                                &task.platform,
+                                Warn,
+                                &task.log_target,
+                                format!(
+                                    "`chain_subscribeFinalizedHeads` subscription has skipped \
+                                    block due to undecodable header. Hash: {}. Error: {}",
+                                    HashDisplay(current_finalized_block),
+                                    error,
+                                )
                             );
                             continue;
                         }
@@ -420,12 +424,16 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 ) {
                     Ok(h) => h,
                     Err(error) => {
-                        log::warn!(
-                            target: &task.log_target,
-                            "`chain_subscribeNewHeads` subscription has skipped block due to \
-                            undecodable header. Hash: {}. Error: {}",
-                            HashDisplay(current_best_block),
-                            error,
+                        log!(
+                            &task.platform,
+                            Warn,
+                            &task.log_target,
+                            format!(
+                                "`chain_subscribeNewHeads` subscription has skipped block due to \
+                                undecodable header. Hash: {}. Error: {}",
+                                HashDisplay(current_best_block),
+                                error
+                            )
                         );
                         continue;
                     }
@@ -685,14 +693,18 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 ) {
                     Ok(h) => h,
                     Err(error) => {
-                        log::warn!(
-                            target: &task.log_target,
-                            "`chain_subscribeAllHeads` subscription has skipped block due to \
-                            undecodable header. Hash: {}. Error: {}",
-                            HashDisplay(&header::hash_from_scale_encoded_header(
-                                &block.scale_encoded_header
-                            )),
-                            error,
+                        log!(
+                            &task.platform,
+                            Warn,
+                            &task.log_target,
+                            format!(
+                                "`chain_subscribeAllHeads` subscription has skipped block \
+                                due to undecodable header. Hash: {}. Error: {}",
+                                HashDisplay(&header::hash_from_scale_encoded_header(
+                                    &block.scale_encoded_header
+                                )),
+                                error
+                            )
                         );
                         continue;
                     }
@@ -818,12 +830,17 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                             ) {
                                 Ok(h) => h,
                                 Err(error) => {
-                                    log::warn!(
-                                        target: &task.log_target,
-                                        "`chain_subscribeNewHeads` subscription has skipped \
-                                        block due to undecodable header. Hash: {}. Error: {}",
-                                        HashDisplay(current_best_block),
-                                        error,
+                                    log!(
+                                        &task.platform,
+                                        Warn,
+                                        &task.log_target,
+                                        format!(
+                                            "`chain_subscribeNewHeads` subscription has \
+                                            skipped block due to undecodable header. Hash: {}. \
+                                            Error: {}",
+                                            HashDisplay(current_best_block),
+                                            error
+                                        )
                                     );
                                     continue;
                                 }
@@ -862,12 +879,17 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                             ) {
                                 Ok(h) => h,
                                 Err(error) => {
-                                    log::warn!(
-                                        target: &task.log_target,
-                                        "`chain_subscribeFinalizedHeads` subscription has skipped \
-                                        block due to undecodable header. Hash: {}. Error: {}",
-                                        HashDisplay(current_finalized_block),
-                                        error,
+                                    log!(
+                                        &task.platform,
+                                        Warn,
+                                        &task.log_target,
+                                        format!(
+                                            "`chain_subscribeFinalizedHeads` subscription \
+                                            has skipped block due to undecodable header. \
+                                            Hash: {}. Error: {}",
+                                            HashDisplay(current_finalized_block),
+                                            error,
+                                        )
                                     );
                                     continue;
                                 }

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -70,11 +70,14 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 request.respond(methods::Response::system_accountNextIndex(u64::from(index)));
             }
             Err(error) => {
-                log::warn!(
-                    target: &self.log_target,
-                    "Returning error from `system_accountNextIndex`. \
-                    API user might not function properly. Error: {}",
-                    error
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
+                    format!(
+                        "Returning error from `system_accountNextIndex`. \
+                        API user might not function properly. Error: {error}"
+                    )
                 );
                 request.fail(service::ErrorResponse::ServerError(
                     -32000,
@@ -421,11 +424,14 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 )),
             },
             Err(error) => {
-                log::warn!(
-                    target: &self.log_target,
-                    "Returning error from `payment_queryInfo`. \
-                    API user might not function properly. Error: {}",
-                    error
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
+                    format!(
+                        "Returning error from `payment_queryInfo`. \
+                        API user might not function properly. Error: {error}"
+                    )
                 );
                 request.fail(json_rpc::parse::ErrorResponse::ServerError(
                     -32000,
@@ -744,10 +750,14 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 &format!("Failed to decode metadata from runtime. Error: {error}"),
             )),
             Err(error) => {
-                log::warn!(
-                    target: &self.log_target,
-                    "Returning error from `state_getMetadata`. API user might not function \
-                    properly. Error: {error}"
+                log!(
+                    &self.platform,
+                    Warn,
+                    &self.log_target,
+                    format!(
+                        "Returning error from `state_getMetadata`. API user might not function \
+                        properly. Error: {error}"
+                    )
                 );
                 request.fail(json_rpc::parse::ErrorResponse::ServerError(
                     -32000,

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -19,7 +19,7 @@
 
 use super::{legacy_state_sub, Background, GetKeysPagedCacheKey, PlatformRef};
 
-use crate::sync_service;
+use crate::{log, sync_service};
 
 use alloc::{format, string::ToString as _, sync::Arc, vec, vec::Vec};
 use core::{iter, num::NonZeroU32, time::Duration};

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -96,54 +96,6 @@ use smoldot::{
     libp2p::{multiaddr, peer_id},
 };
 
-macro_rules! log_inner {
-    () => {
-        core::iter::empty()
-    };
-    (,) => {
-        core::iter::empty()
-    };
-    ($key:ident = $value:expr) => {
-        log_inner!($key = $value,)
-    };
-    ($key:ident = ?$value:expr) => {
-        log_inner!($key = ?$value,)
-    };
-    ($key:ident) => {
-        log_inner!($key = $key,)
-    };
-    (?$key:ident) => {
-        log_inner!($key = ?$key,)
-    };
-    ($key:ident = $value:expr, $($rest:tt)*) => {
-        core::iter::once((stringify!($key), &$value as &dyn core::fmt::Display)).chain(log_inner!($($rest)*))
-    };
-    ($key:ident = ?$value:expr, $($rest:tt)*) => {
-        core::iter::once((stringify!($key), &format_args!("{:?}", $value) as &dyn core::fmt::Display)).chain(log_inner!($($rest)*))
-    };
-    ($key:ident, $($rest:tt)*) => {
-        log_inner!($key = $key, $($rest)*)
-    };
-    (?$key:ident, $($rest:tt)*) => {
-        log_inner!($key = ?$key, $($rest)*)
-    };
-}
-
-macro_rules! log {
-    ($plat:expr, $level:ident, $target:expr, $message:expr) => {
-        log!($plat, $level, $target, $message,)
-    };
-    ($plat:expr, $level:ident, $target:expr, $message:expr, $($params:tt)*) => {
-        $crate::platform::PlatformRef::log(
-            $plat,
-            $crate::platform::LogLevel::$level,
-            $target,
-            core::format_args!("{}", $message),
-            log_inner!($($params)*)
-        )
-    };
-}
-
 mod database;
 mod json_rpc_service;
 mod runtime_service;

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -40,7 +40,10 @@
 //! [`NetworkServiceChain::subscribe`]. These channels inform the foreground about updates to the
 //! network connectivity.
 
-use crate::platform::{self, address_parse, PlatformRef};
+use crate::{
+    log,
+    platform::{self, address_parse, PlatformRef},
+};
 
 use alloc::{
     borrow::ToOwned as _,

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -15,7 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::platform::{PlatformRef, SubstreamDirection};
+use crate::{
+    log,
+    platform::{PlatformRef, SubstreamDirection},
+};
 
 use alloc::{boxed::Box, string::String};
 use core::{pin, time::Duration};

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -153,7 +153,7 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
         &self,
         log_level: LogLevel,
         log_target: &'a str,
-        message: fmt::Arguments<'a>,
+        message: &'a str,
         key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
     );
 
@@ -516,7 +516,7 @@ macro_rules! log {
             $plat,
             $crate::platform::LogLevel::$level,
             $target,
-            core::format_args!("{}", $message),
+            AsRef::<str>::as_ref(&$message),
             $crate::log_inner!($($params)*)
         )
     };

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -149,6 +149,18 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     );
 
     /// Emit a log line.
+    ///
+    /// The `log_level` and `log_target` can be used in order to filter desired log lines.
+    ///
+    /// The `message` is typically a short constant message indicating the nature of the log line.
+    /// The `key_values` are a list of keys and values that are the parameters of the log message.
+    ///
+    /// For example, `message` can be `"block-announce-received"` and `key_values` can contain
+    /// the entries `("block_hash", ...)` and `("sender", ...)`.
+    ///
+    /// At the time of writing of this comment, `message` can also be a message written in plain
+    /// english and destined to the user of the library. This might disappear in the future.
+    // TODO: act on this last sentence ^
     fn log<'a>(
         &self,
         log_level: LogLevel,
@@ -506,6 +518,28 @@ macro_rules! log_inner {
     };
 }
 
+/// Helper macro for using the [`crate::platform::PlatformRef::log`] function.
+///
+/// This macro takes at least 4 parameters:
+///
+/// - A reference to an implementation of the [`crate::platform::PlatformRef`] trait.
+/// - A log level: `Error`, `Warn`, `Info`, `Debug`, or `Trace`. See [`crate::platform::LogLevel`].
+/// - A `&str` representing the target of the logging. This can be used in order to filter log
+/// entries belonging to a specific target.
+/// - An object that implements of `AsRef<str>` and that contains the log message itself.
+///
+/// In addition to these parameters, the macro accepts an unlimited number of extra
+/// (comma-separated) parameters.
+///
+/// Each parameter has one of these four syntaxes:
+///
+/// - `key = value`, where `key` is an identifier and `value` an expression that implements the
+/// `Display` trait.
+/// - `key = ?value`, where `key` is an identifier and `value` an expression that implements
+/// the `Debug` trait.
+/// - `key`, which is syntax sugar for `key = key`.
+/// - `?key`, which is syntax sugar for `key = ?key`.
+///
 #[macro_export]
 macro_rules! log {
     ($plat:expr, $level:ident, $target:expr, $message:expr) => {

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -148,6 +148,15 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
         task: impl future::Future<Output = ()> + Send + 'static,
     );
 
+    /// Emit a log line.
+    fn log<'a>(
+        &self,
+        log_level: LogLevel,
+        log_target: &'a str,
+        message: fmt::Arguments<'a>,
+        key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
+    );
+
     /// Value returned when a JSON-RPC client requests the name of the client, or when a peer
     /// performs an identification request. Reasonable value is `env!("CARGO_PKG_NAME")`.
     fn client_name(&self) -> Cow<str>;
@@ -261,6 +270,18 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
         &self,
         stream: Pin<&'a mut Self::Stream>,
     ) -> Self::StreamUpdateFuture<'a>;
+}
+
+/// Log level of a log entry.
+///
+/// See [`PlatformRef::log`].
+#[derive(Debug)]
+pub enum LogLevel {
+    Error = 1,
+    Warn = 2,
+    Info = 3,
+    Debug = 4,
+    Trace = 5,
 }
 
 /// Established multistream connection information. See [`PlatformRef::connect_multistream`].

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -32,12 +32,12 @@
 //!
 
 use super::{
-    with_buffers, Address, ConnectionType, IpAddr, MultiStreamAddress, MultiStreamWebRtcConnection,
-    PlatformRef, SubstreamDirection,
+    with_buffers, Address, ConnectionType, IpAddr, LogLevel, MultiStreamAddress,
+    MultiStreamWebRtcConnection, PlatformRef, SubstreamDirection,
 };
 
 use alloc::{borrow::Cow, sync::Arc};
-use core::{panic, pin::Pin, str, time::Duration};
+use core::{fmt, panic, pin::Pin, str, time::Duration};
 use futures_util::{future, FutureExt as _};
 use smoldot::libp2p::websocket;
 use std::{
@@ -151,6 +151,22 @@ impl PlatformRef for Arc<DefaultPlatform> {
                 .catch_unwind(),
             )
             .detach();
+    }
+
+    fn log<'a>(
+        &self,
+        log_level: LogLevel,
+        log_target: &'a str,
+        message: fmt::Arguments<'a>,
+        key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
+    ) {
+        log::logger().log(
+            &log::RecordBuilder::new()
+                //.level(todo!())
+                .target(log_target)
+                .args(message)
+                .build(),
+        )
     }
 
     fn client_name(&self) -> Cow<str> {

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -163,7 +163,7 @@ impl PlatformRef for Arc<DefaultPlatform> {
         &self,
         log_level: LogLevel,
         log_target: &'a str,
-        message: fmt::Arguments<'a>,
+        message: &'a str,
         key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
     ) {
         // Note that this conversion is most likely completely optimized out by the compiler due
@@ -177,7 +177,7 @@ impl PlatformRef for Arc<DefaultPlatform> {
         };
 
         let mut message_build = String::with_capacity(128);
-        let _ = write!(message_build, "{}", message);
+        message_build.push_str(message);
         let mut first = true;
         for (key, value) in key_values {
             if first {

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -22,6 +22,10 @@
 //!
 //! This module contains the [`DefaultPlatform`] struct, which implements [`PlatformRef`].
 //!
+//! The [`DefaultPlatform`] delegates the logging to the `log` crate. In order to see log
+//! messages, you should register as "logger" as documented by the `log` crate.
+//! See <https://docs.rs/log>.
+//!
 //! # Example
 //!
 //! ```rust

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -37,7 +37,13 @@ use super::{
 };
 
 use alloc::{borrow::Cow, sync::Arc};
-use core::{fmt, panic, pin::Pin, str, time::Duration};
+use core::{
+    fmt::{self, Write as _},
+    panic,
+    pin::Pin,
+    str,
+    time::Duration,
+};
 use futures_util::{future, FutureExt as _};
 use smoldot::libp2p::websocket;
 use std::{
@@ -160,6 +166,8 @@ impl PlatformRef for Arc<DefaultPlatform> {
         message: fmt::Arguments<'a>,
         key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
     ) {
+        // Note that this conversion is most likely completely optimized out by the compiler due
+        // to log levels having the same numerical values.
         let log_level = match log_level {
             LogLevel::Error => log::Level::Error,
             LogLevel::Warn => log::Level::Warn,
@@ -168,11 +176,24 @@ impl PlatformRef for Arc<DefaultPlatform> {
             LogLevel::Trace => log::Level::Trace,
         };
 
+        let mut message_build = String::with_capacity(128);
+        let _ = write!(message_build, "{}", message);
+        let mut first = true;
+        for (key, value) in key_values {
+            if first {
+                let _ = write!(message_build, "; ");
+                first = false;
+            } else {
+                let _ = write!(message_build, ", ");
+            }
+            let _ = write!(message_build, "{}={}", key, value);
+        }
+
         log::logger().log(
             &log::RecordBuilder::new()
                 .level(log_level)
                 .target(log_target)
-                .args(message)
+                .args(format_args!("{}", message_build))
                 .build(),
         )
     }

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -160,9 +160,17 @@ impl PlatformRef for Arc<DefaultPlatform> {
         message: fmt::Arguments<'a>,
         key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
     ) {
+        let log_level = match log_level {
+            LogLevel::Error => log::Level::Error,
+            LogLevel::Warn => log::Level::Warn,
+            LogLevel::Info => log::Level::Info,
+            LogLevel::Debug => log::Level::Debug,
+            LogLevel::Trace => log::Level::Trace,
+        };
+
         log::logger().log(
             &log::RecordBuilder::new()
-                //.level(todo!())
+                .level(log_level)
                 .target(log_target)
                 .args(message)
                 .build(),

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -30,6 +30,7 @@
 //!
 //! ```rust
 //! use smoldot_light::{Client, platform::DefaultPlatform};
+//! env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 //! let client = Client::new(DefaultPlatform::new(env!("CARGO_PKG_NAME").into(), env!("CARGO_PKG_VERSION").into()));
 //! # let _: Client<_, ()> = client;  // Used in this example to infer the generic parameters of the Client
 //! ```

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -54,7 +54,7 @@
 //! large, the subscription is force-killed by the [`RuntimeService`].
 //!
 
-use crate::{platform::PlatformRef, sync_service};
+use crate::{log, platform::PlatformRef, sync_service};
 
 use alloc::{
     borrow::ToOwned as _,

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -26,7 +26,7 @@
 //!
 //! Use [`SyncService::subscribe_all`] to get notified about updates to the state of the chain.
 
-use crate::{network_service, platform::PlatformRef, runtime_service};
+use crate::{log, network_service, platform::PlatformRef, runtime_service};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{cmp, fmt, future::Future, mem, num::NonZeroU32, pin::Pin, time::Duration};

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -170,12 +170,13 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
             }
         };
 
-        config
-            .platform
-            .spawn_task(log_target.clone().into(), async move {
+        config.platform.spawn_task(log_target.clone().into(), {
+            let platform = config.platform.clone();
+            async move {
                 task.await;
-                log::debug!(target: &log_target, "Shutdown");
-            });
+                log!(&platform, Debug, &log_target, "shutdown");
+            }
+        });
 
         SyncService {
             to_background,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -339,14 +339,21 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
 
                 (WakeUpReason::NewSubscription(relay_chain_subscribe_all), _) => {
                     // Subscription to the relay chain has finished.
-                    log::debug!(
-                        target: &self.log_target,
-                        "RelayChain => NewSubscription(finalized_hash={})",
-                        HashDisplay(&header::hash_from_scale_encoded_header(
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-new-subscription",
+                        finalized_hash = HashDisplay(&header::hash_from_scale_encoded_header(
                             &relay_chain_subscribe_all.finalized_block_scale_encoded_header
                         ))
                     );
-                    log::debug!(target: &self.log_target, "ParaheadFetchOperations <= Clear");
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "parahead-fetch-operations-cleared"
+                    );
 
                     let async_tree = {
                         let mut async_tree =
@@ -460,10 +467,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                     }
                                 }
 
-                                log::debug!(
-                                    target: &self.log_target,
-                                    "Subscriptions <= ParablockFinalized(hash={})",
-                                    HashDisplay(&hash)
+                                log!(
+                                    &self.platform,
+                                    Debug,
+                                    &self.log_target,
+                                    "subscriptions-notify-parablock-finalized",
+                                    hash = HashDisplay(&hash)
                                 );
 
                                 let best_block_hash = runtime_subscription
@@ -532,10 +541,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                             .await;
                                     }
 
-                                    log::debug!(
-                                        target: &self.log_target,
-                                        "Subscriptions <= BestBlockChanged(hash={})",
-                                        HashDisplay(&parahash)
+                                    log!(
+                                        &self.platform,
+                                        Debug,
+                                        &self.log_target,
+                                        "subscriptions-notify-best-block-changed",
+                                        hash = HashDisplay(&parahash)
                                     );
 
                                     // Elements in `all_subscriptions` are removed one by one and
@@ -609,10 +620,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                                 .await;
                                         }
 
-                                        log::debug!(
-                                            target: &self.log_target,
-                                            "Subscriptions <= BestBlockChanged(hash={})",
-                                            HashDisplay(&parahash)
+                                        log!(
+                                            &self.platform,
+                                            Debug,
+                                            &self.log_target,
+                                            "subscriptions-notify-best-block-changed",
+                                            hash = HashDisplay(&parahash)
                                         );
 
                                         // Elements in `all_subscriptions` are removed one by one and
@@ -635,10 +648,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                     continue;
                                 }
 
-                                log::debug!(
-                                    target: &self.log_target,
-                                    "Subscriptions <= NewParablock(hash={})",
-                                    HashDisplay(&parahash)
+                                log!(
+                                    &self.platform,
+                                    Debug,
+                                    &self.log_target,
+                                    "subscriptions-notify-new-parablock",
+                                    hash = HashDisplay(&parahash)
                                 );
 
                                 if is_new_best {
@@ -715,10 +730,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                 Box::pin(future::pending());
                         }
                         async_tree::NextNecessaryAsyncOp::Ready(op) => {
-                            log::debug!(
-                                target: &self.log_target,
-                                "ParaheadFetchOperations <= StartFetch(relay_block_hash={})",
-                                HashDisplay(op.block_user_data),
+                            log!(
+                                &self.platform,
+                                Debug,
+                                &self.log_target,
+                                "parahead-fetch-operation-started",
+                                relay_block_hash = HashDisplay(op.block_user_data),
                             );
 
                             runtime_subscription.in_progress_paraheads.push({
@@ -761,10 +778,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     ParachainBackgroundState::Subscribed(runtime_subscription),
                 ) => {
                     // Relay chain has a new finalized block.
-                    log::debug!(
-                        target: &self.log_target,
-                        "RelayChain => Finalized(hash={})",
-                        HashDisplay(&hash)
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-block-finalized",
+                        hash = HashDisplay(&hash)
                     );
 
                     let finalized = runtime_subscription
@@ -792,11 +811,13 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     // Relay chain has a new block.
                     let hash = header::hash_from_scale_encoded_header(&block.scale_encoded_header);
 
-                    log::debug!(
-                        target: &self.log_target,
-                        "RelayChain => Block(hash={}, parent_hash={})",
-                        HashDisplay(&hash),
-                        HashDisplay(&block.parent_hash)
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-new-block",
+                        hash = HashDisplay(&hash),
+                        parent_hash = HashDisplay(&block.parent_hash)
                     );
 
                     let parent = runtime_subscription
@@ -822,10 +843,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     ParachainBackgroundState::Subscribed(runtime_subscription),
                 ) => {
                     // Relay chain has a new best block.
-                    log::debug!(
-                        target: &self.log_target,
-                        "RelayChain => BestBlockChanged(hash={})",
-                        HashDisplay(&hash)
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-best-block-changed",
+                        hash = HashDisplay(&hash)
                     );
 
                     // If the block isn't found in `async_tree`, assume that it is equal to the
@@ -844,7 +867,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
 
                 (WakeUpReason::SubscriptionDead, _) => {
                     // Recreate the channel.
-                    log::debug!(target: &self.log_target, "Subscriptions <= Reset");
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-subscription-reset"
+                    );
                     self.subscription_state = ParachainBackgroundState::NotSubscribed {
                         all_subscriptions: Vec::new(),
                         subscribe_future: {
@@ -869,11 +897,19 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     ParachainBackgroundState::Subscribed(runtime_subscription),
                 ) => {
                     // A parahead fetching operation is successful.
-                    log::debug!(
-                        target: &self.log_target,
-                        "ParaheadFetchOperations => Parahead(hash={}, relay_blocks={})",
-                        HashDisplay(blake2_rfc::blake2b::blake2b(32, b"", &parahead).as_bytes()),
-                        runtime_subscription.async_tree.async_op_blocks(async_op_id).map(|b| HashDisplay(b)).join(",")
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "parahead-fetch-operation-success",
+                        parahead_hash = HashDisplay(
+                            blake2_rfc::blake2b::blake2b(32, b"", &parahead).as_bytes()
+                        ),
+                        relay_blocks = runtime_subscription
+                            .async_tree
+                            .async_op_blocks(async_op_id)
+                            .map(|b| HashDisplay(b))
+                            .join(",")
                     );
 
                     // Unpin the relay blocks whose parahead is now known.
@@ -903,7 +939,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                     // The relay chain runtime service has some kind of gap or issue and has
                     // discarded the runtime.
                     // Destroy the subscription and recreate the channels.
-                    log::debug!(target: &self.log_target, "Subscriptions <= Reset");
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "relay-chain-subscription-reset"
+                    );
                     self.subscription_state = ParachainBackgroundState::NotSubscribed {
                         all_subscriptions: Vec::new(),
                         subscribe_future: {
@@ -943,19 +984,33 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                         .await
                         && !error.is_network_problem()
                     {
-                        log::error!(
-                            target: &self.log_target,
-                            "Failed to fetch the parachain head from relay chain blocks {}: {}",
-                            runtime_subscription.async_tree.async_op_blocks(async_op_id).map(|b| HashDisplay(b)).join(", "),
-                            error
+                        log!(
+                            &self.platform,
+                            Error,
+                            &self.log_target,
+                            format!(
+                                "Failed to fetch the parachain head from relay chain blocks {}: {}",
+                                runtime_subscription
+                                    .async_tree
+                                    .async_op_blocks(async_op_id)
+                                    .map(|b| HashDisplay(b))
+                                    .join(", "),
+                                error
+                            )
                         );
                     }
 
-                    log::debug!(
-                        target: &self.log_target,
-                        "ParaheadFetchOperations => Error(relay_blocks={}, error={:?})",
-                        runtime_subscription.async_tree.async_op_blocks(async_op_id).map(|b| HashDisplay(b)).join(","),
-                        error
+                    log!(
+                        &self.platform,
+                        Debug,
+                        &self.log_target,
+                        "parahead-fetch-operation-error",
+                        relay_blocks = runtime_subscription
+                            .async_tree
+                            .async_op_blocks(async_op_id)
+                            .map(|b| HashDisplay(b))
+                            .join(","),
+                        ?error
                     );
 
                     runtime_subscription

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::ToBackground;
-use crate::{network_service, platform::PlatformRef, runtime_service, util};
+use crate::{log, network_service, platform::PlatformRef, runtime_service, util};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -18,7 +18,7 @@
 use super::ToBackground;
 use crate::{network_service, platform::PlatformRef, runtime_service, util};
 
-use alloc::{borrow::ToOwned as _, boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{
     iter, mem,
     num::{NonZeroU32, NonZeroUsize},

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -19,7 +19,7 @@ use super::{
     BlockNotification, ConfigRelayChainRuntimeCodeHint, FinalizedBlockRuntime, Notification,
     SubscribeAll, ToBackground,
 };
-use crate::{network_service, platform::PlatformRef, util};
+use crate::{log, network_service, platform::PlatformRef, util};
 
 use alloc::{
     borrow::{Cow, ToOwned as _},

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -67,7 +67,7 @@
 //! transaction.
 //!
 
-use crate::{network_service, platform::PlatformRef, runtime_service, sync_service};
+use crate::{log, network_service, platform::PlatformRef, runtime_service, sync_service};
 
 use alloc::{
     borrow::ToOwned as _,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Most of the log messages emitted by smoldot have been modified in order to unify their syntax and be easier to parse programatically. ([#1560](https://github.com/smol-dot/smoldot/pull/1560))
+
 ### Fixed
 
 - Fix the nodes discovery process being slow for chains that are added long after the smoldot client has started. This was caused by the fact that the discovery was started at the same time for all chains, and that this discovery intentionally slows down over time. The discovery is now performed and slowed down for each chain individually. ([#1544](https://github.com/smol-dot/smoldot/pull/1544))

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -26,7 +26,6 @@ fnv = { version = "1.0.7", default-features = false }
 futures-lite = { version = "2.0.0", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.14.0", default-features = false }
-log = { version = "0.4.18", default-features = false }
 nom = { version = "7.1.3", default-features = false }
 no-std-net = { version = "0.6.0", default-features = false }
 pin-project = "1.1.3"

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -17,7 +17,7 @@
 
 use crate::{allocator, bindings, platform, timers::Delay};
 
-use alloc::{boxed::Box, string::String};
+use alloc::{boxed::Box, format, string::String};
 use core::{iter, sync::atomic::Ordering, time::Duration};
 use futures_util::stream;
 use smoldot::informant::BytesDisplay;
@@ -63,7 +63,7 @@ pub(crate) fn init(max_log_level: u32) {
     platform::PLATFORM_REF.log(
         smoldot_light::platform::LogLevel::Info,
         "smoldot",
-        format_args!("Smoldot v{}", env!("CARGO_PKG_VERSION")),
+        &format!("Smoldot v{}", env!("CARGO_PKG_VERSION")),
         iter::empty(),
     );
 
@@ -101,7 +101,7 @@ pub(crate) fn init(max_log_level: u32) {
             platform::PLATFORM_REF.log(
                 smoldot_light::platform::LogLevel::Info,
                 "smoldot",
-                format_args!(
+                &format!(
                     "Smoldot v{}. Current memory usage: {}. \
                     Average download: {}/s. Average upload: {}/s.",
                     env!("CARGO_PKG_VERSION"),

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -180,6 +180,23 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         runnable.schedule();
     }
 
+    fn log<'a>(
+        &self,
+        log_level: LogLevel,
+        log_target: &'a str,
+        message: fmt::Arguments<'a>,
+        key_values: impl Iterator<Item = (&'a str, &'a dyn fmt::Display)>,
+    ) {
+        // TODO:
+        log::logger().log(
+            &log::RecordBuilder::new()
+                //.level(todo!())
+                .target(log_target)
+                .args(message)
+                .build(),
+        )
+    }
+
     fn client_name(&self) -> Cow<str> {
         env!("CARGO_PKG_NAME").into()
     }


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/756

This PR removes usage of the `log` crate from the light client and instead adds a new function on the `PlatformRef` trait.
The `DefaultPlatform` uses the `log` crate, which means that the behavior actually doesn't change compared to before.

This PR is however a breaking change as it modifies the `PlatformRef` trait. See the changes to `light-base/src/platform/default.rs` to see how to migrate. cc @skunert @ermalkaleci @lexnv as a heads up.

I'm doing this for two reasons:

- Having key-values logging is better than just a plain message for a variety of reasons, notably being able to parse log messages more easily for indexing. The `kv_unstable` feature of the `log` crate has been there for, I don't know, years? and still is nowhere near stabilization.
- In case where there are multiple smoldot light clients running in parallel in the same process, which is useful in testing situations, it is useful to be able to add a prefix before the target of every log message. This is simply impossible to do with the `log` crate (there's a reason why global variables are considered as a bad thing).

An alternative could have been to use the `tracing` crate, but I generally really dislike the `tracing` crate due to being over-engineered and confusing. It shouldn't take ten of hours of learning in order to print a log message.

As part of this refactoring, I've rewritten all the log messages. Since logs are mostly for bug reports, this should be completely fine. I think and I hope that nobody was parsing log message programatically.
