### PR TITLE
Rework `all.rs` to run `all_forks` and `warp_sync` syncing simultaneously

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -41,7 +41,7 @@ use crate::{
 
 use alloc::{borrow::Cow, vec::Vec};
 use core::{
-    iter, marker, mem,
+    iter,
     num::{NonZeroU32, NonZeroU64},
     ops,
     time::Duration,
@@ -179,7 +179,11 @@ pub enum Status<'a, TSrc> {
 }
 
 pub struct AllSync<TRq, TSrc, TBl> {
-    inner: AllSyncInner<TRq, TSrc, TBl>,
+    warp_sync: Option<warp_sync::WarpSync<WarpSyncSourceExtra, WarpSyncRequestExtra>>,
+    ready_to_transition: Option<warp_sync::RuntimeInformation>,
+    // TODO: we store an `Option<TBl>` instead of `TBl` due to API issues; the all.rs doesn't let you insert user datas for pending blocks while the AllForksSync lets you; `None` is stored while a block is pending
+    all_forks:
+        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra, AllForksSourceExtra<TSrc>>,
     shared: Shared<TRq>,
 }
 
@@ -187,8 +191,9 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Initializes a new state machine.
     pub fn new(config: Config) -> Self {
         AllSync {
-            inner: match warp_sync::start_warp_sync(warp_sync::Config {
-                start_chain_information: config.chain_information,
+            // TODO: notify API user if can't start warp sync?
+            warp_sync: warp_sync::start_warp_sync(warp_sync::Config {
+                start_chain_information: config.chain_information.clone(),
                 block_number_bytes: config.block_number_bytes,
                 sources_capacity: config.sources_capacity,
                 requests_capacity: config.sources_capacity, // TODO: ?! add as config?
@@ -200,30 +205,19 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 // TODO: temporarily 0 before https://github.com/smol-dot/smoldot/issues/1109, as otherwise the warp syncing would take a long time if the starting point is too recent
                 warp_sync_minimum_gap: 0,
                 download_block_body: config.download_bodies,
-            }) {
-                Ok(inner) => AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition: None,
-                },
-                Err((
-                    chain_information,
-                    warp_sync::WarpSyncInitError::NotGrandpa
-                    | warp_sync::WarpSyncInitError::UnknownConsensus,
-                )) => {
-                    // On error, `warp_sync` returns back the chain information that was
-                    // provided in its configuration.
-                    AllSyncInner::AllForks(AllForksSync::new(all_forks::Config {
-                        chain_information,
-                        block_number_bytes: config.block_number_bytes,
-                        sources_capacity: config.sources_capacity,
-                        blocks_capacity: config.blocks_capacity,
-                        download_bodies: false,
-                        allow_unknown_consensus_engines: config.allow_unknown_consensus_engines,
-                        max_disjoint_headers: config.max_disjoint_headers,
-                        max_requests_per_block: config.max_requests_per_block,
-                    }))
-                }
-            },
+            })
+            .ok(),
+            ready_to_transition: None,
+            all_forks: AllForksSync::new(all_forks::Config {
+                chain_information: config.chain_information,
+                block_number_bytes: config.block_number_bytes,
+                sources_capacity: config.sources_capacity,
+                blocks_capacity: config.blocks_capacity,
+                download_bodies: false,
+                allow_unknown_consensus_engines: config.allow_unknown_consensus_engines,
+                max_disjoint_headers: config.max_disjoint_headers,
+                max_requests_per_block: config.max_requests_per_block,
+            }),
             shared: Shared {
                 sources: slab::Slab::with_capacity(config.sources_capacity),
                 requests: slab::Slab::with_capacity(config.sources_capacity),
@@ -246,16 +240,14 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Builds a [`chain_information::ChainInformationRef`] struct corresponding to the current
     /// latest finalized block. Can later be used to reconstruct a chain.
     pub fn as_chain_information(&self) -> chain_information::ValidChainInformationRef {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => sync.as_chain_information(),
-            AllSyncInner::WarpSync { inner, .. } => inner.as_chain_information(),
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.as_chain_information()
     }
 
     /// Returns the current status of the syncing.
     pub fn status(&self) -> Status<TSrc> {
-        match &self.inner {
+        // TODO:
+        Status::Sync
+        /*match &self.inner {
             AllSyncInner::AllForks(_) => Status::Sync,
             AllSyncInner::WarpSync { inner, .. } => match inner.status() {
                 warp_sync::Status::Fragments {
@@ -285,18 +277,12 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 },
             },
             AllSyncInner::Poisoned => unreachable!(),
-        }
+        }*/
     }
 
     /// Returns the header of the finalized block.
     pub fn finalized_block_header(&self) -> header::HeaderRef {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => sync.finalized_block_header(),
-            AllSyncInner::WarpSync { inner, .. } => {
-                inner.as_chain_information().as_ref().finalized_block_header
-            }
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.finalized_block_header()
     }
 
     /// Returns the header of the best block.
@@ -304,11 +290,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// > **Note**: This value is provided only for informative purposes. Keep in mind that this
     /// >           best block might be reverted in the future.
     pub fn best_block_header(&self) -> header::HeaderRef {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => sync.best_block_header(),
-            AllSyncInner::WarpSync { .. } => self.finalized_block_header(),
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.best_block_header()
     }
 
     /// Returns the number of the best block.
@@ -316,11 +298,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// > **Note**: This value is provided only for informative purposes. Keep in mind that this
     /// >           best block might be reverted in the future.
     pub fn best_block_number(&self) -> u64 {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => sync.best_block_number(),
-            AllSyncInner::WarpSync { .. } => self.best_block_header().number,
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.best_block_number()
     }
 
     /// Returns the hash of the best block.
@@ -328,35 +306,18 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// > **Note**: This value is provided only for informative purposes. Keep in mind that this
     /// >           best block might be reverted in the future.
     pub fn best_block_hash(&self) -> [u8; 32] {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => sync.best_block_hash(),
-            AllSyncInner::WarpSync { .. } => self
-                .best_block_header()
-                .hash(self.shared.block_number_bytes),
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.best_block_hash()
     }
 
     /// Returns consensus information about the current best block of the chain.
     pub fn best_block_consensus(&self) -> chain_information::ChainInformationConsensusRef {
-        match &self.inner {
-            AllSyncInner::AllForks(_) => todo!(),     // TODO:
-            AllSyncInner::WarpSync { .. } => todo!(), // TODO: ?!
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        todo!() // TODO:
     }
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
     pub fn non_finalized_blocks_unordered(&self) -> impl Iterator<Item = header::HeaderRef> {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync.non_finalized_blocks_unordered();
-                either::Left(iter)
-            }
-            AllSyncInner::WarpSync { .. } => either::Right(iter::empty()),
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.non_finalized_blocks_unordered()
     }
 
     /// Returns the header of all known non-finalized blocks in the chain.
@@ -364,14 +325,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
     pub fn non_finalized_blocks_ancestry_order(&self) -> impl Iterator<Item = header::HeaderRef> {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync.non_finalized_blocks_ancestry_order();
-                either::Left(iter)
-            }
-            AllSyncInner::WarpSync { .. } => either::Right(iter::empty()),
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks.non_finalized_blocks_ancestry_order()
     }
 
     /// Returns true if it is believed that we are near the head of the chain.
@@ -379,11 +333,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// The way this method is implemented is opaque and cannot be relied on. The return value
     /// should only ever be shown to the user and not used for any meaningful logic.
     pub fn is_near_head_of_chain_heuristic(&self) -> bool {
-        match &self.inner {
-            AllSyncInner::AllForks(_) => true,
-            AllSyncInner::WarpSync { .. } => false,
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        todo!() // TODO:
     }
 
     /// Adds a new source to the sync state machine.
@@ -398,60 +348,42 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         best_block_number: u64,
         best_block_hash: [u8; 32],
     ) -> SourceId {
-        // `inner` is temporarily replaced with `Poisoned`. A new value must be put back before
-        // returning.
-        match mem::replace(&mut self.inner, AllSyncInner::Poisoned) {
-            AllSyncInner::WarpSync {
-                mut inner,
-                ready_to_transition,
-            } => {
-                let outer_source_id_entry = self.shared.sources.vacant_entry();
-                let outer_source_id = SourceId(outer_source_id_entry.key());
+        let outer_source_id_entry = self.shared.sources.vacant_entry();
+        let outer_source_id = SourceId(outer_source_id_entry.key());
 
-                let source_extra = WarpSyncSourceExtra {
-                    outer_source_id,
-                    user_data,
-                    best_block_number,
-                    best_block_hash,
-                };
+        let warp_sync_source_id = if let Some(warp_sync) = &mut self.warp_sync {
+            Some(warp_sync.add_source(WarpSyncSourceExtra { outer_source_id }))
+        } else {
+            None
+        };
 
-                let inner_source_id = inner.add_source(source_extra);
-                outer_source_id_entry.insert(SourceMapping::WarpSync(inner_source_id));
+        let all_forks_source_id = {
+            let source_user_data = AllForksSourceExtra {
+                user_data,
+                outer_source_id,
+            };
 
-                self.inner = AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition,
-                };
-                outer_source_id
+            match self
+                .all_forks
+                .prepare_add_source(best_block_number, best_block_hash)
+            {
+                all_forks::AddSource::BestBlockAlreadyVerified(b)
+                | all_forks::AddSource::BestBlockPendingVerification(b) => {
+                    b.add_source(source_user_data)
+                }
+                all_forks::AddSource::OldBestBlock(b) => b.add_source(source_user_data),
+                all_forks::AddSource::UnknownBestBlock(b) => {
+                    b.add_source_and_insert_block(source_user_data, None)
+                }
             }
-            AllSyncInner::AllForks(mut all_forks) => {
-                let outer_source_id_entry = self.shared.sources.vacant_entry();
-                let outer_source_id = SourceId(outer_source_id_entry.key());
+        };
 
-                let source_user_data = AllForksSourceExtra {
-                    user_data,
-                    outer_source_id,
-                };
+        outer_source_id_entry.insert(SourceMapping {
+            warp_sync: warp_sync_source_id,
+            all_forks: all_forks_source_id,
+        });
 
-                let source_id =
-                    match all_forks.prepare_add_source(best_block_number, best_block_hash) {
-                        all_forks::AddSource::BestBlockAlreadyVerified(b)
-                        | all_forks::AddSource::BestBlockPendingVerification(b) => {
-                            b.add_source(source_user_data)
-                        }
-                        all_forks::AddSource::OldBestBlock(b) => b.add_source(source_user_data),
-                        all_forks::AddSource::UnknownBestBlock(b) => {
-                            b.add_source_and_insert_block(source_user_data, None)
-                        }
-                    };
-
-                outer_source_id_entry.insert(SourceMapping::AllForks(source_id));
-
-                self.inner = AllSyncInner::AllForks(all_forks);
-                outer_source_id
-            }
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        outer_source_id
     }
 
     /// Removes a source from the state machine. Returns the user data of this source, and all
@@ -465,92 +397,69 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         &mut self,
         source_id: SourceId,
     ) -> (TSrc, impl Iterator<Item = (RequestId, TRq)>) {
-        debug_assert!(self.shared.sources.contains(source_id.0));
-        match (&mut self.inner, self.shared.sources.remove(source_id.0)) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(source_id)) => {
-                let (user_data, requests) = sync.remove_source(source_id);
-                let requests = requests
-                    .map(
-                        |(_inner_request_id, _request_params, request_inner_user_data)| {
-                            debug_assert!(self
-                                .shared
-                                .requests
-                                .contains(request_inner_user_data.outer_request_id.0));
-                            let _removed = self
-                                .shared
-                                .requests
-                                .remove(request_inner_user_data.outer_request_id.0);
-                            debug_assert!(matches!(
-                                _removed,
-                                RequestMapping::AllForks(_inner_request_id)
-                            ));
+        // TODO:
+        (todo!(), Vec::new().into_iter())
+        /*let source_ids = self.shared.sources.remove(source_id.0);
 
-                            (
-                                request_inner_user_data.outer_request_id,
-                                request_inner_user_data.user_data.unwrap(),
-                            )
-                        },
+        let (all_forks, all_forks_requests) = self.all_forks.remove_source(source_ids.all_forks);
+
+        let all_forks_requests = all_forks_requests
+            .map(
+                |(_inner_request_id, _request_params, request_inner_user_data)| {
+                    debug_assert!(self
+                        .shared
+                        .requests
+                        .contains(request_inner_user_data.outer_request_id.0));
+                    let _removed = self
+                        .shared
+                        .requests
+                        .remove(request_inner_user_data.outer_request_id.0);
+                    debug_assert!(matches!(_removed, RequestInfo::AllForks(_inner_request_id)));
+
+                    (
+                        request_inner_user_data.outer_request_id,
+                        request_inner_user_data.user_data.unwrap(),
                     )
-                    .collect::<Vec<_>>()
-                    .into_iter();
+                },
+            )
+            .collect::<Vec<_>>()
+            .into_iter();
 
-                // TODO: also handle the "inline" requests
+        let warp_sync_requests = if let Some(warp_sync) = &mut self.warp_sync {
+            let (_, requests) = warp_sync.remove_source(source_ids.warp_sync.unwrap());
 
-                (user_data.user_data, requests)
-            }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(source_id)) => {
-                let (user_data, requests) = inner.remove_source(source_id);
+            requests
+                .map(|(_inner_request_id, request_inner_user_data)| {
+                    debug_assert!(self
+                        .shared
+                        .requests
+                        .contains(request_inner_user_data.outer_request_id.0));
+                    let _removed = self
+                        .shared
+                        .requests
+                        .remove(request_inner_user_data.outer_request_id.0);
+                    debug_assert!(matches!(_removed, RequestInfo::WarpSync(_inner_request_id)));
 
-                let requests = requests
-                    .map(|(_inner_request_id, request_inner_user_data)| {
-                        debug_assert!(self
-                            .shared
-                            .requests
-                            .contains(request_inner_user_data.outer_request_id.0));
-                        let _removed = self
-                            .shared
-                            .requests
-                            .remove(request_inner_user_data.outer_request_id.0);
-                        debug_assert!(matches!(
-                            _removed,
-                            RequestMapping::WarpSync(_inner_request_id)
-                        ));
+                    (
+                        request_inner_user_data.outer_request_id,
+                        request_inner_user_data.user_data,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+        } else {
+            Vec::new().into_iter()
+        };
 
-                        (
-                            request_inner_user_data.outer_request_id,
-                            request_inner_user_data.user_data,
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .into_iter();
-
-                // TODO: also handle the "inline" requests
-
-                (user_data.user_data, requests)
-            }
-
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
-        }
+        // TODO: no actually, since some requests are shared
+        all_forks_requests.chain(warp_sync_requests)*/
     }
 
     /// Returns the list of sources in this state machine.
     pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> + '_ {
-        match &self.inner {
-            AllSyncInner::WarpSync { inner, .. } => {
-                let iter = inner.sources().map(move |id| inner[id].outer_source_id);
-                either::Left(iter)
-            }
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync.sources().map(move |id| sync[id].outer_source_id);
-                either::Right(iter)
-            }
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks
+            .sources()
+            .map(move |id| self.all_forks[id].outer_source_id)
     }
 
     /// Returns the number of ongoing requests that concern this source.
@@ -560,7 +469,9 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Panics if the [`SourceId`] is invalid.
     ///
     pub fn source_num_ongoing_requests(&self, source_id: SourceId) -> usize {
-        debug_assert!(self.shared.sources.contains(source_id.0));
+        // TODO: restore
+        todo!()
+        /*debug_assert!(self.shared.sources.contains(source_id.0));
 
         // TODO: O(n) :-/
         let num_inline = self
@@ -586,7 +497,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
             (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
         };
 
-        num_inline + num_inner
+        num_inline + num_inner*/
     }
 
     /// Returns the current best block of the given source.
@@ -600,22 +511,9 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     pub fn source_best_block(&self, source_id: SourceId) -> (u64, &[u8; 32]) {
         debug_assert!(self.shared.sources.contains(source_id.0));
-        match (&self.inner, self.shared.sources.get(source_id.0).unwrap()) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) => {
-                sync.source_best_block(*src)
-            }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(src)) => {
-                let ud = &inner[*src];
-                (ud.best_block_number, &ud.best_block_hash)
-            }
 
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
-        }
+        let inner_source_id = self.shared.sources.get(source_id.0).unwrap().all_forks;
+        self.all_forks.source_best_block(inner_source_id)
     }
 
     /// Returns true if the source has earlier announced the block passed as parameter or one of
@@ -636,31 +534,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         hash: &[u8; 32],
     ) -> bool {
         debug_assert!(self.shared.sources.contains(source_id.0));
-        match (&self.inner, self.shared.sources.get(source_id.0).unwrap()) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) => {
-                sync.source_knows_non_finalized_block(*src, height, hash)
-            }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(src)) => {
-                assert!(
-                    height
-                        > inner
-                            .as_chain_information()
-                            .as_ref()
-                            .finalized_block_header
-                            .number
-                );
 
-                let user_data = &inner[*src];
-                user_data.best_block_hash == *hash && user_data.best_block_number == height
-            }
-
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
-        }
+        let inner_source_id = self.shared.sources.get(source_id.0).unwrap().all_forks;
+        self.all_forks
+            .source_knows_non_finalized_block(inner_source_id, height, hash)
     }
 
     /// Returns the list of sources for which [`AllSync::source_knows_non_finalized_block`] would
@@ -677,42 +554,12 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         height: u64,
         hash: &[u8; 32],
     ) -> impl Iterator<Item = SourceId> + '_ {
-        match &self.inner {
-            AllSyncInner::WarpSync { inner, .. } => {
-                assert!(
-                    height
-                        > inner
-                            .as_chain_information()
-                            .as_ref()
-                            .finalized_block_header
-                            .number
-                );
-
-                let hash = *hash;
-                let iter = inner
-                    .sources()
-                    .filter(move |source_id| {
-                        let user_data = &inner[*source_id];
-                        user_data.best_block_hash == hash && user_data.best_block_number == height
-                    })
-                    .map(move |id| inner[id].outer_source_id);
-
-                either::Right(iter)
-            }
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync
-                    .knows_non_finalized_block(height, hash)
-                    .map(move |id| sync[id].outer_source_id);
-                either::Left(iter)
-            }
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks
+            .knows_non_finalized_block(height, hash)
+            .map(move |id| self.all_forks[id].outer_source_id)
     }
 
     /// Try register a new block that the source is aware of.
-    ///
-    /// Some syncing strategies do not track blocks known to sources, in which case this function
-    /// has no effect
     ///
     /// Has no effect if `height` is inferior or equal to the finalized block height, or if the
     /// source was already known to know this block.
@@ -732,12 +579,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         hash: [u8; 32],
     ) {
         debug_assert!(self.shared.sources.contains(source_id.0));
-        if let (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) = (
-            &mut self.inner,
-            self.shared.sources.get(source_id.0).unwrap(),
-        ) {
-            sync.add_known_block_to_source(*src, height, hash)
-        }
+
+        let inner_source_id = self.shared.sources.get(source_id.0).unwrap().all_forks;
+        self.all_forks
+            .add_known_block_to_source(inner_source_id, height, hash);
     }
 
     /// Returns the details of a request to start towards a source.
@@ -747,24 +592,20 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     pub fn desired_requests(
         &'_ self,
     ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> + '_ {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync.desired_requests().map(
-                    move |(inner_source_id, src_user_data, rq_params)| {
-                        (
-                            sync[inner_source_id].outer_source_id,
-                            &src_user_data.user_data,
-                            all_forks_request_convert(rq_params, self.shared.download_bodies),
-                        )
-                    },
-                );
+        let all_forks_requests = self.all_forks.desired_requests().map(
+            move |(inner_source_id, src_user_data, rq_params)| {
+                (
+                    self.all_forks[inner_source_id].outer_source_id,
+                    &src_user_data.user_data,
+                    all_forks_request_convert(rq_params, self.shared.download_bodies),
+                )
+            },
+        );
 
-                either::Right(iter)
-            }
-            AllSyncInner::WarpSync { inner, .. } => {
-                let iter = inner
-                    .desired_requests()
-                    .map(move |(_, src_user_data, rq_detail)| {
+        let warp_sync_requests =
+            if let Some(warp_sync) = &self.warp_sync {
+                either::Left(warp_sync.desired_requests().map(
+                    move |(_, src_user_data, rq_detail)| {
                         let detail = match rq_detail {
                             warp_sync::DesiredRequest::WarpSyncRequest { block_hash } => {
                                 DesiredRequest::WarpSync {
@@ -806,15 +647,18 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
 
                         (
                             src_user_data.outer_source_id,
-                            &src_user_data.user_data,
+                            &self.all_forks
+                                [self.shared.sources[src_user_data.outer_source_id.0].all_forks]
+                                .user_data,
                             detail,
                         )
-                    });
+                    },
+                ))
+            } else {
+                either::Right(iter::empty())
+            };
 
-                either::Left(iter)
-            }
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        all_forks_requests.chain(warp_sync_requests)
     }
 
     /// Inserts a new request in the data structure.
@@ -832,170 +676,107 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         detail: RequestDetail,
         user_data: TRq,
     ) -> RequestId {
-        match (&mut self.inner, &detail) {
-            (
-                AllSyncInner::AllForks(sync),
-                RequestDetail::BlocksRequest {
-                    ascending: false, // TODO: ?
-                    first_block_hash: Some(first_block_hash),
+        let request_mapping_entry = self.shared.requests.vacant_entry();
+        let outer_request_id = RequestId(request_mapping_entry.key());
+        let Some(source_ids) = self.shared.sources.get(source_id.0) else {
+            panic!()
+        };
+
+        let all_forks_request_id = if let RequestDetail::BlocksRequest {
+            first_block_height,
+            first_block_hash: Some(first_block_hash),
+            ascending,
+            num_blocks,
+            request_headers,
+            request_bodies,
+            request_justification,
+        } = detail
+        {
+            Some(self.all_forks.add_request(
+                source_ids.all_forks,
+                all_forks::RequestParams {
+                    first_block_hash,
                     first_block_height,
                     num_blocks,
-                    ..
                 },
-            ) => {
-                let inner_source_id = match self.shared.sources.get(source_id.0).unwrap() {
-                    SourceMapping::AllForks(inner_source_id) => *inner_source_id,
-                    _ => unreachable!(),
-                };
+                AllForksRequestExtra { outer_request_id },
+            ))
+        } else {
+            None
+        };
 
-                let request_mapping_entry = self.shared.requests.vacant_entry();
-                let outer_request_id = RequestId(request_mapping_entry.key());
-
-                let inner_request_id = sync.add_request(
-                    inner_source_id,
-                    all_forks::RequestParams {
-                        first_block_hash: *first_block_hash,
-                        first_block_height: *first_block_height,
-                        num_blocks: *num_blocks,
-                    },
-                    AllForksRequestExtra {
-                        outer_request_id,
-                        user_data: Some(user_data),
-                    },
-                );
-
-                request_mapping_entry.insert(RequestMapping::AllForks(inner_request_id));
-                return outer_request_id;
-            }
+        let warp_sync_request_id = match (&mut self.warp_sync, source_ids.warp_sync, detail) {
             (
-                AllSyncInner::WarpSync { inner, .. },
+                Some(warp_sync),
+                Some(inner_source_id),
                 RequestDetail::WarpSync {
                     sync_start_block_hash,
                 },
-            ) => {
-                let inner_source_id = match self.shared.sources.get(source_id.0).unwrap() {
-                    SourceMapping::WarpSync(inner_source_id) => *inner_source_id,
-                    _ => unreachable!(),
-                };
-
-                let request_mapping_entry = self.shared.requests.vacant_entry();
-                let outer_request_id = RequestId(request_mapping_entry.key());
-
-                let inner_request_id = inner.add_request(
-                    inner_source_id,
-                    WarpSyncRequestExtra {
-                        outer_request_id,
-                        user_data,
-                    },
-                    warp_sync::RequestDetail::WarpSyncRequest {
-                        block_hash: *sync_start_block_hash,
-                    },
-                );
-
-                request_mapping_entry.insert(RequestMapping::WarpSync(inner_request_id));
-                return outer_request_id;
-            }
+            ) => Some(warp_sync.add_request(
+                inner_source_id,
+                WarpSyncRequestExtra { outer_request_id },
+                warp_sync::RequestDetail::WarpSyncRequest {
+                    block_hash: sync_start_block_hash,
+                },
+            )),
             (
-                AllSyncInner::WarpSync { inner, .. },
+                Some(warp_sync),
+                Some(inner_source_id),
                 RequestDetail::BlocksRequest {
                     first_block_height,
                     first_block_hash: Some(first_block_hash),
                     request_bodies: true,
                     ..
                 },
-            ) => {
-                let inner_source_id = match self.shared.sources.get(source_id.0).unwrap() {
-                    SourceMapping::WarpSync(inner_source_id) => *inner_source_id,
-                    _ => unreachable!(),
-                };
-
-                let request_mapping_entry = self.shared.requests.vacant_entry();
-                let outer_request_id = RequestId(request_mapping_entry.key());
-
-                let inner_request_id = inner.add_request(
-                    inner_source_id,
-                    WarpSyncRequestExtra {
-                        outer_request_id,
-                        user_data,
-                    },
-                    warp_sync::RequestDetail::BlockBodyDownload {
-                        block_hash: *first_block_hash,
-                        block_number: *first_block_height,
-                    },
-                );
-
-                request_mapping_entry.insert(RequestMapping::WarpSync(inner_request_id));
-                return outer_request_id;
-            }
+            ) => Some(warp_sync.add_request(
+                inner_source_id,
+                WarpSyncRequestExtra { outer_request_id },
+                warp_sync::RequestDetail::BlockBodyDownload {
+                    block_hash: first_block_hash,
+                    block_number: first_block_height,
+                },
+            )),
             (
-                AllSyncInner::WarpSync { inner, .. },
+                Some(warp_sync),
+                Some(inner_source_id),
                 RequestDetail::StorageGet { block_hash, keys },
-            ) => {
-                let inner_source_id = match self.shared.sources.get(source_id.0).unwrap() {
-                    SourceMapping::WarpSync(inner_source_id) => *inner_source_id,
-                    _ => unreachable!(),
-                };
-
-                let request_mapping_entry = self.shared.requests.vacant_entry();
-                let outer_request_id = RequestId(request_mapping_entry.key());
-
-                let inner_request_id = inner.add_request(
-                    inner_source_id,
-                    WarpSyncRequestExtra {
-                        outer_request_id,
-                        user_data,
-                    },
-                    warp_sync::RequestDetail::StorageGetMerkleProof {
-                        block_hash: *block_hash,
-                        keys: keys.clone(), // TODO: clone?
-                    },
-                );
-
-                request_mapping_entry.insert(RequestMapping::WarpSync(inner_request_id));
-                return outer_request_id;
-            }
+            ) => Some(warp_sync.add_request(
+                inner_source_id,
+                WarpSyncRequestExtra { outer_request_id },
+                warp_sync::RequestDetail::StorageGetMerkleProof { block_hash, keys },
+            )),
             (
-                AllSyncInner::WarpSync { inner, .. },
+                Some(warp_sync),
+                Some(inner_source_id),
                 RequestDetail::RuntimeCallMerkleProof {
                     block_hash,
                     function_name,
                     parameter_vectored,
                 },
-            ) => {
-                let inner_source_id = match self.shared.sources.get(source_id.0).unwrap() {
-                    SourceMapping::WarpSync(inner_source_id) => *inner_source_id,
-                    _ => unreachable!(),
-                };
-
-                let request_mapping_entry = self.shared.requests.vacant_entry();
-                let outer_request_id = RequestId(request_mapping_entry.key());
-
-                let inner_request_id = inner.add_request(
-                    inner_source_id,
-                    WarpSyncRequestExtra {
-                        outer_request_id,
-                        user_data,
-                    },
-                    warp_sync::RequestDetail::RuntimeCallMerkleProof {
-                        block_hash: *block_hash,
-                        function_name: function_name.clone(), // TODO: don't clone
-                        parameter_vectored: parameter_vectored.clone(), // TODO: don't clone
-                    },
-                );
-
-                request_mapping_entry.insert(RequestMapping::WarpSync(inner_request_id));
-                return outer_request_id;
+            ) => Some(warp_sync.add_request(
+                inner_source_id,
+                WarpSyncRequestExtra { outer_request_id },
+                warp_sync::RequestDetail::RuntimeCallMerkleProof {
+                    block_hash,
+                    function_name,
+                    parameter_vectored,
+                },
+            )),
+            (None, None, _) | (Some(_), Some(_), _) => None,
+            (Some(_), None, _) | (None, Some(_), _) => {
+                debug_assert!(false);
+                None
             }
-            (AllSyncInner::AllForks { .. }, _) => {}
-            (AllSyncInner::WarpSync { .. }, _) => {}
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-        }
+        };
 
-        RequestId(
-            self.shared
-                .requests
-                .insert(RequestMapping::Inline(source_id, detail, user_data)),
-        )
+        request_mapping_entry.insert(RequestInfo {
+            all_forks: all_forks_request_id,
+            warp_sync: warp_sync_request_id,
+            source_id,
+            user_data,
+        });
+
+        outer_request_id
     }
 
     /// Returns a list of requests that are considered obsolete and can be removed using
@@ -1007,23 +788,17 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
     pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> + '_ {
-        match &self.inner {
-            AllSyncInner::AllForks(sync) => {
-                let iter = sync
-                    .obsolete_requests()
-                    .map(move |(_, rq)| rq.outer_request_id)
-                    .chain(
-                        self.shared
-                            .requests
-                            .iter()
-                            .filter(|(_, rq)| matches!(rq, RequestMapping::Inline(..)))
-                            .map(|(id, _)| RequestId(id)),
-                    );
-                either::Left(iter)
-            }
-            AllSyncInner::WarpSync { .. } => either::Right(iter::empty()), // TODO: not implemented properly
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        // TODO: not implemented properly
+        self.all_forks
+            .obsolete_requests()
+            .map(move |(_, rq)| rq.outer_request_id)
+            .chain(
+                self.shared
+                    .requests
+                    .iter()
+                    .filter(|(_, rq)| rq.all_forks.is_none() && rq.warp_sync.is_none())
+                    .map(|(id, _)| RequestId(id)),
+            )
     }
 
     /// Returns the [`SourceId`] that is expected to fulfill the given request.
@@ -1033,15 +808,11 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Panics if the [`RequestId`] is invalid.
     ///
     pub fn request_source_id(&self, request_id: RequestId) -> SourceId {
-        match (&self.inner, &self.shared.requests[request_id.0]) {
-            (AllSyncInner::AllForks(inner), RequestMapping::AllForks(rq)) => {
-                inner[inner.request_source_id(*rq)].outer_source_id
-            }
-            (AllSyncInner::WarpSync { inner, .. }, RequestMapping::WarpSync(rq)) => {
-                inner[inner.request_source_id(*rq)].outer_source_id
-            }
-            _ => unreachable!(),
-        }
+        let Some(request) = self.shared.requests.get(request_id.0) else {
+            panic!()
+        };
+
+        request.source_id
     }
 
     /// Process the next block in the queue of verification.
@@ -1049,86 +820,88 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// This method takes ownership of the [`AllSync`] and starts a verification process. The
     /// [`AllSync`] is yielded back at the end of this process.
     pub fn process_one(mut self) -> ProcessOne<TRq, TSrc, TBl> {
-        match self.inner {
-            AllSyncInner::WarpSync {
-                inner,
-                ready_to_transition: None,
-            } => match inner.process_one() {
+        if let Some(warp_sync) = self.warp_sync.take() {
+            match warp_sync.process_one() {
                 warp_sync::ProcessOne::Idle(inner) => {
-                    self.inner = AllSyncInner::WarpSync {
-                        inner,
-                        ready_to_transition: None,
-                    };
-                    ProcessOne::AllSync(self)
+                    self.warp_sync = Some(inner);
                 }
                 warp_sync::ProcessOne::VerifyWarpSyncFragment(inner) => {
-                    ProcessOne::VerifyWarpSyncFragment(WarpSyncFragmentVerify {
+                    return ProcessOne::VerifyWarpSyncFragment(WarpSyncFragmentVerify {
                         inner,
                         ready_to_transition: None,
+                        all_forks: self.all_forks,
                         shared: self.shared,
-                        marker: marker::PhantomData,
                     })
                 }
                 warp_sync::ProcessOne::BuildRuntime(inner) => {
-                    ProcessOne::WarpSyncBuildRuntime(WarpSyncBuildRuntime {
+                    return ProcessOne::WarpSyncBuildRuntime(WarpSyncBuildRuntime {
                         inner,
                         ready_to_transition: None,
+                        all_forks: self.all_forks,
                         shared: self.shared,
-                        marker: marker::PhantomData,
                     })
                 }
                 warp_sync::ProcessOne::BuildChainInformation(inner) => {
-                    ProcessOne::WarpSyncBuildChainInformation(WarpSyncBuildChainInformation {
-                        inner,
-                        shared: self.shared,
-                        marker: marker::PhantomData,
-                    })
-                }
-            },
-            AllSyncInner::WarpSync {
-                inner,
-                ready_to_transition: Some(ready_to_transition),
-            } => {
-                let (
-                    new_inner,
-                    finalized_block_runtime,
-                    finalized_body,
-                    finalized_storage_code,
-                    finalized_storage_heap_pages,
-                    finalized_storage_code_merkle_value,
-                    finalized_storage_code_closest_ancestor_excluding,
-                ) = self
-                    .shared
-                    .transition_warp_sync_all_forks(inner, ready_to_transition);
-                self.inner = AllSyncInner::AllForks(new_inner);
-                ProcessOne::WarpSyncFinished {
-                    sync: self,
-                    finalized_block_runtime,
-                    finalized_body,
-                    finalized_storage_code,
-                    finalized_storage_heap_pages,
-                    finalized_storage_code_merkle_value,
-                    finalized_storage_code_closest_ancestor_excluding,
+                    return ProcessOne::WarpSyncBuildChainInformation(
+                        WarpSyncBuildChainInformation {
+                            inner,
+                            all_forks: self.all_forks,
+                            shared: self.shared,
+                        },
+                    )
                 }
             }
-            AllSyncInner::AllForks(sync) => match sync.process_one() {
-                all_forks::ProcessOne::AllSync { sync } => {
-                    self.inner = AllSyncInner::AllForks(sync);
-                    ProcessOne::AllSync(self)
-                }
-                all_forks::ProcessOne::BlockVerify(inner) => ProcessOne::VerifyBlock(BlockVerify {
-                    inner,
-                    shared: self.shared,
-                }),
-                all_forks::ProcessOne::FinalityProofVerify(inner) => {
-                    ProcessOne::VerifyFinalityProof(FinalityProofVerify {
-                        inner,
-                        shared: self.shared,
-                    })
-                }
-            },
-            AllSyncInner::Poisoned => unreachable!(),
         }
+
+        if let Some(ready_to_transition) = self.ready_to_transition.take() {
+            // TODO: restore
+            todo!()
+            /*let (
+                new_inner,
+                finalized_block_runtime,
+                finalized_body,
+                finalized_storage_code,
+                finalized_storage_heap_pages,
+                finalized_storage_code_merkle_value,
+                finalized_storage_code_closest_ancestor_excluding,
+            ) = self
+                .shared
+                .transition_warp_sync_all_forks(inner, ready_to_transition);
+            self.inner = AllSyncInner::AllForks(new_inner);
+            return ProcessOne::WarpSyncFinished {
+                sync: self,
+                finalized_block_runtime,
+                finalized_body,
+                finalized_storage_code,
+                finalized_storage_heap_pages,
+                finalized_storage_code_merkle_value,
+                finalized_storage_code_closest_ancestor_excluding,
+            };*/
+        }
+
+        match self.all_forks.process_one() {
+            all_forks::ProcessOne::AllSync { sync } => {
+                self.all_forks = sync;
+            }
+            all_forks::ProcessOne::BlockVerify(inner) => {
+                return ProcessOne::VerifyBlock(BlockVerify {
+                    inner,
+                    warp_sync: self.warp_sync,
+                    ready_to_transition: self.ready_to_transition,
+                    shared: self.shared,
+                })
+            }
+            all_forks::ProcessOne::FinalityProofVerify(inner) => {
+                return ProcessOne::VerifyFinalityProof(FinalityProofVerify {
+                    inner,
+                    warp_sync: self.warp_sync,
+                    ready_to_transition: self.ready_to_transition,
+                    shared: self.shared,
+                })
+            }
+        }
+
+        ProcessOne::AllSync(self)
     }
 
     /// Injects a block announcement made by a source into the state machine.
@@ -1138,59 +911,32 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         announced_scale_encoded_header: Vec<u8>,
         is_best: bool,
     ) -> BlockAnnounceOutcome {
-        let source_id = self.shared.sources.get(source_id.0).unwrap();
+        let inner_source_id = self.shared.sources.get(source_id.0).unwrap().all_forks;
 
-        match (&mut self.inner, source_id) {
-            (AllSyncInner::AllForks(sync), &SourceMapping::AllForks(source_id)) => {
-                match sync.block_announce(source_id, announced_scale_encoded_header, is_best) {
-                    all_forks::BlockAnnounceOutcome::TooOld {
-                        announce_block_height,
-                        finalized_block_height,
-                    } => BlockAnnounceOutcome::TooOld {
-                        announce_block_height,
-                        finalized_block_height,
-                    },
-                    all_forks::BlockAnnounceOutcome::Unknown(source_update) => {
-                        source_update.insert_and_update_source(None);
-                        BlockAnnounceOutcome::StoredForLater // TODO: arbitrary
-                    }
-                    all_forks::BlockAnnounceOutcome::AlreadyInChain(source_update)
-                    | all_forks::BlockAnnounceOutcome::Known(source_update) => {
-                        source_update.update_source_and_block();
-                        BlockAnnounceOutcome::StoredForLater // TODO: arbitrary
-                    }
-                    all_forks::BlockAnnounceOutcome::InvalidHeader(error) => {
-                        BlockAnnounceOutcome::InvalidHeader(error)
-                    }
-                }
+        match self.all_forks.block_announce(
+            inner_source_id,
+            announced_scale_encoded_header,
+            is_best,
+        ) {
+            all_forks::BlockAnnounceOutcome::TooOld {
+                announce_block_height,
+                finalized_block_height,
+            } => BlockAnnounceOutcome::TooOld {
+                announce_block_height,
+                finalized_block_height,
+            },
+            all_forks::BlockAnnounceOutcome::Unknown(source_update) => {
+                source_update.insert_and_update_source(None);
+                BlockAnnounceOutcome::StoredForLater // TODO: arbitrary
             }
-            (AllSyncInner::WarpSync { inner, .. }, &SourceMapping::WarpSync(source_id)) => {
-                match header::decode(
-                    &announced_scale_encoded_header,
-                    self.shared.block_number_bytes,
-                ) {
-                    Err(err) => BlockAnnounceOutcome::InvalidHeader(err),
-                    Ok(header) => {
-                        // If GrandPa warp syncing is in progress, the best block of the source is stored
-                        // in the user data. It will be useful later when transitioning to another
-                        // syncing strategy.
-                        if is_best {
-                            let user_data = &mut inner[source_id];
-                            user_data.best_block_number = header.number;
-                            user_data.best_block_hash = header.hash(self.shared.block_number_bytes);
-                        }
-
-                        BlockAnnounceOutcome::Discarded
-                    }
-                }
+            all_forks::BlockAnnounceOutcome::AlreadyInChain(source_update)
+            | all_forks::BlockAnnounceOutcome::Known(source_update) => {
+                source_update.update_source_and_block();
+                BlockAnnounceOutcome::StoredForLater // TODO: arbitrary
             }
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
+            all_forks::BlockAnnounceOutcome::InvalidHeader(error) => {
+                BlockAnnounceOutcome::InvalidHeader(error)
+            }
         }
     }
 
@@ -1207,19 +953,19 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ) {
         let source_id = self.shared.sources.get(source_id.0).unwrap();
 
-        match (&mut self.inner, source_id) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(source_id)) => {
-                sync.update_source_finality_state(*source_id, finalized_block_height)
+        match (&mut self.warp_sync, source_id.warp_sync) {
+            (Some(warp_sync), Some(inner_source_id)) => {
+                warp_sync.set_source_finality_state(inner_source_id, finalized_block_height);
             }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(source_id)) => {
-                inner.set_source_finality_state(*source_id, finalized_block_height);
+            (None, None) => {}
+            _ => {
+                // Invalid internal state.
+                debug_assert!(false);
             }
-
-            // Invalid internal states.
-            (AllSyncInner::AllForks(_), _) => unreachable!(),
-            (AllSyncInner::WarpSync { .. }, _) => unreachable!(),
-            (AllSyncInner::Poisoned, _) => unreachable!(),
         }
+
+        self.all_forks
+            .update_source_finality_state(source_id.all_forks, finalized_block_height);
     }
 
     /// Update the state machine with a Grandpa commit message received from the network.
@@ -1233,34 +979,33 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ) -> GrandpaCommitMessageOutcome {
         let source_id = self.shared.sources.get(source_id.0).unwrap();
 
-        match (&mut self.inner, source_id) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(source_id)) => {
-                match sync.grandpa_commit_message(*source_id, scale_encoded_message) {
-                    all_forks::GrandpaCommitMessageOutcome::ParseError => {
-                        GrandpaCommitMessageOutcome::Discarded
-                    }
-                    all_forks::GrandpaCommitMessageOutcome::Queued => {
-                        GrandpaCommitMessageOutcome::Queued
-                    }
-                }
-            }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(source_id)) => {
+        match (&mut self.warp_sync, source_id.warp_sync) {
+            (Some(warp_sync), Some(inner_source_id)) => {
                 let block_number = match decode::decode_grandpa_commit(
                     &scale_encoded_message,
-                    inner.block_number_bytes(),
+                    warp_sync.block_number_bytes(),
                 ) {
                     Ok(msg) => msg.target_number,
                     Err(_) => return GrandpaCommitMessageOutcome::Discarded,
                 };
 
-                inner.set_source_finality_state(*source_id, block_number);
+                warp_sync.set_source_finality_state(inner_source_id, block_number);
+            }
+            (None, None) => {}
+            _ => {
+                // Invalid internal state.
+                debug_assert!(false);
+            }
+        }
+
+        match self
+            .all_forks
+            .grandpa_commit_message(source_id.all_forks, scale_encoded_message)
+        {
+            all_forks::GrandpaCommitMessageOutcome::ParseError => {
                 GrandpaCommitMessageOutcome::Discarded
             }
-
-            // Invalid internal states.
-            (AllSyncInner::AllForks(_), _) => unreachable!(),
-            (AllSyncInner::WarpSync { .. }, _) => unreachable!(),
-            (AllSyncInner::Poisoned, _) => unreachable!(),
+            all_forks::GrandpaCommitMessageOutcome::Queued => GrandpaCommitMessageOutcome::Queued,
         }
     }
 
@@ -1279,114 +1024,92 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         debug_assert!(self.shared.requests.contains(request_id.0));
         let request = self.shared.requests.remove(request_id.0);
 
-        match (&mut self.inner, request) {
-            (_, RequestMapping::Inline(_, _, user_data)) => (user_data, ResponseOutcome::Outdated),
-            (AllSyncInner::WarpSync { inner, .. }, RequestMapping::WarpSync(inner_request_id)) => {
-                match blocks
-                    .and_then(|mut b| b.next().ok_or(()))
-                    .map(|b| b.scale_encoded_extrinsics)
-                {
-                    Ok(body) => {
-                        let user_data = inner
-                            .body_download_success(inner_request_id, body)
-                            .user_data;
-                        (user_data, ResponseOutcome::Queued)
-                    }
-                    Err(_) => {
-                        // TODO: report source misbehaviour
-                        let user_data = inner.remove_request(inner_request_id).user_data;
-                        (user_data, ResponseOutcome::Outdated)
-                    }
-                }
-            }
-            (
-                sync_container @ AllSyncInner::AllForks(_),
-                RequestMapping::AllForks(inner_request_id),
-            ) => {
-                // We need to extract the `AllForksSync` object in order to inject the
-                // response.
-                let sync = match mem::replace(sync_container, AllSyncInner::Poisoned) {
-                    AllSyncInner::AllForks(sync) => sync,
-                    _ => unreachable!(),
-                };
+        if let Some(all_forks_request_id) = request.all_forks {
+            let outcome = if let Ok(blocks) = blocks {
+                let (_, mut blocks_append) = self.all_forks.finish_request(all_forks_request_id);
+                let mut blocks_iter = blocks.into_iter().enumerate();
 
-                let (sync, request_user_data, outcome) = if let Ok(blocks) = blocks {
-                    let (request_user_data, mut blocks_append) =
-                        sync.finish_request(inner_request_id);
-                    let mut blocks_iter = blocks.into_iter().enumerate();
+                loop {
+                    let (block_index, block) = match blocks_iter.next() {
+                        Some(v) => v,
+                        None => {
+                            self.all_forks = blocks_append.finish();
+                            break ResponseOutcome::Queued;
+                        }
+                    };
 
-                    loop {
-                        let (block_index, block) = match blocks_iter.next() {
-                            Some(v) => v,
-                            None => {
-                                break (
-                                    blocks_append.finish(),
-                                    request_user_data,
-                                    ResponseOutcome::Queued,
-                                );
-                            }
-                        };
-
-                        // TODO: many of the errors don't properly translate here, needs some refactoring
-                        match blocks_append.add_block(
-                            &block.scale_encoded_header,
-                            block.scale_encoded_extrinsics,
-                            block
-                                .scale_encoded_justifications
-                                .into_iter()
-                                .map(|j| (j.engine_id, j.justification)),
-                        ) {
-                            Ok(all_forks::AddBlock::UnknownBlock(ba)) => {
-                                blocks_append = ba.insert(Some(block.user_data))
-                            }
-                            Ok(all_forks::AddBlock::AlreadyPending(ba)) => {
-                                // TODO: replacing the user data entirely is very opinionated, instead the API of the AllSync should be changed
-                                blocks_append = ba.replace(Some(block.user_data)).0
-                            }
-                            Ok(all_forks::AddBlock::AlreadyInChain(ba)) if block_index == 0 => {
-                                break (
-                                    ba.cancel(),
-                                    request_user_data,
-                                    ResponseOutcome::AllAlreadyInChain,
-                                )
-                            }
-                            Ok(all_forks::AddBlock::AlreadyInChain(ba)) => {
-                                break (ba.cancel(), request_user_data, ResponseOutcome::Queued)
-                            }
-                            Err((
-                                all_forks::AncestrySearchResponseError::NotFinalizedChain {
-                                    discarded_unverified_block_headers,
-                                },
-                                sync,
-                            )) => {
-                                break (
-                                    sync,
-                                    request_user_data,
-                                    ResponseOutcome::NotFinalizedChain {
-                                        discarded_unverified_block_headers,
-                                    },
-                                )
-                            }
-                            Err((_, sync)) => {
-                                break (sync, request_user_data, ResponseOutcome::Queued);
-                            }
+                    // TODO: many of the errors don't properly translate here, needs some refactoring
+                    match blocks_append.add_block(
+                        &block.scale_encoded_header,
+                        block.scale_encoded_extrinsics,
+                        block
+                            .scale_encoded_justifications
+                            .into_iter()
+                            .map(|j| (j.engine_id, j.justification)),
+                    ) {
+                        Ok(all_forks::AddBlock::UnknownBlock(ba)) => {
+                            blocks_append = ba.insert(Some(block.user_data))
+                        }
+                        Ok(all_forks::AddBlock::AlreadyPending(ba)) => {
+                            // TODO: replacing the user data entirely is very opinionated, instead the API of the AllSync should be changed
+                            blocks_append = ba.replace(Some(block.user_data)).0
+                        }
+                        Ok(all_forks::AddBlock::AlreadyInChain(ba)) if block_index == 0 => {
+                            self.all_forks = ba.cancel();
+                            break ResponseOutcome::AllAlreadyInChain;
+                        }
+                        Ok(all_forks::AddBlock::AlreadyInChain(ba)) => {
+                            self.all_forks = ba.cancel();
+                            break ResponseOutcome::Queued;
+                        }
+                        Err((
+                            all_forks::AncestrySearchResponseError::NotFinalizedChain {
+                                discarded_unverified_block_headers,
+                            },
+                            sync,
+                        )) => {
+                            self.all_forks = sync;
+                            break ResponseOutcome::NotFinalizedChain {
+                                discarded_unverified_block_headers,
+                            };
+                        }
+                        Err((_, sync)) => {
+                            self.all_forks = sync;
+                            break ResponseOutcome::Queued;
                         }
                     }
-                } else {
-                    let (ud, finish_request) = sync.finish_request(inner_request_id);
-                    let sync = finish_request.finish();
-                    // TODO: `Queued`?! doesn't seem right
-                    (sync, ud, ResponseOutcome::Queued)
-                };
-
-                // Don't forget to re-insert the `AllForksSync`.
-                *sync_container = AllSyncInner::AllForks(sync);
-
-                debug_assert_eq!(request_user_data.outer_request_id, request_id);
-                (request_user_data.user_data.unwrap(), outcome)
-            }
-            _ => unreachable!(),
+                }
+            } else {
+                let (_, finish_request) = self.all_forks.finish_request(all_forks_request_id);
+                self.all_forks = finish_request.finish();
+                // TODO: `Queued`?! doesn't seem right
+                ResponseOutcome::Queued
+            };
         }
+
+        if let Some(warp_sync_request_id) = request.warp_sync {
+            let Some(warp_sync) = &mut self.warp_sync else {
+                unreachable!()
+            };
+
+            let outcome = match blocks
+                .and_then(|mut b| b.next().ok_or(()))
+                .map(|b| b.scale_encoded_extrinsics)
+            {
+                Ok(body) => {
+                    warp_sync.body_download_success(warp_sync_request_id, body);
+                    ResponseOutcome::Queued
+                }
+                Err(_) => {
+                    // TODO: report source misbehaviour
+                    warp_sync.remove_request(warp_sync_request_id);
+                    ResponseOutcome::Outdated
+                }
+            };
+        }
+
+        // TODO: merge the outcomes
+        (request.user_data, ResponseOutcome::Queued)
     }
 
     /// Inject a successful response to a previously-emitted GrandPa warp sync request.
@@ -1425,26 +1148,28 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         response: Option<(Vec<WarpSyncFragment>, bool)>,
     ) -> (TRq, ResponseOutcome) {
         debug_assert!(self.shared.requests.contains(request_id.0));
+
         let request = self.shared.requests.remove(request_id.0);
 
-        match (&mut self.inner, request) {
-            (AllSyncInner::WarpSync { inner, .. }, RequestMapping::WarpSync(request_id)) => {
-                let user_data = if let Some((fragments, is_finished)) = response {
-                    inner.warp_sync_request_success(request_id, fragments, is_finished)
-                } else {
-                    inner.remove_request(request_id)
-                };
-
-                (user_data.user_data, ResponseOutcome::Queued)
+        if let Some(warp_sync_request_id) = request.warp_sync {
+            if let Some((fragments, is_finished)) = response {
+                self.warp_sync.as_mut().unwrap().warp_sync_request_success(
+                    warp_sync_request_id,
+                    fragments,
+                    is_finished,
+                );
+            } else {
+                self.warp_sync
+                    .as_mut()
+                    .unwrap()
+                    .remove_request(warp_sync_request_id);
             }
-
-            // Only the GrandPa warp syncing ever starts GrandPa warp sync requests.
-            (_, RequestMapping::Inline(_, _, user_data)) => {
-                (user_data, ResponseOutcome::Queued) // TODO: no, not queued
-            }
-
-            _ => todo!(), // TODO: handle other variants
         }
+
+        // TODO: type of request not always verified
+
+        // TODO: don't always return Queued
+        (request.user_data, ResponseOutcome::Queued)
     }
 
     /// Inject a response to a previously-emitted storage proof request.
@@ -1463,53 +1188,27 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         response: Result<Vec<u8>, ()>,
     ) -> (TRq, ResponseOutcome) {
         debug_assert!(self.shared.requests.contains(request_id.0));
+
         let request = self.shared.requests.remove(request_id.0);
 
-        match (
-            mem::replace(&mut self.inner, AllSyncInner::Poisoned),
-            response,
-            request,
-        ) {
-            (
-                AllSyncInner::WarpSync {
-                    mut inner,
-                    ready_to_transition,
-                },
-                Ok(response),
-                RequestMapping::WarpSync(request_id),
-            ) => {
-                let user_data = inner.storage_get_success(request_id, response);
-                self.inner = AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition,
-                };
-                (user_data.user_data, ResponseOutcome::Queued)
-            }
-            (
-                AllSyncInner::WarpSync {
-                    mut inner,
-                    ready_to_transition,
-                },
-                Err(_),
-                RequestMapping::WarpSync(request_id),
-            ) => {
-                let user_data = inner.remove_request(request_id).user_data;
-                self.inner = AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition,
-                };
-                (user_data, ResponseOutcome::Queued)
-            }
-            // Only the GrandPa warp syncing ever starts GrandPa warp sync requests.
-            (other, _, RequestMapping::Inline(_, _, user_data)) => {
-                self.inner = other;
-                (user_data, ResponseOutcome::Queued) // TODO: no
-            }
-            (_, _, _) => {
-                // Type of request doesn't correspond to a storage get.
-                panic!()
+        if let Some(warp_sync_request_id) = request.warp_sync {
+            if let Ok(response) = response {
+                self.warp_sync
+                    .as_mut()
+                    .unwrap()
+                    .storage_get_success(warp_sync_request_id, response);
+            } else {
+                self.warp_sync
+                    .as_mut()
+                    .unwrap()
+                    .remove_request(warp_sync_request_id);
             }
         }
+
+        // TODO: type of request not always verified
+
+        // TODO: don't always return Queued
+        (request.user_data, ResponseOutcome::Queued)
     }
 
     /// Inject a response to a previously-emitted call proof request.
@@ -1528,54 +1227,27 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         response: Result<Vec<u8>, ()>,
     ) -> (TRq, ResponseOutcome) {
         debug_assert!(self.shared.requests.contains(request_id.0));
+
         let request = self.shared.requests.remove(request_id.0);
 
-        match (
-            mem::replace(&mut self.inner, AllSyncInner::Poisoned),
-            response,
-            request,
-        ) {
-            (
-                AllSyncInner::WarpSync {
-                    mut inner,
-                    ready_to_transition,
-                },
-                Ok(response),
-                RequestMapping::WarpSync(request_id),
-            ) => {
-                let user_data = inner.runtime_call_merkle_proof_success(request_id, response);
-                self.inner = AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition,
-                };
-                (user_data.user_data, ResponseOutcome::Queued)
-            }
-            (
-                AllSyncInner::WarpSync {
-                    mut inner,
-                    ready_to_transition,
-                },
-                Err(_),
-                RequestMapping::WarpSync(request_id),
-            ) => {
-                let user_data = inner.remove_request(request_id);
-                // TODO: notify user of the problem
-                self.inner = AllSyncInner::WarpSync {
-                    inner,
-                    ready_to_transition,
-                };
-                (user_data.user_data, ResponseOutcome::Queued)
-            }
-            // Only the GrandPa warp syncing ever starts call proof requests.
-            (other, _, RequestMapping::Inline(_, _, user_data)) => {
-                self.inner = other;
-                (user_data, ResponseOutcome::Queued) // TODO: no
-            }
-            (_, _, _) => {
-                // Type of request doesn't correspond to a call proof request.
-                panic!()
+        if let Some(warp_sync_request_id) = request.warp_sync {
+            if let Ok(response) = response {
+                self.warp_sync
+                    .as_mut()
+                    .unwrap()
+                    .runtime_call_merkle_proof_success(warp_sync_request_id, response);
+            } else {
+                self.warp_sync
+                    .as_mut()
+                    .unwrap()
+                    .remove_request(warp_sync_request_id);
             }
         }
+
+        // TODO: type of request not always verified
+
+        // TODO: don't always return Queued
+        (request.user_data, ResponseOutcome::Queued)
     }
 }
 
@@ -1585,19 +1257,7 @@ impl<TRq, TSrc, TBl> ops::Index<SourceId> for AllSync<TRq, TSrc, TBl> {
     #[track_caller]
     fn index(&self, source_id: SourceId) -> &TSrc {
         debug_assert!(self.shared.sources.contains(source_id.0));
-        match (&self.inner, self.shared.sources.get(source_id.0).unwrap()) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) => &sync[*src].user_data,
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(src)) => {
-                &inner[*src].user_data
-            }
-
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
-        }
+        &self.all_forks[self.shared.sources.get(source_id.0).unwrap().all_forks].user_data
     }
 }
 
@@ -1605,24 +1265,7 @@ impl<TRq, TSrc, TBl> ops::IndexMut<SourceId> for AllSync<TRq, TSrc, TBl> {
     #[track_caller]
     fn index_mut(&mut self, source_id: SourceId) -> &mut TSrc {
         debug_assert!(self.shared.sources.contains(source_id.0));
-        match (
-            &mut self.inner,
-            self.shared.sources.get(source_id.0).unwrap(),
-        ) {
-            (AllSyncInner::AllForks(sync), SourceMapping::AllForks(src)) => {
-                &mut sync[*src].user_data
-            }
-            (AllSyncInner::WarpSync { inner, .. }, SourceMapping::WarpSync(src)) => {
-                &mut inner[*src].user_data
-            }
-
-            (AllSyncInner::Poisoned, _) => unreachable!(),
-            // Invalid combinations of syncing state machine and source id.
-            // This indicates a internal bug during the switch from one state machine to the
-            // other.
-            (AllSyncInner::WarpSync { .. }, SourceMapping::AllForks(_)) => unreachable!(),
-            (AllSyncInner::AllForks(_), SourceMapping::WarpSync(_)) => unreachable!(),
-        }
+        &mut self.all_forks[self.shared.sources.get(source_id.0).unwrap().all_forks].user_data
     }
 }
 
@@ -1631,22 +1274,14 @@ impl<'a, TRq, TSrc, TBl> ops::Index<(u64, &'a [u8; 32])> for AllSync<TRq, TSrc, 
 
     #[track_caller]
     fn index(&self, (block_height, block_hash): (u64, &'a [u8; 32])) -> &TBl {
-        match &self.inner {
-            AllSyncInner::AllForks(inner) => inner[(block_height, block_hash)].as_ref().unwrap(),
-            AllSyncInner::WarpSync { .. } => panic!("unknown block"), // No block is ever stored during the warp syncing.
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks[(block_height, block_hash)].as_ref().unwrap()
     }
 }
 
 impl<'a, TRq, TSrc, TBl> ops::IndexMut<(u64, &'a [u8; 32])> for AllSync<TRq, TSrc, TBl> {
     #[track_caller]
     fn index_mut(&mut self, (block_height, block_hash): (u64, &'a [u8; 32])) -> &mut TBl {
-        match &mut self.inner {
-            AllSyncInner::AllForks(inner) => inner[(block_height, block_hash)].as_mut().unwrap(),
-            AllSyncInner::WarpSync { .. } => panic!("unknown block"), // No block is ever stored during the warp syncing.
-            AllSyncInner::Poisoned => unreachable!(),
-        }
+        self.all_forks[(block_height, block_hash)].as_mut().unwrap()
     }
 }
 
@@ -1973,8 +1608,9 @@ pub struct BlockFull {
 }
 
 pub struct BlockVerify<TRq, TSrc, TBl> {
-    inner:
-        all_forks::BlockVerify<Option<TBl>, AllForksRequestExtra<TRq>, AllForksSourceExtra<TSrc>>,
+    inner: all_forks::BlockVerify<Option<TBl>, AllForksRequestExtra, AllForksSourceExtra<TSrc>>,
+    warp_sync: Option<warp_sync::WarpSync<WarpSyncSourceExtra, WarpSyncRequestExtra>>,
+    ready_to_transition: Option<warp_sync::RuntimeInformation>,
     shared: Shared<TRq>,
 }
 
@@ -2013,14 +1649,18 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
             } => HeaderVerifyOutcome::Success {
                 is_new_best,
                 success: HeaderVerifySuccess {
-                    inner: HeaderVerifySuccessInner::AllForks(success),
+                    inner: success,
+                    warp_sync: self.warp_sync,
+                    ready_to_transition: self.ready_to_transition,
                     shared: self.shared,
                     verified_block_hash,
                 },
             },
             all_forks::HeaderVerifyOutcome::Error { sync, error } => HeaderVerifyOutcome::Error {
                 sync: AllSync {
-                    inner: AllSyncInner::AllForks(sync),
+                    all_forks: sync,
+                    warp_sync: self.warp_sync,
+                    ready_to_transition: self.ready_to_transition,
                     shared: self.shared,
                 },
                 error: match error {
@@ -2070,34 +1710,27 @@ pub enum HeaderVerifyError {
 }
 
 pub struct HeaderVerifySuccess<TRq, TSrc, TBl> {
-    inner: HeaderVerifySuccessInner<TRq, TSrc, TBl>,
+    inner: all_forks::HeaderVerifySuccess<
+        Option<TBl>,
+        AllForksRequestExtra,
+        AllForksSourceExtra<TSrc>,
+    >,
+    warp_sync: Option<warp_sync::WarpSync<WarpSyncSourceExtra, WarpSyncRequestExtra>>,
+    ready_to_transition: Option<warp_sync::RuntimeInformation>,
     shared: Shared<TRq>,
     verified_block_hash: [u8; 32],
-}
-
-enum HeaderVerifySuccessInner<TRq, TSrc, TBl> {
-    AllForks(
-        all_forks::HeaderVerifySuccess<
-            Option<TBl>,
-            AllForksRequestExtra<TRq>,
-            AllForksSourceExtra<TSrc>,
-        >,
-    ),
 }
 
 impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
     /// Returns the height of the block that was verified.
     pub fn height(&self) -> u64 {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => verify.height(),
-        }
+        self.inner.height()
     }
 
     /// Returns the hash of the block that was verified.
     pub fn hash(&self) -> [u8; 32] {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => *verify.hash(),
-        }
+        // TODO: return by ref
+        *self.inner.hash()
     }
 
     /// Returns the list of SCALE-encoded extrinsics of the block to verify.
@@ -2106,80 +1739,62 @@ impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
     pub fn scale_encoded_extrinsics(
         &'_ self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => verify.scale_encoded_extrinsics(),
-        }
+        self.inner.scale_encoded_extrinsics()
     }
 
     /// Returns the hash of the parent of the block that was verified.
     pub fn parent_hash(&self) -> &[u8; 32] {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => verify.parent_hash(),
-        }
+        self.inner.parent_hash()
     }
 
     /// Returns the user data of the parent of the block to be verified, or `None` if the parent
     /// is the finalized block.
     pub fn parent_user_data(&self) -> Option<&TBl> {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => {
-                verify.parent_user_data().map(|ud| ud.as_ref().unwrap()) // TODO: don't unwrap
-            }
-        }
+        self.inner.parent_user_data().map(|ud| ud.as_ref().unwrap()) // TODO: don't unwrap
     }
 
     /// Returns the SCALE-encoded header of the block that was verified.
     pub fn scale_encoded_header(&self) -> &[u8] {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(verify) => verify.scale_encoded_header(),
-        }
+        self.inner.scale_encoded_header()
     }
 
     /// Returns the SCALE-encoded header of the parent of the block.
     pub fn parent_scale_encoded_header(&self) -> Vec<u8> {
-        match &self.inner {
-            HeaderVerifySuccessInner::AllForks(inner) => inner.parent_scale_encoded_header(),
-        }
+        self.inner.parent_scale_encoded_header()
     }
 
     /// Cancel the block verification.
     pub fn cancel(self) -> AllSync<TRq, TSrc, TBl> {
-        match self.inner {
-            HeaderVerifySuccessInner::AllForks(inner) => {
-                let sync = inner.cancel();
-                AllSync {
-                    inner: AllSyncInner::AllForks(sync),
-                    shared: self.shared,
-                }
-            }
+        let all_forks = self.inner.cancel();
+        AllSync {
+            all_forks,
+            warp_sync: self.warp_sync,
+            ready_to_transition: self.ready_to_transition,
+            shared: self.shared,
         }
     }
 
     /// Reject the block and mark it as bad.
     pub fn reject_bad_block(self) -> AllSync<TRq, TSrc, TBl> {
-        match self.inner {
-            HeaderVerifySuccessInner::AllForks(inner) => {
-                let sync = inner.reject_bad_block();
-                AllSync {
-                    inner: AllSyncInner::AllForks(sync),
-                    shared: self.shared,
-                }
-            }
+        let all_forks = self.inner.reject_bad_block();
+        AllSync {
+            all_forks,
+            warp_sync: self.warp_sync,
+            ready_to_transition: self.ready_to_transition,
+            shared: self.shared,
         }
     }
 
     /// Finish inserting the block header.
     pub fn finish(self, user_data: TBl) -> AllSync<TRq, TSrc, TBl> {
         let height = self.height();
-        match self.inner {
-            HeaderVerifySuccessInner::AllForks(inner) => {
-                let mut sync = inner.finish();
-                *sync.block_user_data_mut(height, &self.verified_block_hash) = Some(user_data);
-                AllSync {
-                    inner: AllSyncInner::AllForks(sync),
-                    shared: self.shared,
-                }
-            }
+        let mut all_forks = self.inner.finish();
+        *all_forks.block_user_data_mut(height, &self.verified_block_hash) = Some(user_data);
+        AllSync {
+            all_forks,
+            warp_sync: self.warp_sync,
+            ready_to_transition: self.ready_to_transition,
+            shared: self.shared,
         }
     }
 }
@@ -2187,9 +1802,11 @@ impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
 pub struct FinalityProofVerify<TRq, TSrc, TBl> {
     inner: all_forks::FinalityProofVerify<
         Option<TBl>,
-        AllForksRequestExtra<TRq>,
+        AllForksRequestExtra,
         AllForksSourceExtra<TSrc>,
     >,
+    warp_sync: Option<warp_sync::WarpSync<WarpSyncSourceExtra, WarpSyncRequestExtra>>,
+    ready_to_transition: Option<warp_sync::RuntimeInformation>,
     shared: Shared<TRq>,
 }
 
@@ -2208,7 +1825,7 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
         self,
         randomness_seed: [u8; 32],
     ) -> (AllSync<TRq, TSrc, TBl>, FinalityProofVerifyOutcome<TBl>) {
-        let (sync, outcome) = match self.inner.perform(randomness_seed) {
+        let (all_forks, outcome) = match self.inner.perform(randomness_seed) {
             (
                 sync,
                 all_forks::FinalityProofVerifyOutcome::NewFinalized {
@@ -2251,7 +1868,9 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
 
         (
             AllSync {
-                inner: AllSyncInner::AllForks(sync),
+                all_forks,
+                warp_sync: self.warp_sync,
+                ready_to_transition: self.ready_to_transition,
                 shared: self.shared,
             },
             outcome,
@@ -2285,10 +1904,11 @@ pub enum FinalityProofVerifyOutcome<TBl> {
 }
 
 pub struct WarpSyncFragmentVerify<TRq, TSrc, TBl> {
-    inner: warp_sync::VerifyWarpSyncFragment<WarpSyncSourceExtra<TSrc>, WarpSyncRequestExtra<TRq>>,
+    inner: warp_sync::VerifyWarpSyncFragment<WarpSyncSourceExtra, WarpSyncRequestExtra>,
     ready_to_transition: Option<warp_sync::RuntimeInformation>,
     shared: Shared<TRq>,
-    marker: marker::PhantomData<Vec<TBl>>,
+    all_forks:
+        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra, AllForksSourceExtra<TSrc>>,
 }
 
 impl<TRq, TSrc, TBl> WarpSyncFragmentVerify<TRq, TSrc, TBl> {
@@ -2298,7 +1918,10 @@ impl<TRq, TSrc, TBl> WarpSyncFragmentVerify<TRq, TSrc, TBl> {
     /// Returns `None` if the source has been removed since the fragments have been downloaded.
     pub fn proof_sender(&self) -> Option<(SourceId, &TSrc)> {
         let (_, ud) = self.inner.proof_sender()?;
-        Some((ud.outer_source_id, &ud.user_data))
+        Some((
+            ud.outer_source_id,
+            &self.all_forks[self.shared.sources[ud.outer_source_id.0].all_forks].user_data,
+        ))
     }
 
     /// Perform the verification.
@@ -2315,14 +1938,13 @@ impl<TRq, TSrc, TBl> WarpSyncFragmentVerify<TRq, TSrc, TBl> {
         AllSync<TRq, TSrc, TBl>,
         Result<([u8; 32], u64), VerifyFragmentError>,
     ) {
-        let (next_grandpa_warp_sync, result) = self.inner.verify(randomness_seed);
+        let (warp_sync, result) = self.inner.verify(randomness_seed);
 
         (
             AllSync {
-                inner: AllSyncInner::WarpSync {
-                    inner: next_grandpa_warp_sync,
-                    ready_to_transition: self.ready_to_transition,
-                },
+                warp_sync: Some(warp_sync),
+                ready_to_transition: self.ready_to_transition,
+                all_forks: self.all_forks,
                 shared: self.shared,
             },
             result,
@@ -2333,10 +1955,11 @@ impl<TRq, TSrc, TBl> WarpSyncFragmentVerify<TRq, TSrc, TBl> {
 /// Compiling a new runtime is necessary for the warp sync process.
 #[must_use]
 pub struct WarpSyncBuildRuntime<TRq, TSrc, TBl> {
-    inner: warp_sync::BuildRuntime<WarpSyncSourceExtra<TSrc>, WarpSyncRequestExtra<TRq>>,
+    inner: warp_sync::BuildRuntime<WarpSyncSourceExtra, WarpSyncRequestExtra>,
     ready_to_transition: Option<warp_sync::RuntimeInformation>,
     shared: Shared<TRq>,
-    marker: marker::PhantomData<Vec<TBl>>,
+    all_forks:
+        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra, AllForksSourceExtra<TSrc>>,
 }
 
 impl<TRq, TSrc, TBl> WarpSyncBuildRuntime<TRq, TSrc, TBl> {
@@ -2353,14 +1976,13 @@ impl<TRq, TSrc, TBl> WarpSyncBuildRuntime<TRq, TSrc, TBl> {
         AllSync<TRq, TSrc, TBl>,
         Result<(), WarpSyncBuildRuntimeError>,
     ) {
-        let (warp_sync_status, outcome) = self.inner.build(exec_hint, allow_unresolved_imports);
+        let (warp_sync, outcome) = self.inner.build(exec_hint, allow_unresolved_imports);
 
         (
             AllSync {
-                inner: AllSyncInner::WarpSync {
-                    inner: warp_sync_status,
-                    ready_to_transition: self.ready_to_transition,
-                },
+                warp_sync: Some(warp_sync),
+                ready_to_transition: self.ready_to_transition,
+                all_forks: self.all_forks,
                 shared: self.shared,
             },
             outcome,
@@ -2371,9 +1993,10 @@ impl<TRq, TSrc, TBl> WarpSyncBuildRuntime<TRq, TSrc, TBl> {
 /// Building the chain information is necessary for the warp sync process.
 #[must_use]
 pub struct WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
-    inner: warp_sync::BuildChainInformation<WarpSyncSourceExtra<TSrc>, WarpSyncRequestExtra<TRq>>,
+    inner: warp_sync::BuildChainInformation<WarpSyncSourceExtra, WarpSyncRequestExtra>,
     shared: Shared<TRq>,
-    marker: marker::PhantomData<Vec<TBl>>,
+    all_forks:
+        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra, AllForksSourceExtra<TSrc>>,
 }
 
 impl<TRq, TSrc, TBl> WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
@@ -2384,7 +2007,7 @@ impl<TRq, TSrc, TBl> WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
         AllSync<TRq, TSrc, TBl>,
         Result<(), WarpSyncBuildChainInformationError>,
     ) {
-        let (warp_sync_status, outcome) = self.inner.build();
+        let (warp_sync, outcome) = self.inner.build();
 
         let (ready_to_transition, outcome) = match outcome {
             Ok(info) => (Some(info), Ok(())),
@@ -2393,10 +2016,9 @@ impl<TRq, TSrc, TBl> WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
 
         (
             AllSync {
-                inner: AllSyncInner::WarpSync {
-                    inner: warp_sync_status,
-                    ready_to_transition,
-                },
+                warp_sync: Some(warp_sync),
+                ready_to_transition,
+                all_forks: self.all_forks,
                 shared: self.shared,
             },
             outcome,
@@ -2404,43 +2026,26 @@ impl<TRq, TSrc, TBl> WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
     }
 }
 
-enum AllSyncInner<TRq, TSrc, TBl> {
-    WarpSync {
-        inner: warp_sync::WarpSync<WarpSyncSourceExtra<TSrc>, WarpSyncRequestExtra<TRq>>,
-        ready_to_transition: Option<warp_sync::RuntimeInformation>,
-    },
-    // TODO: we store an `Option<TBl>` instead of `TBl` due to API issues; the all.rs doesn't let you insert user datas for pending blocks while the AllForksSync lets you; `None` is stored while a block is pending
-    AllForks(
-        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra<TRq>, AllForksSourceExtra<TSrc>>,
-    ),
-    Poisoned,
-}
-
 struct AllForksSourceExtra<TSrc> {
     outer_source_id: SourceId,
     user_data: TSrc,
 }
 
-struct AllForksRequestExtra<TRq> {
+struct AllForksRequestExtra {
     outer_request_id: RequestId,
-    user_data: Option<TRq>, // TODO: why option?
 }
 
-struct WarpSyncSourceExtra<TSrc> {
+struct WarpSyncSourceExtra {
     outer_source_id: SourceId,
-    user_data: TSrc,
-    best_block_number: u64,
-    best_block_hash: [u8; 32],
 }
 
-struct WarpSyncRequestExtra<TRq> {
+struct WarpSyncRequestExtra {
     outer_request_id: RequestId,
-    user_data: TRq,
 }
 
 struct Shared<TRq> {
     sources: slab::Slab<SourceMapping>,
-    requests: slab::Slab<RequestMapping<TRq>>,
+    requests: slab::Slab<RequestInfo<TRq>>,
 
     /// See [`Config::download_bodies`].
     download_bodies: bool,
@@ -2459,154 +2064,18 @@ struct Shared<TRq> {
     allow_unknown_consensus_engines: bool,
 }
 
-impl<TRq> Shared<TRq> {
-    /// Transitions the sync state machine from the warp sync strategy to the "all-forks"
-    /// strategy.
-    fn transition_warp_sync_all_forks<TSrc, TBl>(
-        &mut self,
-        warp_sync: warp_sync::WarpSync<WarpSyncSourceExtra<TSrc>, WarpSyncRequestExtra<TRq>>,
-        ready_to_transition: warp_sync::RuntimeInformation,
-    ) -> (
-        all_forks::AllForksSync<Option<TBl>, AllForksRequestExtra<TRq>, AllForksSourceExtra<TSrc>>,
-        host::HostVmPrototype,
-        Option<Vec<Vec<u8>>>,
-        Option<Vec<u8>>,
-        Option<Vec<u8>>,
-        Option<Vec<u8>>,
-        Option<Vec<Nibble>>,
-    ) {
-        let warp_sync = warp_sync.deconstruct();
-
-        let mut all_forks = all_forks::AllForksSync::new(all_forks::Config {
-            chain_information: warp_sync.chain_information,
-            block_number_bytes: self.block_number_bytes,
-            sources_capacity: self.sources_capacity,
-            blocks_capacity: self.blocks_capacity,
-            max_disjoint_headers: self.max_disjoint_headers,
-            max_requests_per_block: self.max_requests_per_block,
-            allow_unknown_consensus_engines: self.allow_unknown_consensus_engines,
-            download_bodies: self.download_bodies,
-        });
-
-        debug_assert!(self
-            .sources
-            .iter()
-            .all(|(_, s)| matches!(s, SourceMapping::WarpSync(_))));
-
-        for (
-            source_id,
-            _,
-            WarpSyncRequestExtra {
-                outer_request_id,
-                user_data,
-            },
-            detail,
-        ) in warp_sync.in_progress_requests
-        {
-            // TODO: DRY
-            let detail = match detail {
-                warp_sync::RequestDetail::WarpSyncRequest { block_hash } => {
-                    RequestDetail::WarpSync {
-                        sync_start_block_hash: block_hash,
-                    }
-                }
-                warp_sync::RequestDetail::BlockBodyDownload {
-                    block_hash,
-                    block_number,
-                } => RequestDetail::BlocksRequest {
-                    first_block_height: block_number,
-                    first_block_hash: Some(block_hash),
-                    ascending: true,
-                    num_blocks: NonZeroU64::new(1).unwrap(),
-                    request_headers: false,
-                    request_bodies: true,
-                    request_justification: false,
-                },
-                warp_sync::RequestDetail::StorageGetMerkleProof { block_hash, keys } => {
-                    RequestDetail::StorageGet { block_hash, keys }
-                }
-                warp_sync::RequestDetail::RuntimeCallMerkleProof {
-                    block_hash,
-                    function_name,
-                    parameter_vectored,
-                } => RequestDetail::RuntimeCallMerkleProof {
-                    block_hash,
-                    function_name,
-                    parameter_vectored,
-                },
-            };
-
-            // TODO: O(n2)
-            let (source_id, _) = self
-                .sources
-                .iter()
-                .find(|(_, s)| {
-                    matches!(s,
-                        SourceMapping::WarpSync(s) if *s == source_id
-                    )
-                })
-                .unwrap();
-
-            self.requests[outer_request_id.0] =
-                RequestMapping::Inline(SourceId(source_id), detail, user_data);
-        }
-
-        for (_, finalized_block_height, source) in warp_sync.sources_ordered {
-            let source_user_data = AllForksSourceExtra {
-                user_data: source.user_data,
-                outer_source_id: source.outer_source_id,
-            };
-
-            let updated_source_id = match all_forks
-                .prepare_add_source(source.best_block_number, source.best_block_hash)
-            {
-                all_forks::AddSource::BestBlockAlreadyVerified(b)
-                | all_forks::AddSource::BestBlockPendingVerification(b) => {
-                    b.add_source(source_user_data)
-                }
-                all_forks::AddSource::OldBestBlock(b) => b.add_source(source_user_data),
-                all_forks::AddSource::UnknownBestBlock(b) => {
-                    b.add_source_and_insert_block(source_user_data, None)
-                }
-            };
-
-            all_forks.update_source_finality_state(updated_source_id, finalized_block_height);
-
-            self.sources[source.outer_source_id.0] = SourceMapping::AllForks(updated_source_id);
-        }
-
-        debug_assert!(self
-            .sources
-            .iter()
-            .all(|(_, s)| matches!(s, SourceMapping::AllForks(_))));
-        debug_assert!(self
-            .requests
-            .iter()
-            .all(|(_, s)| matches!(s, RequestMapping::AllForks(..) | RequestMapping::Inline(..))));
-
-        (
-            all_forks,
-            ready_to_transition.finalized_runtime,
-            ready_to_transition.finalized_body,
-            ready_to_transition.finalized_storage_code,
-            ready_to_transition.finalized_storage_heap_pages,
-            ready_to_transition.finalized_storage_code_merkle_value,
-            ready_to_transition.finalized_storage_code_closest_ancestor_excluding,
-        )
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequestInfo<TRq> {
+    warp_sync: Option<warp_sync::RequestId>,
+    all_forks: Option<all_forks::RequestId>,
+    source_id: SourceId,
+    user_data: TRq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum RequestMapping<TRq> {
-    Inline(SourceId, RequestDetail, TRq),
-    AllForks(all_forks::RequestId),
-    WarpSync(warp_sync::RequestId),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum SourceMapping {
-    WarpSync(warp_sync::SourceId),
-    AllForks(all_forks::SourceId),
+struct SourceMapping {
+    warp_sync: Option<warp_sync::SourceId>,
+    all_forks: all_forks::SourceId,
 }
 
 fn all_forks_request_convert(

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -362,8 +362,18 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     /// The way this method is implemented is opaque and cannot be relied on. The return value
     /// should only ever be shown to the user and not used for any meaningful logic.
+    // TODO: remove this function as it's too imprecise
     pub fn is_near_head_of_chain_heuristic(&self) -> bool {
-        todo!() // TODO:
+        let Some(all_forks) = &self.all_forks else {
+            unreachable!()
+        };
+
+        let local_best_block = all_forks.best_block_number();
+
+        // We return `false` if any source is more than 5 blocks ahead, and `true` otherwise.
+        !self.shared.sources.iter().any(|(_, src)| {
+            all_forks.source_best_block(src.all_forks).0 > local_best_block.saturating_add(5)
+        })
     }
 
     /// Adds a new source to the sync state machine.

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -751,7 +751,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 },
             ) => Some(warp_sync.add_request(
                 inner_source_id,
-                WarpSyncRequestExtra { outer_request_id },
+                WarpSyncRequestExtra {},
                 warp_sync::RequestDetail::WarpSyncRequest {
                     block_hash: sync_start_block_hash,
                 },
@@ -767,7 +767,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 },
             ) => Some(warp_sync.add_request(
                 inner_source_id,
-                WarpSyncRequestExtra { outer_request_id },
+                WarpSyncRequestExtra {},
                 warp_sync::RequestDetail::BlockBodyDownload {
                     block_hash: first_block_hash,
                     block_number: first_block_height,
@@ -779,7 +779,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 RequestDetail::StorageGet { block_hash, keys },
             ) => Some(warp_sync.add_request(
                 inner_source_id,
-                WarpSyncRequestExtra { outer_request_id },
+                WarpSyncRequestExtra {},
                 warp_sync::RequestDetail::StorageGetMerkleProof { block_hash, keys },
             )),
             (
@@ -792,7 +792,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 },
             ) => Some(warp_sync.add_request(
                 inner_source_id,
-                WarpSyncRequestExtra { outer_request_id },
+                WarpSyncRequestExtra {},
                 warp_sync::RequestDetail::RuntimeCallMerkleProof {
                     block_hash,
                     function_name,
@@ -2171,6 +2171,7 @@ impl<TRq, TSrc, TBl> WarpSyncBuildChainInformation<TRq, TSrc, TBl> {
     }
 }
 
+// TODO: are these structs useful?
 struct AllForksSourceExtra {
     outer_source_id: SourceId,
 }
@@ -2183,9 +2184,8 @@ struct WarpSyncSourceExtra {
     outer_source_id: SourceId,
 }
 
-struct WarpSyncRequestExtra {
-    outer_request_id: RequestId,
-}
+// TODO: consider removing struct altogether
+struct WarpSyncRequestExtra {}
 
 struct Shared<TRq, TSrc> {
     sources: slab::Slab<SourceMapping<TSrc>>,

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Changed
 
+- The warp syncing and regular syncing algorithms now run in parallel, meaning that smoldot will now try to perform a warp sync against peers whose finalized block is (or pretends to be) far ahead from the local finalized block, while at the same time continuing to sync normally from other peers. Additionally, smoldot will no longer try to warp sync to peers whose finalized block is too close to the local finalized block, and will instead sync normally.
 - The `system_health` JSON-RPC function now returns `isSyncing: true` if any of the peers smoldot is connected to is more than 10 blocks ahead of smoldot, and `false` in any other situation including having no peer.
+
+### Fixed
+
+- The syncing no longer gets stuck when connecting to a chain whose head is at the same block height as the checkpoint in the chain specification.
 
 ## 2.0.17 - 2024-01-17
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- The `system_health` JSON-RPC function now returns `isSyncing: true` if any of the peers smoldot is connected to is more than 10 blocks ahead of smoldot, and `false` in any other situation including having no peer.
+
 ## 2.0.17 - 2024-01-17
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Changed
 
-- The warp syncing and regular syncing algorithms now run in parallel, meaning that smoldot will now try to perform a warp sync against peers whose finalized block is (or pretends to be) far ahead from the local finalized block, while at the same time continuing to sync normally from other peers. Additionally, smoldot will no longer try to warp sync to peers whose finalized block is too close to the local finalized block, and will instead sync normally.
-- The `system_health` JSON-RPC function now returns `isSyncing: true` if any of the peers smoldot is connected to is more than 10 blocks ahead of smoldot, and `false` in any other situation including having no peer.
+- The warp syncing and regular syncing algorithms now run in parallel, meaning that smoldot will now try to perform a warp sync against peers whose finalized block is (or pretends to be) far ahead from the local finalized block, while at the same time continuing to sync normally from other peers. Additionally, smoldot will no longer try to warp sync to peers whose finalized block is too close to the local finalized block, and will instead sync normally. ([#1591](https://github.com/smol-dot/smoldot/pull/1591))
+- The `system_health` JSON-RPC function now returns `isSyncing: true` if any of the peers smoldot is connected to is more than 10 blocks ahead of smoldot, and `false` in any other situation including having no peer. ([#1591](https://github.com/smol-dot/smoldot/pull/1591))
 
 ### Fixed
 
-- The syncing no longer gets stuck when connecting to a chain whose head is at the same block height as the checkpoint in the chain specification.
+- The syncing no longer gets stuck when connecting to a chain whose head is at the same block height as the checkpoint in the chain specification. ([#1591](https://github.com/smol-dot/smoldot/pull/1591))
 
 ## 2.0.17 - 2024-01-17
 


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/1109
Close https://github.com/smol-dot/smoldot/issues/1562

Previously, smoldot would always do a warp sync, then start syncing normally from the warp sync target.
What this PR does is always run the warp sync and normal syncing, and at the same time.

As described in the CHANGELOG, the consequence is that smoldot is able to perform a warp sync after it has been offline for a long time (or that the chain's finality has stalled for a long time) even if it has already warp synced before, and that it will no longer try to warp sync if peers are too close to the local best block.

This change opens the possibility for significant clean ups in `all.rs`. This module was a bit left rotten while waiting for this change.
