### PR TITLE
Pass the remote certificate by reference in `MultiStreamAddress`

### DIFF
--- a/lib/src/libp2p/multihash.rs
+++ b/lib/src/libp2p/multihash.rs
@@ -59,6 +59,11 @@ impl<T: AsRef<[u8]>> Multihash<T> {
 }
 
 impl<'a> Multihash<&'a [u8]> {
+    /// Returns the data stored in this multihash.
+    pub fn data_ref(&self) -> &'a [u8] {
+        decode(&self.0.as_ref()).unwrap().1
+    }
+
     /// Checks whether `input` is a valid multihash.
     ///
     /// Contrary to [`Multihash::from_bytes`], doesn't return an error if the slice is too long

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -2662,7 +2662,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                             .collect();
                         let remote_tls_certificate_multihash = [18u8, 32]
                             .into_iter()
-                            .chain(remote_certificate_sha256.into_iter())
+                            .chain(remote_certificate_sha256.into_iter().copied())
                             .collect();
 
                         let (connection_id, connection_task) =

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -385,7 +385,7 @@ impl<'a> From<&'a Address<'a>> for ConnectionType {
     }
 }
 
-impl<'a> From<&'a MultiStreamAddress> for ConnectionType {
+impl<'a> From<&'a MultiStreamAddress<'a>> for ConnectionType {
     fn from(address: &'a MultiStreamAddress) -> ConnectionType {
         match address {
             MultiStreamAddress::WebRtc {
@@ -454,7 +454,7 @@ pub enum Address<'a> {
 /// Address passed to [`PlatformRef::connect_multistream`].
 // TODO: we don't differentiate between Dns4 and Dns6
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum MultiStreamAddress {
+pub enum MultiStreamAddress<'a> {
     /// Libp2p-specific WebRTC flavour.
     ///
     /// The implementation the [`PlatformRef`] trait is responsible for opening the SCTP
@@ -467,8 +467,7 @@ pub enum MultiStreamAddress {
         /// UDP port to connect to.
         port: u16,
         /// SHA-256 hash of the target's WebRTC certificate.
-        // TODO: consider providing a reference here; right now there's some issues with multiaddr preventing that
-        remote_certificate_sha256: [u8; 32],
+        remote_certificate_sha256: &'a [u8; 32],
     },
 }
 

--- a/light-base/src/platform/address_parse.rs
+++ b/light-base/src/platform/address_parse.rs
@@ -22,7 +22,7 @@ use core::str;
 
 pub enum AddressOrMultiStreamAddress<'a> {
     Address(Address<'a>),
-    MultiStreamAddress(MultiStreamAddress),
+    MultiStreamAddress(MultiStreamAddress<'a>),
 }
 
 impl<'a> From<&'a AddressOrMultiStreamAddress<'a>> for ConnectionType {
@@ -117,7 +117,7 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
-            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data()) else {
+            let Ok(remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data_ref()) else {
                 return Err(Error::InvalidMultihashLength);
             };
             AddressOrMultiStreamAddress::MultiStreamAddress(MultiStreamAddress::WebRtc {
@@ -136,7 +136,7 @@ pub fn multiaddr_to_address(multiaddr: &Multiaddr) -> Result<AddressOrMultiStrea
             if multihash.hash_algorithm_code() != 0x12 {
                 return Err(Error::NonSha256Certhash);
             }
-            let Ok(&remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data()) else {
+            let Ok(remote_certificate_sha256) = <&[u8; 32]>::try_from(multihash.data_ref()) else {
                 return Err(Error::InvalidMultihashLength);
             };
             AddressOrMultiStreamAddress::MultiStreamAddress(MultiStreamAddress::WebRtc {


### PR DESCRIPTION
Fixes a TODO. Minor breaking change.

`MultiStreamAddress` now contains the remote TLS certificate by reference instead of by value. Consequently, `MultiStreamAddress` now gets a lifetime generic parameter.
