### PR TITLE
Rework runtime service to directly perform runtime calls

### DIFF
--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -926,7 +926,8 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 }
             })?;
 
-        let precall = self
+        // TODO: consider keeping pinned runtimes in a cache instead
+        Ok(self
             .runtime_service
             .pinned_runtime_access(
                 pinned_runtime_id.clone(),
@@ -934,12 +935,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 block_number,
                 state_trie_root_hash,
             )
-            .await;
-
-        // TODO: consider keeping pinned runtimes in a cache instead
-        self.runtime_service.unpin_runtime(pinned_runtime_id).await;
-
-        Ok(precall)
+            .await)
     }
 
     /// Performs a runtime call to a random block.

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -1018,7 +1018,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             )
             .await
         {
-            Ok(output) => Ok((output, todo!())),
+            Ok(output) => Ok((output.output, output.api_version)),
             Err(error) => {
                 return Err(RuntimeCallError::Call(error));
             }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -785,7 +785,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
     ) -> Result<(runtime_service::PinnedRuntime, [u8; 32], u64), RuntimeCallError> {
         // Try to find the block in the cache of recent blocks. Most of the time, the call target
         // should be in there.
-        if let Some(pinned_runtime) = {
+        if let Some((pinned_runtime, state_trie_root_hash, block_number)) = {
             let (tx, rx) = oneshot::channel();
             self.to_legacy
                 .lock()
@@ -798,7 +798,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                 .unwrap();
             rx.await.unwrap()
         } {
-            return Ok(pinned_runtime);
+            return Ok((pinned_runtime, state_trie_root_hash, block_number));
         };
 
         // Second situation: the block is not in the cache of recent blocks. This isn't great.
@@ -1044,7 +1044,7 @@ enum RuntimeCallError {
     #[display(fmt = "Failed to obtain block state trie root: {_0}")]
     FindStorageRootHashError(legacy_state_sub::StateTrieRootHashError),
     #[display(fmt = "{_0}")]
-    Call(runtime_service::RuntimeCallError2),
+    Call(runtime_service::RuntimeCallError),
 }
 
 #[derive(Debug)]

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -858,8 +858,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
                     NonZeroU32::new(1).unwrap(),
                 )
                 .await
-                .map_err(runtime_service::RuntimeCallError::StorageQuery)
-                .map_err(RuntimeCallError::Call)?;
+                .map_err(RuntimeCallError::StorageQuery)?;
             // TODO: not elegant
             let heap_pages = entries
                 .iter()
@@ -923,7 +922,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
             .await
             .map_err(|err| match err {
                 runtime_service::CompileAndPinRuntimeError::Crash => {
-                    RuntimeCallError::RuntimeServiceCrash
+                    RuntimeCallError::Call(runtime_service::RuntimeCallError::Crash)
                 }
             })?;
 
@@ -1043,6 +1042,8 @@ enum RuntimeCallError {
     /// Error while finding the storage root hash of the requested block.
     #[display(fmt = "Failed to obtain block state trie root: {_0}")]
     FindStorageRootHashError(legacy_state_sub::StateTrieRootHashError),
+    /// Error while downloading the runtime from the network.
+    StorageQuery(sync_service::StorageQueryError),
     #[display(fmt = "{_0}")]
     Call(runtime_service::RuntimeCallError),
 }

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -39,7 +39,6 @@ use core::{
 };
 use futures_channel::oneshot;
 use smoldot::{
-    executor::{host, runtime_call},
     json_rpc::{self, methods, service},
     libp2p::{multiaddr, PeerId},
 };

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1294,7 +1294,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                     return;
                 }
 
-                let pinned_runtime = match self
+                match self
                     .runtime_service
                     .pin_pinned_block_runtime(subscription_id, hash.0)
                     .await
@@ -1310,27 +1310,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                         ));
                         return;
                     }
-                };
-
-                let (block_state_trie_root_hash, block_number) = match self
-                    .runtime_service
-                    .pinned_block_state_trie_root_hash_number(subscription_id, hash.0)
-                    .await
-                {
-                    Ok(r) => r,
-                    Err(runtime_service::PinnedBlockStateTrieRootHashNumberError::BlockNotPinned) => {
-                        unreachable!()
-                    }
-                    Err(runtime_service::PinnedBlockStateTrieRootHashNumberError::ObsoleteSubscription) => {
-                        // The runtime service subscription is dead.
-                        request.respond(methods::Response::chainHead_unstable_call(
-                            methods::ChainHeadBodyCallReturn::LimitReached {},
-                        ));
-                        return;
-                    }
-                };
-
-                (pinned_runtime, block_state_trie_root_hash, block_number)
+                }
             }
             Subscription::WithoutRuntime(_) => {
                 // It is invalid to call this function for a "without runtime" subscription.

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1380,7 +1380,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::InvalidRuntime(error)) => {
+                    Err(runtime_service::RuntimeCallError::InvalidRuntime(error)) => {
                         let _ = to_main_task
                             .send(OperationEvent {
                                 operation_id: operation_id.clone(),
@@ -1392,12 +1392,12 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::ApiVersionRequirementUnfulfilled) => {
+                    Err(runtime_service::RuntimeCallError::ApiVersionRequirementUnfulfilled) => {
                         // We pass `None` for the API requirement, thus this error can never
                         // happen.
                         unreachable!()
                     }
-                    Err(runtime_service::RuntimeCallError2::Crash) => {
+                    Err(runtime_service::RuntimeCallError::Crash) => {
                         // TODO: is this the appropriate error?
                         let _ = to_main_task
                             .send(OperationEvent {
@@ -1409,7 +1409,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::Execution(
+                    Err(runtime_service::RuntimeCallError::Execution(
                         runtime_service::RuntimeCallExecutionError::ForbiddenHostFunction,
                     )) => {
                         let _ = to_main_task
@@ -1425,7 +1425,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::Execution(
+                    Err(runtime_service::RuntimeCallError::Execution(
                         runtime_service::RuntimeCallExecutionError::Start(error),
                     )) => {
                         let _ = to_main_task
@@ -1439,7 +1439,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::Execution(
+                    Err(runtime_service::RuntimeCallError::Execution(
                         runtime_service::RuntimeCallExecutionError::Execution(error),
                     )) => {
                         let _ = to_main_task
@@ -1453,7 +1453,7 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                             })
                             .await;
                     }
-                    Err(runtime_service::RuntimeCallError2::Inaccessible(_)) => {
+                    Err(runtime_service::RuntimeCallError::Inaccessible(_)) => {
                         let _ = to_main_task
                             .send(OperationEvent {
                                 operation_id: operation_id.clone(),

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -1368,14 +1368,14 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
                 };
 
                 match runtime_call_result {
-                    Ok(output) => {
+                    Ok(success) => {
                         let _ = to_main_task
                             .send(OperationEvent {
                                 operation_id: operation_id.clone(),
                                 is_done: true,
                                 notification: methods::FollowEvent::OperationCallDone {
                                     operation_id: operation_id.clone().into(),
-                                    output: methods::HexString(output),
+                                    output: methods::HexString(success.output),
                                 },
                             })
                             .await;

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -38,7 +38,7 @@ use smoldot::{
 use crate::{platform::PlatformRef, runtime_service, sync_service};
 
 /// Message that can be passed to the task started with [`start_task`].
-pub(super) enum Message<TPlat: PlatformRef> {
+pub(super) enum Message {
     /// JSON-RPC client has sent a subscription request.
     ///
     /// Only the legacy API subscription requests are supported. Any other will trigger a panic.
@@ -53,11 +53,11 @@ pub(super) enum Message<TPlat: PlatformRef> {
 
     /// The task must send back access to the runtime of the given block, or `None` if the block
     /// isn't available in the cache.
-    RecentBlockRuntimeAccess {
+    RecentBlockPinnedRuntime {
         /// Hash of the block to query.
         block_hash: [u8; 32],
         /// How to send back the result.
-        result_tx: oneshot::Sender<Option<runtime_service::RuntimeAccess<TPlat>>>,
+        result_tx: oneshot::Sender<Option<runtime_service::PinnedRuntime>>,
     },
 
     /// The task must send back the current best block hash.
@@ -138,7 +138,7 @@ pub(super) enum StateTrieRootHashError {
 /// JSON-RPC client starts.
 pub(super) fn start_task<TPlat: PlatformRef>(
     config: Config<TPlat>,
-) -> async_channel::Sender<Message<TPlat>> {
+) -> async_channel::Sender<Message> {
     let (requests_tx, requests_rx) = async_channel::bounded(8);
     let requests_rx = Box::pin(requests_rx);
 
@@ -217,9 +217,9 @@ struct Task<TPlat: PlatformRef> {
     best_block_report: Vec<oneshot::Sender<[u8; 32]>>,
 
     /// Sending side of [`Task::requests_rx`].
-    requests_tx: async_channel::WeakSender<Message<TPlat>>,
+    requests_tx: async_channel::WeakSender<Message>,
     /// How to receive messages from the API user.
-    requests_rx: Pin<Box<async_channel::Receiver<Message<TPlat>>>>,
+    requests_rx: Pin<Box<async_channel::Receiver<Message>>>,
 
     /// List of all active `chain_subscribeAllHeads` subscriptions, indexed by the subscription ID.
     // TODO: shrink_to_fit?
@@ -576,7 +576,7 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
             },
             SubscriptionDead,
             SubscriptionReady(runtime_service::SubscribeAll<TPlat>),
-            Message(Message<TPlat>),
+            Message(Message),
             ForegroundDead,
         }
 
@@ -999,7 +999,7 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 // TODO: shrink_to_fit?
             }
 
-            WakeUpReason::Message(Message::RecentBlockRuntimeAccess {
+            WakeUpReason::Message(Message::RecentBlockPinnedRuntime {
                 block_hash,
                 result_tx,
             }) => {
@@ -1021,10 +1021,20 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
                 };
 
                 let access = if let Some(subscription_id) = subscription_id_with_block {
-                    task.runtime_service
-                        .pinned_block_runtime_access(subscription_id, block_hash)
+                    match task
+                        .runtime_service
+                        .pin_pinned_block_runtime(subscription_id, block_hash)
                         .await
-                        .ok()
+                    {
+                        Ok(r) => Some(r),
+                        Err(runtime_service::PinPinnedBlockRuntimeError::BlockNotPinned) => {
+                            debug_assert!(false);
+                            None
+                        }
+                        Err(runtime_service::PinPinnedBlockRuntimeError::ObsoleteSubscription) => {
+                            None
+                        }
+                    }
                 } else {
                     None
                 };

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -57,7 +57,7 @@ pub(super) enum Message {
         /// Hash of the block to query.
         block_hash: [u8; 32],
         /// How to send back the result.
-        result_tx: oneshot::Sender<Option<runtime_service::PinnedRuntime>>,
+        result_tx: oneshot::Sender<Option<(runtime_service::PinnedRuntime, [u8; 32], u64)>>,
     },
 
     /// The task must send back the current best block hash.

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -51,10 +51,10 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let result = self
             .runtime_call(
                 &block_hash,
-                "AccountNonceApi",
+                "AccountNonceApi".to_owned(),
                 1..=1,
-                "AccountNonceApi_account_nonce",
-                iter::once(&account.0),
+                "AccountNonceApi_account_nonce".to_owned(),
+                account.0,
                 4,
                 Duration::from_secs(4),
                 NonZeroU32::new(2).unwrap(),
@@ -402,10 +402,16 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let result = self
             .runtime_call(
                 &block_hash,
-                "TransactionPaymentApi",
+                "TransactionPaymentApi".to_owned(),
                 1..=2,
-                json_rpc::payment_info::PAYMENT_FEES_FUNCTION_NAME,
-                json_rpc::payment_info::payment_info_parameters(&extrinsic.0),
+                json_rpc::payment_info::PAYMENT_FEES_FUNCTION_NAME.to_owned(),
+                json_rpc::payment_info::payment_info_parameters(&extrinsic.0).fold(
+                    Vec::new(),
+                    |mut a, b| {
+                        a.extend_from_slice(b.as_ref());
+                        a
+                    },
+                ),
                 4,
                 Duration::from_secs(4),
                 NonZeroU32::new(2).unwrap(),
@@ -468,8 +474,8 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let result = self
             .runtime_call_no_api_check(
                 &block_hash,
-                &function_to_call,
-                iter::once(call_parameters.0),
+                function_to_call.into_owned(),
+                call_parameters.0,
                 3,
                 Duration::from_secs(10),
                 NonZeroU32::new(3).unwrap(),
@@ -728,10 +734,10 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         let result = self
             .runtime_call(
                 &block_hash,
-                "Metadata",
+                "Metadata".to_owned(),
                 1..=2,
-                "Metadata_metadata",
-                iter::empty::<Vec<u8>>(),
+                "Metadata_metadata".to_owned(),
+                Vec::new(),
                 3,
                 Duration::from_secs(8),
                 NonZeroU32::new(1).unwrap(),
@@ -792,7 +798,7 @@ impl<TPlat: PlatformRef> Background<TPlat> {
         };
 
         match self
-            .runtime_access(&block_hash)
+            .pinned_runtime_and_block_info(&block_hash)
             .await
             .map(|l| l.specification())
         {

--- a/light-base/src/json_rpc_service/background/state_chain.rs
+++ b/light-base/src/json_rpc_service/background/state_chain.rs
@@ -21,7 +21,7 @@ use super::{legacy_state_sub, Background, GetKeysPagedCacheKey, PlatformRef};
 
 use crate::{log, sync_service};
 
-use alloc::{format, string::ToString as _, sync::Arc, vec, vec::Vec};
+use alloc::{borrow::ToOwned as _, format, string::ToString as _, sync::Arc, vec, vec::Vec};
 use core::{iter, num::NonZeroU32, time::Duration};
 use futures_channel::oneshot;
 use smoldot::{

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1228,9 +1228,6 @@ fn start_services<TPlat: platform::PlatformRef>(
                         finalized_block_header,
                         para_id,
                         relay_chain_sync: relay_chain.runtime_service.clone(),
-                        relay_chain_block_number_bytes: relay_chain
-                            .sync_service
-                            .block_number_bytes(),
                     },
                 ),
             }));

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -1239,6 +1239,7 @@ fn start_services<TPlat: platform::PlatformRef>(
                     log_name: log_name.clone(),
                     platform: platform.clone(),
                     sync_service: sync_service.clone(),
+                    network_service: network_service_chain.clone(),
                     genesis_block_scale_encoded_header,
                 },
             ));
@@ -1277,6 +1278,7 @@ fn start_services<TPlat: platform::PlatformRef>(
                     log_name: log_name.clone(),
                     platform: platform.clone(),
                     sync_service: sync_service.clone(),
+                    network_service: network_service_chain.clone(),
                     genesis_block_scale_encoded_header,
                 },
             ));

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -67,13 +67,13 @@ use smoldot::{
     libp2p::{
         connection,
         multiaddr::{self, Multiaddr},
-        peer_id::{self, PeerId},
+        peer_id,
     },
     network::{basic_peering_strategy, codec, service},
 };
 
-pub use codec::Role;
-pub use service::{ChainId, EncodedMerkleProof, QueueNotificationError};
+pub use codec::{CallProofRequestConfig, Role};
+pub use service::{ChainId, EncodedMerkleProof, PeerId, QueueNotificationError};
 
 mod tasks;
 

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -347,9 +347,8 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
 
     /// Performs a runtime call against a pinned block.
     ///
-    /// This function is a shortcut for calling [`RuntimeService::pin_pinned_block_runtime`],
-    /// [`RuntimeService::pinned_block_state_trie_root_hash_number`], and
-    /// [`RuntimeService:runtime_call`].
+    /// This function is a shortcut for calling [`RuntimeService::pin_pinned_block_runtime`]
+    /// and [`RuntimeService::runtime_call`].
     ///
     /// The hash of the block passed as parameter corresponds to the block whose runtime to use
     /// to make the call. The block must be currently pinned in the context of the provided
@@ -399,8 +398,7 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
 
     /// Tries to find a runtime within the [`RuntimeService`] that has the given storage code and
     /// heap pages. If none is found, compiles the runtime and stores it within the
-    /// [`RuntimeService`]. In both cases, it is kept pinned until it is unpinned with
-    /// [`RuntimeService::unpin_runtime`].
+    /// [`RuntimeService`].
     pub async fn compile_and_pin_runtime(
         &self,
         storage_code: Option<Vec<u8>>,
@@ -427,10 +425,7 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
         ))
     }
 
-    /// Tries to find a runtime within the [`RuntimeService`] that has the given storage code and
-    /// heap pages. If none is found, compiles the runtime and stores it within the
-    /// [`RuntimeService`]. In both cases, it is kept pinned until it is unpinned with
-    /// [`RuntimeService::unpin_runtime`].
+    /// Returns the runtime specification of the given runtime.
     pub async fn pinned_runtime_specification(
         &self,
         pinned_runtime: PinnedRuntime,
@@ -2803,7 +2798,7 @@ enum ProgressRuntimeCallRequest {
     },
 }
 
-/// See [`CallProofRequestDone::operation`].
+/// See [`ProgressRuntimeCallRequest`].
 struct RuntimeCallRequest {
     block_hash: [u8; 32],
     block_number: u64,

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -54,7 +54,7 @@
 //! large, the subscription is force-killed by the [`RuntimeService`].
 //!
 
-use crate::{log, network_service, platform::PlatformRef, sync_service};
+use crate::{log, platform::PlatformRef, sync_service};
 
 use alloc::{
     borrow::{Cow, ToOwned as _},
@@ -65,7 +65,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use async_lock::{Mutex, MutexGuard};
+use async_lock::Mutex;
 use core::{
     cmp, iter, mem,
     num::{NonZeroU32, NonZeroUsize},
@@ -81,8 +81,7 @@ use smoldot::{
     chain::async_tree,
     executor, header,
     informant::{BytesDisplay, HashDisplay},
-    network::codec,
-    trie::{self, proof_decode, Nibble, TrieEntryVersion},
+    trie::{self, proof_decode, Nibble},
 };
 
 /// Configuration for a runtime service.

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -422,6 +422,22 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
         ))
     }
 
+    /// Tries to find a runtime within the [`RuntimeService`] that has the given storage code and
+    /// heap pages. If none is found, compiles the runtime and stores it within the
+    /// [`RuntimeService`]. In both cases, it is kept pinned until it is unpinned with
+    /// [`RuntimeService::unpin_runtime`].
+    pub async fn pinned_runtime_specification(
+        &self,
+        pinned_runtime: PinnedRuntime,
+    ) -> Result<executor::CoreVersion, PinnedRuntimeSpecificationError> {
+        match &pinned_runtime.0.runtime {
+            Ok(rt) => Ok(rt.runtime_spec.clone()),
+            Err(error) => Err(PinnedRuntimeSpecificationError::InvalidRuntime(
+                error.clone(),
+            )),
+        }
+    }
+
     /// Returns true if it is believed that we are near the head of the chain.
     ///
     /// The way this method is implemented is opaque and cannot be relied on. The return value
@@ -637,6 +653,13 @@ pub enum PinnedBlockStateTrieRootHashNumberError {
 
     /// Requested block isn't pinned by the subscription.
     BlockNotPinned,
+}
+
+/// See [`RuntimeService::pinned_runtime_specification`].
+#[derive(Debug, derive_more::Display, Clone)]
+pub enum PinnedRuntimeSpecificationError {
+    /// The runtime is invalid.
+    InvalidRuntime(RuntimeError),
 }
 
 /// See [`RuntimeService::runtime_call`].

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -272,6 +272,9 @@ impl<TPlat: PlatformRef> RuntimeService<TPlat> {
         block_hash: [u8; 32],
         function_name: String,
         parameters_vectored: Vec<u8>,
+        total_attempts: u32,
+        timeout_per_request: Duration,
+        max_parallel: NonZeroU32,
     ) -> Result<Vec<u8>, PinnedBlockRuntimeCallError> {
         let (result_tx, result_rx) = oneshot::channel();
 

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2095,6 +2095,10 @@ async fn run_background<TPlat: PlatformRef>(
                             }
                         };
 
+                        // Yield once at every iteration. This avoids monopolizing the CPU for
+                        // too long.
+                        futures_lite::future::yield_now().await;
+
                         let child_trie = match call {
                             executor::runtime_call::RuntimeCall::Finished(Ok(finished)) => {
                                 // Execution finished successfully.

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -655,16 +655,6 @@ pub enum PinPinnedBlockRuntimeError {
     BlockNotPinned,
 }
 
-/// See [`RuntimeService::pinned_block_state_trie_root_hash_number`].
-#[derive(Debug, derive_more::Display, Clone)]
-pub enum PinnedBlockStateTrieRootHashNumberError {
-    /// Subscription is dead.
-    ObsoleteSubscription,
-
-    /// Requested block isn't pinned by the subscription.
-    BlockNotPinned,
-}
-
 /// See [`RuntimeService::pinned_runtime_specification`].
 #[derive(Debug, derive_more::Display, Clone)]
 pub enum PinnedRuntimeSpecificationError {

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -1030,14 +1030,6 @@ pub struct CallProofQueryError {
     pub errors: Vec<network_service::CallProofRequestError>,
 }
 
-impl CallProofQueryError {
-    /// Returns `true` if this is caused by networking issues, as opposed to a consensus-related
-    /// issue.
-    pub fn is_network_problem(&self) -> bool {
-        self.errors.iter().all(|err| err.is_network_problem())
-    }
-}
-
 impl fmt::Display for CallProofQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.errors.is_empty() {

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -106,9 +106,6 @@ pub struct ConfigParachain<TPlat: PlatformRef> {
     /// Runtime service that synchronizes the relay chain of this parachain.
     pub relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
 
-    /// Number of bytes used by the block number in the relay chain.
-    pub relay_chain_block_number_bytes: usize,
-
     /// SCALE-encoded header of a known finalized block of the parachain. Used in the situation
     /// where the API user subscribes using [`SyncService::subscribe_all`] before any parachain
     /// block can be gathered.
@@ -155,7 +152,6 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
                 config_parachain.finalized_block_header,
                 config.block_number_bytes,
                 config_parachain.relay_chain_sync.clone(),
-                config_parachain.relay_chain_block_number_bytes,
                 config_parachain.para_id,
                 from_foreground,
                 config.network_service.clone(),

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -44,6 +44,9 @@ use smoldot::{
 mod parachain;
 mod standalone;
 
+pub use codec::CallProofRequestConfig;
+pub use network_service::EncodedMerkleProof;
+
 /// Configuration for a [`SyncService`].
 pub struct Config<TPlat: PlatformRef> {
     /// Name of the chain, for logging purposes.
@@ -807,11 +810,11 @@ impl<TPlat: PlatformRef> SyncService<TPlat> {
     pub async fn call_proof_query(
         self: Arc<Self>,
         block_number: u64,
-        config: codec::CallProofRequestConfig<'_, impl Iterator<Item = impl AsRef<[u8]>> + Clone>,
+        config: CallProofRequestConfig<'_, impl Iterator<Item = impl AsRef<[u8]>> + Clone>,
         total_attempts: u32,
         timeout_per_request: Duration,
         _max_parallel: NonZeroU32,
-    ) -> Result<network_service::EncodedMerkleProof, CallProofQueryError> {
+    ) -> Result<EncodedMerkleProof, CallProofQueryError> {
         let mut outcome_errors =
             Vec::with_capacity(usize::try_from(total_attempts).unwrap_or(usize::max_value()));
 

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1395,13 +1395,24 @@ impl ParaheadError {
     fn is_network_problem(&self) -> bool {
         match self {
             ParaheadError::RuntimeCall(
-                runtime_service::PinnedBlockRuntimeCallError::Inaccessible(_),
+                runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
+                    runtime_service::RuntimeCallError2::Inaccessible(_),
+                ),
             ) => true,
             ParaheadError::RuntimeCall(
                 runtime_service::PinnedBlockRuntimeCallError::BlockNotPinned
-                | runtime_service::PinnedBlockRuntimeCallError::Execution(_)
-                | runtime_service::PinnedBlockRuntimeCallError::InvalidRuntime(_)
-                | runtime_service::PinnedBlockRuntimeCallError::ApiVersionRequirementUnfulfilled
+                | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
+                    runtime_service::RuntimeCallError2::Execution(_),
+                )
+                | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
+                    runtime_service::RuntimeCallError2::Crash,
+                )
+                | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
+                    runtime_service::RuntimeCallError2::InvalidRuntime(_),
+                )
+                | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
+                    runtime_service::RuntimeCallError2::ApiVersionRequirementUnfulfilled,
+                )
                 | runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription,
             ) => false,
             ParaheadError::NoCore => false,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1346,6 +1346,7 @@ async fn fetch_parahead<TPlat: PlatformRef>(
             subscription_id,
             *block_hash,
             para::PERSISTED_VALIDATION_FUNCTION_NAME.to_owned(),
+            None, // TODO: /!\
             para::persisted_validation_data_parameters(
                 parachain_id,
                 para::OccupiedCoreAssumption::TimedOut,
@@ -1400,6 +1401,7 @@ impl ParaheadError {
                 runtime_service::PinnedBlockRuntimeCallError::BlockNotPinned
                 | runtime_service::PinnedBlockRuntimeCallError::Execution(_)
                 | runtime_service::PinnedBlockRuntimeCallError::InvalidRuntime(_)
+                | runtime_service::PinnedBlockRuntimeCallError::ApiVersionRequirementUnfulfilled
                 | runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription,
             ) => false,
             ParaheadError::NoCore => false,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1396,22 +1396,22 @@ impl ParaheadError {
         match self {
             ParaheadError::RuntimeCall(
                 runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-                    runtime_service::RuntimeCallError2::Inaccessible(_),
+                    runtime_service::RuntimeCallError::Inaccessible(_),
                 ),
             ) => true,
             ParaheadError::RuntimeCall(
                 runtime_service::PinnedBlockRuntimeCallError::BlockNotPinned
                 | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-                    runtime_service::RuntimeCallError2::Execution(_),
+                    runtime_service::RuntimeCallError::Execution(_),
                 )
                 | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-                    runtime_service::RuntimeCallError2::Crash,
+                    runtime_service::RuntimeCallError::Crash,
                 )
                 | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-                    runtime_service::RuntimeCallError2::InvalidRuntime(_),
+                    runtime_service::RuntimeCallError::InvalidRuntime(_),
                 )
                 | runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-                    runtime_service::RuntimeCallError2::ApiVersionRequirementUnfulfilled,
+                    runtime_service::RuntimeCallError::ApiVersionRequirementUnfulfilled,
                 )
                 | runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription,
             ) => false,

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -1341,7 +1341,7 @@ async fn fetch_parahead<TPlat: PlatformRef>(
     block_hash: &[u8; 32],
 ) -> Result<Vec<u8>, ParaheadError> {
     // Call `ParachainHost_persisted_validation_data` in order to know where the parachain is.
-    let output = relay_chain_sync
+    let success = relay_chain_sync
         .pinned_block_runtime_call(
             subscription_id,
             *block_hash,
@@ -1365,7 +1365,7 @@ async fn fetch_parahead<TPlat: PlatformRef>(
     // Try decode the result of the runtime call.
     // If this fails, it indicates an incompatibility between smoldot and the relay chain.
     match para::decode_persisted_validation_data_return_value(
-        &output,
+        &success.output,
         relay_chain_sync.block_number_bytes(),
     ) {
         Ok(Some(pvd)) => Ok(pvd.parent_head.to_vec()),

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -20,7 +20,7 @@ use crate::{log, network_service, platform::PlatformRef, runtime_service, util};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{
-    iter, mem,
+    mem,
     num::{NonZeroU32, NonZeroUsize},
     pin::Pin,
     time::Duration,
@@ -31,7 +31,6 @@ use hashbrown::HashMap;
 use itertools::Itertools as _;
 use smoldot::{
     chain::async_tree,
-    executor::{host, runtime_call},
     header,
     informant::HashDisplay,
     libp2p::PeerId,
@@ -46,7 +45,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
     finalized_block_header: Vec<u8>,
     block_number_bytes: usize,
     relay_chain_sync: Arc<runtime_service::RuntimeService<TPlat>>,
-    relay_chain_block_number_bytes: usize,
     parachain_id: u32,
     from_foreground: Pin<Box<async_channel::Receiver<ToBackground>>>,
     network_service: Arc<network_service::NetworkServiceChain<TPlat>>,
@@ -55,7 +53,6 @@ pub(super) async fn start_parachain<TPlat: PlatformRef>(
         log_target,
         from_foreground,
         block_number_bytes,
-        relay_chain_block_number_bytes,
         parachain_id,
         from_network_service: None,
         network_service,
@@ -105,9 +102,6 @@ struct ParachainBackgroundTask<TPlat: PlatformRef> {
 
     /// Number of bytes to use to encode the parachain block numbers in headers.
     block_number_bytes: usize,
-
-    /// Number of bytes to use to encode the relay chain block numbers in headers.
-    relay_chain_block_number_bytes: usize,
 
     /// Id of the parachain registered within the relay chain. Chosen by the user.
     parachain_id: u32,
@@ -744,15 +738,12 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                     runtime_subscription.relay_chain_subscribe_all.id();
                                 let block_hash = *op.block_user_data;
                                 let async_op_id = op.id;
-                                let relay_chain_block_number_bytes =
-                                    self.relay_chain_block_number_bytes;
                                 let parachain_id = self.parachain_id;
                                 Box::pin(async move {
                                     (
                                         async_op_id,
                                         fetch_parahead(
                                             &relay_chain_sync,
-                                            relay_chain_block_number_bytes,
                                             subscription_id,
                                             parachain_id,
                                             &block_hash,
@@ -931,7 +922,10 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
 
                 (
                     WakeUpReason::ParaheadFetchFinished {
-                        parahead_result: Err(ParaheadError::ObsoleteSubscription),
+                        parahead_result:
+                            Err(ParaheadError::RuntimeCall(
+                                runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription,
+                            )),
                         ..
                     },
                     _,
@@ -1342,149 +1336,36 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
 
 async fn fetch_parahead<TPlat: PlatformRef>(
     relay_chain_sync: &Arc<runtime_service::RuntimeService<TPlat>>,
-    relay_chain_block_number_bytes: usize,
     subscription_id: runtime_service::SubscriptionId,
     parachain_id: u32,
     block_hash: &[u8; 32],
 ) -> Result<Vec<u8>, ParaheadError> {
-    // For each relay chain block, call `ParachainHost_persisted_validation_data` in
-    // order to know where the parachains are.
-    let precall = match relay_chain_sync
-        .pinned_block_runtime_access(subscription_id, *block_hash)
-        .await
-    {
-        Ok(p) => p,
-        Err(runtime_service::PinnedBlockRuntimeAccessError::ObsoleteSubscription) => {
-            return Err(ParaheadError::ObsoleteSubscription)
-        }
-    };
-
-    let (runtime_call_lock, virtual_machine) = precall
-        .start(
-            para::PERSISTED_VALIDATION_FUNCTION_NAME,
+    // Call `ParachainHost_persisted_validation_data` in order to know where the parachain is.
+    let output = relay_chain_sync
+        .pinned_block_runtime_call(
+            subscription_id,
+            *block_hash,
+            para::PERSISTED_VALIDATION_FUNCTION_NAME.to_owned(),
             para::persisted_validation_data_parameters(
                 parachain_id,
                 para::OccupiedCoreAssumption::TimedOut,
-            ),
+            )
+            .fold(Vec::new(), |mut a, b| {
+                a.extend_from_slice(b.as_ref());
+                a
+            }),
             6,
             Duration::from_secs(10),
             NonZeroU32::new(2).unwrap(),
         )
         .await
-        .map_err(ParaheadError::Call)?;
-
-    // TODO: move the logic below in the `para` module
-
-    let mut runtime_call = match runtime_call::run(runtime_call::Config {
-        virtual_machine,
-        function_to_call: para::PERSISTED_VALIDATION_FUNCTION_NAME,
-        parameter: para::persisted_validation_data_parameters(
-            parachain_id,
-            para::OccupiedCoreAssumption::TimedOut,
-        ),
-        max_log_level: 0,
-        storage_main_trie_changes: Default::default(),
-        calculate_trie_changes: false,
-    }) {
-        Ok(vm) => vm,
-        Err((err, prototype)) => {
-            runtime_call_lock.unlock(prototype);
-            return Err(ParaheadError::StartError(err));
-        }
-    };
-
-    let output = loop {
-        match runtime_call {
-            runtime_call::RuntimeCall::Finished(Ok(success)) => {
-                let output = success.virtual_machine.value().as_ref().to_owned();
-                runtime_call_lock.unlock(success.virtual_machine.into_prototype());
-                break output;
-            }
-            runtime_call::RuntimeCall::Finished(Err(error)) => {
-                runtime_call_lock.unlock(error.prototype);
-                return Err(ParaheadError::Runtime(error.detail));
-            }
-            runtime_call::RuntimeCall::StorageGet(get) => {
-                let storage_value = {
-                    let child_trie = get.child_trie();
-                    runtime_call_lock
-                        .storage_entry(child_trie.as_ref().map(|c| c.as_ref()), get.key().as_ref())
-                };
-                let storage_value = match storage_value {
-                    Ok(v) => v,
-                    Err(err) => {
-                        runtime_call_lock
-                            .unlock(runtime_call::RuntimeCall::StorageGet(get).into_prototype());
-                        return Err(ParaheadError::Call(err));
-                    }
-                };
-                runtime_call =
-                    get.inject_value(storage_value.map(|(val, ver)| (iter::once(val), ver)));
-            }
-            runtime_call::RuntimeCall::NextKey(nk) => {
-                let next_key = {
-                    let child_trie = nk.child_trie();
-                    runtime_call_lock.next_key(
-                        child_trie.as_ref().map(|c| c.as_ref()),
-                        nk.key(),
-                        nk.or_equal(),
-                        nk.prefix(),
-                        nk.branch_nodes(),
-                    )
-                };
-                let next_key = match next_key {
-                    Ok(v) => v,
-                    Err(err) => {
-                        runtime_call_lock
-                            .unlock(runtime_call::RuntimeCall::NextKey(nk).into_prototype());
-                        return Err(ParaheadError::Call(err));
-                    }
-                };
-                runtime_call = nk.inject_key(next_key);
-            }
-            runtime_call::RuntimeCall::ClosestDescendantMerkleValue(mv) => {
-                let merkle_value = {
-                    let child_trie = mv.child_trie();
-                    runtime_call_lock.closest_descendant_merkle_value(
-                        child_trie.as_ref().map(|c| c.as_ref()),
-                        mv.key(),
-                    )
-                };
-                let merkle_value = match merkle_value {
-                    Ok(v) => v,
-                    Err(err) => {
-                        runtime_call_lock.unlock(
-                            runtime_call::RuntimeCall::ClosestDescendantMerkleValue(mv)
-                                .into_prototype(),
-                        );
-                        return Err(ParaheadError::Call(err));
-                    }
-                };
-                runtime_call = mv.inject_merkle_value(merkle_value);
-            }
-            runtime_call::RuntimeCall::SignatureVerification(sig) => {
-                runtime_call = sig.verify_and_resume();
-            }
-            runtime_call::RuntimeCall::OffchainStorageSet(req) => {
-                // Do nothing.
-                runtime_call = req.resume();
-            }
-            runtime_call::RuntimeCall::Offchain(req) => {
-                runtime_call_lock.unlock(runtime_call::RuntimeCall::Offchain(req).into_prototype());
-                return Err(ParaheadError::OffchainWorkerHostFunction);
-            }
-            runtime_call::RuntimeCall::LogEmit(log) => {
-                // Logs are ignored.
-                runtime_call = log.resume();
-            }
-        }
-    };
+        .map_err(ParaheadError::RuntimeCall)?;
 
     // Try decode the result of the runtime call.
     // If this fails, it indicates an incompatibility between smoldot and the relay chain.
     match para::decode_persisted_validation_data_return_value(
         &output,
-        relay_chain_block_number_bytes,
+        relay_chain_sync.block_number_bytes(),
     ) {
         Ok(Some(pvd)) => Ok(pvd.parent_head.to_vec()),
         Ok(None) => Err(ParaheadError::NoCore),
@@ -1497,13 +1378,7 @@ async fn fetch_parahead<TPlat: PlatformRef>(
 enum ParaheadError {
     /// Error while performing call request over the network.
     #[display(fmt = "Error while performing call request over the network: {_0}")]
-    Call(runtime_service::RuntimeCallError),
-    /// Error while starting virtual machine to verify call proof.
-    #[display(fmt = "Error while starting virtual machine to verify call proof: {_0}")]
-    StartError(host::StartErr),
-    /// Error during the execution of the virtual machine to verify call proof.
-    #[display(fmt = "Error during the call proof verification: {_0}")]
-    Runtime(runtime_call::ErrorDetail),
+    RuntimeCall(runtime_service::PinnedBlockRuntimeCallError),
     /// Parachain doesn't have a core in the relay chain.
     NoCore,
     /// Error while decoding the output of the call.
@@ -1511,10 +1386,6 @@ enum ParaheadError {
     /// This indicates some kind of incompatibility between smoldot and the relay chain.
     #[display(fmt = "Error while decoding the output of the call: {_0}")]
     InvalidRuntimeOutput(para::Error),
-    /// Runtime has called an offchain worker host function.
-    OffchainWorkerHostFunction,
-    /// Runtime service subscription is no longer valid.
-    ObsoleteSubscription,
 }
 
 impl ParaheadError {
@@ -1522,13 +1393,17 @@ impl ParaheadError {
     /// issue.
     fn is_network_problem(&self) -> bool {
         match self {
-            ParaheadError::Call(err) => err.is_network_problem(),
-            ParaheadError::StartError(_) => false,
-            ParaheadError::Runtime(_) => false,
+            ParaheadError::RuntimeCall(
+                runtime_service::PinnedBlockRuntimeCallError::Inaccessible(_),
+            ) => true,
+            ParaheadError::RuntimeCall(
+                runtime_service::PinnedBlockRuntimeCallError::BlockNotPinned
+                | runtime_service::PinnedBlockRuntimeCallError::Execution(_)
+                | runtime_service::PinnedBlockRuntimeCallError::InvalidRuntime(_)
+                | runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription,
+            ) => false,
             ParaheadError::NoCore => false,
             ParaheadError::InvalidRuntimeOutput(_) => false,
-            ParaheadError::OffchainWorkerHostFunction => false,
-            ParaheadError::ObsoleteSubscription => false,
         }
     }
 }

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1460,35 +1460,35 @@ async fn validate_transaction<TPlat: PlatformRef>(
             return Err(ValidationError::ObsoleteSubscription)
         }
         Err(runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-            runtime_service::RuntimeCallError2::Execution(error),
+            runtime_service::RuntimeCallError::Execution(error),
         )) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Execution(error)),
             ))
         }
         Err(runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-            runtime_service::RuntimeCallError2::Crash,
+            runtime_service::RuntimeCallError::Crash,
         )) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Crash),
             ))
         }
         Err(runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-            runtime_service::RuntimeCallError2::Inaccessible(errors),
+            runtime_service::RuntimeCallError::Inaccessible(errors),
         )) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Inaccessible(errors)),
             ))
         }
         Err(runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-            runtime_service::RuntimeCallError2::InvalidRuntime(error),
+            runtime_service::RuntimeCallError::InvalidRuntime(error),
         )) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::InvalidRuntime(error)),
             ))
         }
         Err(runtime_service::PinnedBlockRuntimeCallError::RuntimeCall(
-            runtime_service::RuntimeCallError2::ApiVersionRequirementUnfulfilled,
+            runtime_service::RuntimeCallError::ApiVersionRequirementUnfulfilled,
         )) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1454,7 +1454,7 @@ async fn validate_transaction<TPlat: PlatformRef>(
         .unwrap_or_else(|| "unknown".to_owned())
     );
 
-    let output = match runtime_call_future.await {
+    let success = match runtime_call_future.await {
         Ok(output) => output,
         Err(runtime_service::PinnedBlockRuntimeCallError::ObsoleteSubscription) => {
             return Err(ValidationError::ObsoleteSubscription)
@@ -1499,7 +1499,7 @@ async fn validate_transaction<TPlat: PlatformRef>(
         Err(runtime_service::PinnedBlockRuntimeCallError::BlockNotPinned) => unreachable!(),
     };
 
-    match validate::decode_validate_transaction_return_value(&output) {
+    match validate::decode_validate_transaction_return_value(&success.output) {
         Ok(Ok(decoded)) => Ok(decoded),
         Ok(Err(err)) => Err(ValidationError::InvalidOrError(InvalidOrError::Invalid(
             err,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -1422,7 +1422,7 @@ async fn validate_transaction<TPlat: PlatformRef>(
         relay_chain_sync_subscription_id,
         block_hash,
         validate::VALIDATION_FUNCTION_NAME.to_owned(),
-        Some(("TaggedTransactionQueue".to_owned(), 3)),
+        Some(("TaggedTransactionQueue".to_owned(), 3..=3)),
         validate::validate_transaction_runtime_parameters_v3(
             iter::once(scale_encoded_transaction.as_ref()),
             source,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fix the nodes discovery process being slow for chains that are added long after the smoldot client has started. This was caused by the fact that the discovery was started at the same time for all chains, and that this discovery intentionally slows down over time. The discovery is now performed and slowed down for each chain individually. ([#1544](https://github.com/smol-dot/smoldot/pull/1544))
+- The `chainHead_unstable_call` JSON-RPC function now produces a `operationInaccessible` event instead of an `operationError` event when peers send back bad or incomplete Merkle proofs.
 
 ## 2.0.16 - 2023-12-29
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,8 +9,8 @@
 ### Fixed
 
 - Fix the nodes discovery process being slow for chains that are added long after the smoldot client has started. This was caused by the fact that the discovery was started at the same time for all chains, and that this discovery intentionally slows down over time. The discovery is now performed and slowed down for each chain individually. ([#1544](https://github.com/smol-dot/smoldot/pull/1544))
-- Runtime calls no longer fail instantly when a peer sends back an invalid Merkle proof. Instead, the call proof is requested again from a different peer.
-- The `chainHead_unstable_call` JSON-RPC function now produces a `operationInaccessible` event instead of an `operationError` event when peers send back bad or incomplete Merkle proofs.
+- Runtime calls no longer fail instantly when a peer sends back an invalid Merkle proof. Instead, the call proof is requested again from a different peer. ([#1570](https://github.com/smol-dot/smoldot/pull/1570))
+- The `chainHead_unstable_call` JSON-RPC function now produces a `operationInaccessible` event instead of an `operationError` event when peers send back bad or incomplete Merkle proofs. ([#1570](https://github.com/smol-dot/smoldot/pull/1570))
 
 ## 2.0.16 - 2023-12-29
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fix the nodes discovery process being slow for chains that are added long after the smoldot client has started. This was caused by the fact that the discovery was started at the same time for all chains, and that this discovery intentionally slows down over time. The discovery is now performed and slowed down for each chain individually. ([#1544](https://github.com/smol-dot/smoldot/pull/1544))
+- Runtime calls no longer fail instantly when a peer sends back an invalid Merkle proof. Instead, the call proof is requested again from a different peer.
 - The `chainHead_unstable_call` JSON-RPC function now produces a `operationInaccessible` event instead of an `operationError` event when peers send back bad or incomplete Merkle proofs.
 
 ## 2.0.16 - 2023-12-29


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1524

This PR refactors the runtime call "infrastructure" of the light client.

Beforehand, runtime calls suffered from many issues: the sync service would try to download call proofs multiple times but without giving a guarantee that the call proof is correct, the runtime service would have this awkward runtime access system, and the runtime call code was duplicated a couple of times throughout the node.

This PR fixes all of this by making the runtime service directly sends call proof requests using the network service, and directly execute runtime calls.

The runtime service is now much more clean, and can IMO be considered as having a stable API from now on.
