### PR TITLE
Simplify `runtime_service` and make `async_tree` easier to use

### DIFF
--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -1020,7 +1020,6 @@ where
                 return Some(OutputUpdate::Finalized {
                     former_index: new_finalized,
                     user_data: pruned_finalized.user_data.user_data,
-                    async_op_user_data: &self.output_finalized_async_user_data,
                     former_finalized_async_op_user_data,
                     pruned_blocks,
                     best_block_index: self.output_best_block_index,
@@ -1184,7 +1183,7 @@ pub struct InputIterItem<'a, TBl, TAsync> {
 
 /// See [`AsyncTree::try_advance_output`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum OutputUpdate<'a, TBl, TAsync> {
+pub enum OutputUpdate<TBl, TAsync> {
     /// A non-finalized block has been finalized in the output.
     ///
     /// This block is no longer part of the data structure.
@@ -1197,12 +1196,6 @@ pub enum OutputUpdate<'a, TBl, TAsync> {
 
         /// User data associated to this block.
         user_data: TBl,
-
-        /// User data associated to the `async` operation of this block.
-        ///
-        /// This is the same value as is now returned by
-        /// [`AsyncTree::output_finalized_async_user_data`], and is provided here for convenience.
-        async_op_user_data: &'a TAsync,
 
         /// User data associated to the `async` operation of the previous finalized block.
         former_finalized_async_op_user_data: TAsync,

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -120,23 +120,20 @@ pub use fork_tree::NodeIndex;
 pub struct AsyncOpId(u64);
 
 #[derive(Debug)]
-pub enum NextNecessaryAsyncOp<'a, TNow, TBl> {
-    Ready(AsyncOpParams<'a, TBl>),
+pub enum NextNecessaryAsyncOp<TNow> {
+    Ready(AsyncOpParams),
     NotReady { when: Option<TNow> },
 }
 
 /// Information about an operation that must be started.
 #[derive(Debug)]
-pub struct AsyncOpParams<'a, TBl> {
+pub struct AsyncOpParams {
     /// Identifier to later provide when calling [`AsyncTree::async_op_finished`] or
     /// [`AsyncTree::async_op_failure`].
     pub id: AsyncOpId,
 
     /// Index of the block to perform the operation against.
     pub block_index: NodeIndex,
-
-    /// User data of the block to perform the operation against.
-    pub block_user_data: &'a TBl,
 }
 
 /// Configuration for [`AsyncTree::new`].
@@ -551,7 +548,7 @@ where
     /// - The input best block.
     /// - Any other block.
     ///
-    pub fn next_necessary_async_op(&mut self, now: &TNow) -> NextNecessaryAsyncOp<TNow, TBl> {
+    pub fn next_necessary_async_op(&mut self, now: &TNow) -> NextNecessaryAsyncOp<TNow> {
         let mut when_not_ready = None;
 
         // Finalized block according to the blocks input.
@@ -561,11 +558,6 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                        block_user_data: &self
-                            .non_finalized_blocks
-                            .get(block_index)
-                            .unwrap()
-                            .user_data,
                     })
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {
@@ -590,11 +582,6 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                        block_user_data: &self
-                            .non_finalized_blocks
-                            .get(block_index)
-                            .unwrap()
-                            .user_data,
                     })
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {
@@ -620,11 +607,6 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                        block_user_data: &self
-                            .non_finalized_blocks
-                            .get(block_index)
-                            .unwrap()
-                            .user_data,
                     })
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -290,30 +290,6 @@ where
         })
     }
 
-    /// Returns the user data associated to the given block.
-    ///
-    /// # Panic
-    ///
-    /// Panics if the [`NodeIndex`] is invalid.
-    ///
-    pub fn block_user_data(&self, node_index: NodeIndex) -> &TBl {
-        &self.non_finalized_blocks.get(node_index).unwrap().user_data
-    }
-
-    /// Returns the user data associated to the given block.
-    ///
-    /// # Panic
-    ///
-    /// Panics if the [`NodeIndex`] is invalid.
-    ///
-    pub fn block_user_data_mut(&mut self, node_index: NodeIndex) -> &mut TBl {
-        &mut self
-            .non_finalized_blocks
-            .get_mut(node_index)
-            .unwrap()
-            .user_data
-    }
-
     /// Returns the outcome of the asynchronous operation for the output finalized block.
     ///
     /// This is the value that was passed at initialization, or is updated after
@@ -1173,6 +1149,24 @@ where
 
         // Nothing to do.
         None
+    }
+}
+
+impl<TNow, TBl, TAsync> ops::Index<NodeIndex> for AsyncTree<TNow, TBl, TAsync> {
+    type Output = TBl;
+
+    fn index(&self, node_index: NodeIndex) -> &Self::Output {
+        &self.non_finalized_blocks.get(node_index).unwrap().user_data
+    }
+}
+
+impl<TNow, TBl, TAsync> ops::IndexMut<NodeIndex> for AsyncTree<TNow, TBl, TAsync> {
+    fn index_mut(&mut self, node_index: NodeIndex) -> &mut Self::Output {
+        &mut self
+            .non_finalized_blocks
+            .get_mut(node_index)
+            .unwrap()
+            .user_data
     }
 }
 

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -894,6 +894,7 @@ where
     ///
     /// Returns `None` if the state machine doesn't have any update. This method should be called
     /// repeatedly until it returns `None`. Each call can perform an additional update.
+    // TODO: should cache the information about whether an update is ready, so that calling this method becomes cheap
     pub fn try_advance_output(&mut self) -> Option<OutputUpdate<TBl, TAsync>> {
         // Try to advance the output finalized block.
         // `input_finalized_index` is `Some` if the input finalized is not already equal to the

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -1081,16 +1081,6 @@ where
             // Report the new block.
             return Some(OutputUpdate::Block(OutputUpdateBlock {
                 index: node_index,
-                user_data: &self.non_finalized_blocks.get(node_index).unwrap().user_data,
-                async_op_user_data: match &self
-                    .non_finalized_blocks
-                    .get(node_index)
-                    .unwrap()
-                    .async_op
-                {
-                    AsyncOpState::Finished { user_data, .. } => user_data,
-                    _ => unreachable!(),
-                },
                 is_new_best,
             }));
         }
@@ -1230,7 +1220,7 @@ pub enum OutputUpdate<'a, TBl, TAsync> {
     },
 
     /// A new block has been added to the list of output unfinalized blocks.
-    Block(OutputUpdateBlock<'a, TBl, TAsync>),
+    Block(OutputUpdateBlock),
 
     /// The output best block has been modified.
     BestBlockChanged {
@@ -1242,15 +1232,9 @@ pub enum OutputUpdate<'a, TBl, TAsync> {
 
 /// See [`OutputUpdate`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OutputUpdateBlock<'a, TBl, TAsync> {
+pub struct OutputUpdateBlock {
     /// Index of the node within the data structure.
     pub index: NodeIndex,
-
-    /// User data associated to this block.
-    pub user_data: &'a TBl,
-
-    /// User data associated to the `async` operation of this block.
-    pub async_op_user_data: &'a TAsync,
 
     /// True if this block is considered as the best block of the chain.
     pub is_new_best: bool,

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -79,7 +79,7 @@
 //! let async_op_id = match tree.next_necessary_async_op(&Instant::now()) {
 //!     async_tree::NextNecessaryAsyncOp::Ready(params) => {
 //!         assert_eq!(params.block_index, _my_block_index);
-//!         assert_eq!(*params.block_user_data, "my block");
+//!         assert_eq!(tree[params.block_index], "my block");
 //!         params.id
 //!     }
 //!     async_tree::NextNecessaryAsyncOp::NotReady { when: _ } => {
@@ -101,8 +101,6 @@
 //! match tree.try_advance_output() {
 //!     Some(async_tree::OutputUpdate::Block(block)) => {
 //!         assert_eq!(block.index, _my_block_index);
-//!         assert_eq!(*block.user_data, "my block");
-//!         assert_eq!(*block.async_op_user_data, "world");
 //!         assert!(block.is_new_best);
 //!     }
 //!     _ => unreachable!() // Unreachable in this example.

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1082,8 +1082,8 @@ async fn run_background<TPlat: PlatformRef>(
                             ..
                         }) => {
                             *finalized_block = new_finalized;
-                            let best_block_hash = best_block_index
-                                .map_or(finalized_block.hash, |idx| tree.block_user_data(idx).hash);
+                            let best_block_hash =
+                                best_block_index.map_or(finalized_block.hash, |idx| tree[idx].hash);
 
                             log!(
                                 &background.platform,
@@ -1181,16 +1181,14 @@ async fn run_background<TPlat: PlatformRef>(
                                 Debug,
                                 &background.log_target,
                                 "output-chain-new-block",
-                                block_hash = HashDisplay(&tree.block_user_data(block_index).hash),
+                                block_hash = HashDisplay(&tree[block_index].hash),
                                 is_new_best
                             );
 
                             let notif = Notification::Block(BlockNotification {
                                 parent_hash: tree
                                     .parent(block_index)
-                                    .map_or(finalized_block.hash, |idx| {
-                                        tree.block_user_data(idx).hash
-                                    }),
+                                    .map_or(finalized_block.hash, |idx| tree[idx].hash),
                                 is_new_best,
                                 scale_encoded_header,
                                 new_runtime: if !Arc::ptr_eq(&parent_runtime, &block_runtime) {
@@ -1241,7 +1239,7 @@ async fn run_background<TPlat: PlatformRef>(
                         }
                         Some(async_tree::OutputUpdate::BestBlockChanged { best_block_index }) => {
                             let hash = best_block_index
-                                .map_or(&*finalized_block, |idx| tree.block_user_data(idx))
+                                .map_or(&*finalized_block, |idx| &tree[idx])
                                 .hash;
 
                             log!(
@@ -1297,9 +1295,7 @@ async fn run_background<TPlat: PlatformRef>(
                                 debug_assert!(former_finalized_async_op_user_data.is_none());
 
                                 let best_block_hash = best_block_index
-                                    .map_or(new_finalized.hash, |idx| {
-                                        tree.block_user_data(idx).hash
-                                    });
+                                    .map_or(new_finalized.hash, |idx| tree[idx].hash);
                                 log!(
                                     &background.platform,
                                     Debug,

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -827,7 +827,8 @@ async fn run_background<TPlat: PlatformRef>(
         enum WakeUpReason<TPlat: PlatformRef> {
             MustSubscribe,
             NewNecessaryDownload,
-            MustAdvanceTree,
+            MustAdvanceTreeFinalizedKnown(async_tree::OutputUpdate<Block, Arc<Runtime>>),
+            MustAdvanceTreeFinalizedUnknown(async_tree::OutputUpdate<Block, Option<Arc<Runtime>>>),
             StartPendingSubscribeAll,
             Notification(Option<sync_service::Notification>),
             ToBackground(ToBackground<TPlat>),
@@ -849,10 +850,10 @@ async fn run_background<TPlat: PlatformRef>(
 
         // Wait for something to happen or for some processing to be necessary.
         let wake_up_reason: WakeUpReason<_> = {
+            let finalized_block_known =
+                matches!(background.tree, Tree::FinalizedBlockRuntimeKnown { .. });
             async {
-                if !background.pending_subscriptions.is_empty()
-                    && matches!(background.tree, Tree::FinalizedBlockRuntimeKnown { .. })
-                {
+                if !background.pending_subscriptions.is_empty() && finalized_block_known {
                     WakeUpReason::StartPendingSubscribeAll
                 } else {
                     future::pending().await
@@ -898,11 +899,19 @@ async fn run_background<TPlat: PlatformRef>(
                 WakeUpReason::NewNecessaryDownload
             })
             .or(async {
-                if background.must_update_tree_and_notify_subscribers {
-                    background.must_update_tree_and_notify_subscribers = false;
-                    WakeUpReason::MustAdvanceTree
-                } else {
-                    future::pending().await
+                match &mut background.tree {
+                    Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
+                        match tree.try_advance_output() {
+                            Some(update) => WakeUpReason::MustAdvanceTreeFinalizedKnown(update),
+                            None => future::pending().await,
+                        }
+                    }
+                    Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
+                        match tree.try_advance_output() {
+                            Some(update) => WakeUpReason::MustAdvanceTreeFinalizedUnknown(update),
+                            None => future::pending().await,
+                        }
+                    }
                 }
             })
             .await
@@ -1064,282 +1073,293 @@ async fn run_background<TPlat: PlatformRef>(
                 background.wake_up_new_necessary_download = Box::pin(future::ready(()));
             }
 
-            WakeUpReason::MustAdvanceTree => {
-                // The tree of blocks might need to be advanced.
-                match &mut background.tree {
-                    Tree::FinalizedBlockRuntimeKnown {
-                        tree,
-                        finalized_block,
-                        all_blocks_subscriptions,
-                        pinned_blocks,
-                    } => match tree.try_advance_output() {
-                        None => continue,
-                        Some(async_tree::OutputUpdate::Finalized {
-                            user_data: new_finalized,
-                            best_block_index,
-                            pruned_blocks,
-                            former_finalized_async_op_user_data: former_finalized_runtime,
-                            ..
-                        }) => {
-                            *finalized_block = new_finalized;
-                            let best_block_hash =
-                                best_block_index.map_or(finalized_block.hash, |idx| tree[idx].hash);
+            WakeUpReason::MustAdvanceTreeFinalizedKnown(async_tree::OutputUpdate::Finalized {
+                user_data: new_finalized,
+                best_block_index,
+                pruned_blocks,
+                former_finalized_async_op_user_data: former_finalized_runtime,
+                ..
+            }) => {
+                let Tree::FinalizedBlockRuntimeKnown {
+                    tree,
+                    finalized_block,
+                    all_blocks_subscriptions,
+                    pinned_blocks,
+                } = &mut background.tree
+                else {
+                    unreachable!()
+                };
 
-                            log!(
-                                &background.platform,
-                                Debug,
-                                &background.log_target,
-                                "output-chain-finalized",
-                                block_hash = HashDisplay(&finalized_block.hash),
-                                best_block_hash = HashDisplay(&best_block_hash)
-                            );
+                *finalized_block = new_finalized;
+                let best_block_hash =
+                    best_block_index.map_or(finalized_block.hash, |idx| tree[idx].hash);
 
-                            // The finalization might cause some runtimes in the list of runtimes
-                            // to have become unused. Clean them up.
-                            drop(former_finalized_runtime);
-                            background
-                                .runtimes
-                                .retain(|_, runtime| runtime.strong_count() > 0);
+                log!(
+                    &background.platform,
+                    Debug,
+                    &background.log_target,
+                    "output-chain-finalized",
+                    block_hash = HashDisplay(&finalized_block.hash),
+                    best_block_hash = HashDisplay(&best_block_hash)
+                );
 
-                            let all_blocks_notif = Notification::Finalized {
-                                best_block_hash,
-                                hash: finalized_block.hash,
-                                pruned_blocks: pruned_blocks
-                                    .iter()
-                                    .map(|(_, b, _)| b.hash)
-                                    .collect(),
-                            };
+                // The finalization might cause some runtimes in the list of runtimes
+                // to have become unused. Clean them up.
+                drop(former_finalized_runtime);
+                background
+                    .runtimes
+                    .retain(|_, runtime| runtime.strong_count() > 0);
 
-                            let mut to_remove = Vec::new();
-                            for (subscription_id, (sender, finalized_pinned_remaining)) in
-                                all_blocks_subscriptions.iter_mut()
-                            {
-                                let count_limit = pruned_blocks.len() + 1;
+                let all_blocks_notif = Notification::Finalized {
+                    best_block_hash,
+                    hash: finalized_block.hash,
+                    pruned_blocks: pruned_blocks.iter().map(|(_, b, _)| b.hash).collect(),
+                };
 
-                                if *finalized_pinned_remaining < count_limit {
-                                    to_remove.push(*subscription_id);
-                                    continue;
-                                }
+                let mut to_remove = Vec::new();
+                for (subscription_id, (sender, finalized_pinned_remaining)) in
+                    all_blocks_subscriptions.iter_mut()
+                {
+                    let count_limit = pruned_blocks.len() + 1;
 
-                                if sender.try_send(all_blocks_notif.clone()).is_err() {
-                                    to_remove.push(*subscription_id);
-                                    continue;
-                                }
+                    if *finalized_pinned_remaining < count_limit {
+                        to_remove.push(*subscription_id);
+                        continue;
+                    }
 
-                                *finalized_pinned_remaining -= count_limit;
+                    if sender.try_send(all_blocks_notif.clone()).is_err() {
+                        to_remove.push(*subscription_id);
+                        continue;
+                    }
 
-                                // Mark the finalized and pruned blocks as finalized or non-canonical.
-                                for block in iter::once(&finalized_block.hash)
-                                    .chain(pruned_blocks.iter().map(|(_, b, _)| &b.hash))
-                                {
-                                    if let Some(pin) =
-                                        pinned_blocks.get_mut(&(*subscription_id, *block))
-                                    {
-                                        debug_assert!(pin.block_ignores_limit);
-                                        pin.block_ignores_limit = false;
-                                    }
-                                }
-                            }
-                            for to_remove in to_remove {
-                                all_blocks_subscriptions.remove(&to_remove);
-                                let pinned_blocks_to_remove = pinned_blocks
-                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                    .map(|((_, h), _)| *h)
-                                    .collect::<Vec<_>>();
-                                for block in pinned_blocks_to_remove {
-                                    pinned_blocks.remove(&(to_remove, block));
-                                }
-                            }
+                    *finalized_pinned_remaining -= count_limit;
 
-                            // There might be other updates.
-                            background.must_update_tree_and_notify_subscribers = true;
-                        }
-                        Some(async_tree::OutputUpdate::Block(block)) => {
-                            let block_index = block.index;
-                            let block_runtime =
-                                tree.block_async_user_data(block_index).unwrap().clone();
-                            let block_hash = tree[block_index].hash;
-                            let scale_encoded_header =
-                                tree[block_index].scale_encoded_header.clone();
-                            let is_new_best = block.is_new_best;
-
-                            let (block_number, state_trie_root_hash) = {
-                                let decoded = header::decode(
-                                    &scale_encoded_header,
-                                    background.sync_service.block_number_bytes(),
-                                )
-                                .unwrap();
-                                (decoded.number, *decoded.state_root)
-                            };
-
-                            let parent_runtime = tree
-                                .parent(block_index)
-                                .map_or(tree.output_finalized_async_user_data().clone(), |idx| {
-                                    tree.block_async_user_data(idx).unwrap().clone()
-                                });
-
-                            log!(
-                                &background.platform,
-                                Debug,
-                                &background.log_target,
-                                "output-chain-new-block",
-                                block_hash = HashDisplay(&tree[block_index].hash),
-                                is_new_best
-                            );
-
-                            let notif = Notification::Block(BlockNotification {
-                                parent_hash: tree
-                                    .parent(block_index)
-                                    .map_or(finalized_block.hash, |idx| tree[idx].hash),
-                                is_new_best,
-                                scale_encoded_header,
-                                new_runtime: if !Arc::ptr_eq(&parent_runtime, &block_runtime) {
-                                    Some(
-                                        block_runtime
-                                            .runtime
-                                            .as_ref()
-                                            .map(|rt| rt.runtime_version().clone())
-                                            .map_err(|err| err.clone()),
-                                    )
-                                } else {
-                                    None
-                                },
-                            });
-
-                            let mut to_remove = Vec::new();
-                            for (subscription_id, (sender, _)) in
-                                all_blocks_subscriptions.iter_mut()
-                            {
-                                if sender.try_send(notif.clone()).is_ok() {
-                                    let _prev_value = pinned_blocks.insert(
-                                        (*subscription_id, block_hash),
-                                        PinnedBlock {
-                                            runtime: block_runtime.clone(),
-                                            state_trie_root_hash,
-                                            block_number,
-                                            block_ignores_limit: true,
-                                        },
-                                    );
-                                    debug_assert!(_prev_value.is_none());
-                                } else {
-                                    to_remove.push(*subscription_id);
-                                }
-                            }
-                            for to_remove in to_remove {
-                                all_blocks_subscriptions.remove(&to_remove);
-                                let pinned_blocks_to_remove = pinned_blocks
-                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                    .map(|((_, h), _)| *h)
-                                    .collect::<Vec<_>>();
-                                for block in pinned_blocks_to_remove {
-                                    pinned_blocks.remove(&(to_remove, block));
-                                }
-                            }
-
-                            // There might be other updates.
-                            background.must_update_tree_and_notify_subscribers = true;
-                        }
-                        Some(async_tree::OutputUpdate::BestBlockChanged { best_block_index }) => {
-                            let hash = best_block_index
-                                .map_or(&*finalized_block, |idx| &tree[idx])
-                                .hash;
-
-                            log!(
-                                &background.platform,
-                                Debug,
-                                &background.log_target,
-                                "output-chain-best-block-update",
-                                block_hash = HashDisplay(&hash),
-                            );
-
-                            let notif = Notification::BestBlockChanged { hash };
-
-                            let mut to_remove = Vec::new();
-                            for (subscription_id, (sender, _)) in
-                                all_blocks_subscriptions.iter_mut()
-                            {
-                                if sender.try_send(notif.clone()).is_err() {
-                                    to_remove.push(*subscription_id);
-                                }
-                            }
-                            for to_remove in to_remove {
-                                all_blocks_subscriptions.remove(&to_remove);
-                                let pinned_blocks_to_remove = pinned_blocks
-                                    .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
-                                    .map(|((_, h), _)| *h)
-                                    .collect::<Vec<_>>();
-                                for block in pinned_blocks_to_remove {
-                                    pinned_blocks.remove(&(to_remove, block));
-                                }
-                            }
-
-                            // There might be other updates.
-                            background.must_update_tree_and_notify_subscribers = true;
-                        }
-                    },
-                    Tree::FinalizedBlockRuntimeUnknown { tree } => {
-                        match tree.try_advance_output() {
-                            None => continue,
-                            Some(async_tree::OutputUpdate::Block(_))
-                            | Some(async_tree::OutputUpdate::BestBlockChanged { .. }) => {
-                                // There might be other updates.
-                                background.must_update_tree_and_notify_subscribers = true;
-                                continue;
-                            }
-                            Some(async_tree::OutputUpdate::Finalized {
-                                user_data: new_finalized,
-                                former_finalized_async_op_user_data,
-                                best_block_index,
-                                ..
-                            }) => {
-                                // Make sure that this is the first finalized block whose runtime is
-                                // known, otherwise there's a pretty big bug somewhere.
-                                debug_assert!(former_finalized_async_op_user_data.is_none());
-
-                                let best_block_hash = best_block_index
-                                    .map_or(new_finalized.hash, |idx| tree[idx].hash);
-                                log!(
-                                    &background.platform,
-                                    Debug,
-                                    &background.log_target,
-                                    "output-chain-initialized",
-                                    finalized_block_hash = HashDisplay(&new_finalized.hash),
-                                    best_block_hash = HashDisplay(&best_block_hash)
-                                );
-
-                                // Substitute `tree` with a dummy empty tree just in order to extract
-                                // the value. The `tree` only contains "async op user datas" equal
-                                // to `Some` (they're inserted manually when a download finishes)
-                                // except for the finalized block which has now just been extracted.
-                                // We can safely unwrap() all these user datas.
-                                let new_tree = mem::replace(
-                                    tree,
-                                    async_tree::AsyncTree::new(async_tree::Config {
-                                        finalized_async_user_data: None,
-                                        retry_after_failed: Duration::new(0, 0),
-                                        blocks_capacity: 0,
-                                    }),
-                                )
-                                .map_async_op_user_data(|runtime_index| runtime_index.unwrap());
-
-                                // Change the state of `Background` to the "finalized runtime known" state.
-                                background.tree = Tree::FinalizedBlockRuntimeKnown {
-                                    all_blocks_subscriptions:
-                                        hashbrown::HashMap::with_capacity_and_hasher(
-                                            32,
-                                            Default::default(),
-                                        ), // TODO: capacity?
-                                    pinned_blocks: BTreeMap::new(),
-                                    tree: new_tree,
-                                    finalized_block: new_finalized,
-                                };
-
-                                // There might be other updates.
-                                background.must_update_tree_and_notify_subscribers = true;
-                            }
+                    // Mark the finalized and pruned blocks as finalized or non-canonical.
+                    for block in iter::once(&finalized_block.hash)
+                        .chain(pruned_blocks.iter().map(|(_, b, _)| &b.hash))
+                    {
+                        if let Some(pin) = pinned_blocks.get_mut(&(*subscription_id, *block)) {
+                            debug_assert!(pin.block_ignores_limit);
+                            pin.block_ignores_limit = false;
                         }
                     }
                 }
+                for to_remove in to_remove {
+                    all_blocks_subscriptions.remove(&to_remove);
+                    let pinned_blocks_to_remove = pinned_blocks
+                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                        .map(|((_, h), _)| *h)
+                        .collect::<Vec<_>>();
+                    for block in pinned_blocks_to_remove {
+                        pinned_blocks.remove(&(to_remove, block));
+                    }
+                }
+
+                // There might be other updates.
+                background.must_update_tree_and_notify_subscribers = true;
+            }
+            WakeUpReason::MustAdvanceTreeFinalizedKnown(async_tree::OutputUpdate::Block(block)) => {
+                let Tree::FinalizedBlockRuntimeKnown {
+                    tree,
+                    finalized_block,
+                    all_blocks_subscriptions,
+                    pinned_blocks,
+                } = &mut background.tree
+                else {
+                    unreachable!()
+                };
+
+                let block_index = block.index;
+                let block_runtime = tree.block_async_user_data(block_index).unwrap().clone();
+                let block_hash = tree[block_index].hash;
+                let scale_encoded_header = tree[block_index].scale_encoded_header.clone();
+                let is_new_best = block.is_new_best;
+
+                let (block_number, state_trie_root_hash) = {
+                    let decoded = header::decode(
+                        &scale_encoded_header,
+                        background.sync_service.block_number_bytes(),
+                    )
+                    .unwrap();
+                    (decoded.number, *decoded.state_root)
+                };
+
+                let parent_runtime = tree
+                    .parent(block_index)
+                    .map_or(tree.output_finalized_async_user_data().clone(), |idx| {
+                        tree.block_async_user_data(idx).unwrap().clone()
+                    });
+
+                log!(
+                    &background.platform,
+                    Debug,
+                    &background.log_target,
+                    "output-chain-new-block",
+                    block_hash = HashDisplay(&tree[block_index].hash),
+                    is_new_best
+                );
+
+                let notif = Notification::Block(BlockNotification {
+                    parent_hash: tree
+                        .parent(block_index)
+                        .map_or(finalized_block.hash, |idx| tree[idx].hash),
+                    is_new_best,
+                    scale_encoded_header,
+                    new_runtime: if !Arc::ptr_eq(&parent_runtime, &block_runtime) {
+                        Some(
+                            block_runtime
+                                .runtime
+                                .as_ref()
+                                .map(|rt| rt.runtime_version().clone())
+                                .map_err(|err| err.clone()),
+                        )
+                    } else {
+                        None
+                    },
+                });
+
+                let mut to_remove = Vec::new();
+                for (subscription_id, (sender, _)) in all_blocks_subscriptions.iter_mut() {
+                    if sender.try_send(notif.clone()).is_ok() {
+                        let _prev_value = pinned_blocks.insert(
+                            (*subscription_id, block_hash),
+                            PinnedBlock {
+                                runtime: block_runtime.clone(),
+                                state_trie_root_hash,
+                                block_number,
+                                block_ignores_limit: true,
+                            },
+                        );
+                        debug_assert!(_prev_value.is_none());
+                    } else {
+                        to_remove.push(*subscription_id);
+                    }
+                }
+                for to_remove in to_remove {
+                    all_blocks_subscriptions.remove(&to_remove);
+                    let pinned_blocks_to_remove = pinned_blocks
+                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                        .map(|((_, h), _)| *h)
+                        .collect::<Vec<_>>();
+                    for block in pinned_blocks_to_remove {
+                        pinned_blocks.remove(&(to_remove, block));
+                    }
+                }
+
+                // There might be other updates.
+                background.must_update_tree_and_notify_subscribers = true;
+            }
+            WakeUpReason::MustAdvanceTreeFinalizedKnown(
+                async_tree::OutputUpdate::BestBlockChanged { best_block_index },
+            ) => {
+                let Tree::FinalizedBlockRuntimeKnown {
+                    tree,
+                    finalized_block,
+                    all_blocks_subscriptions,
+                    pinned_blocks,
+                } = &mut background.tree
+                else {
+                    unreachable!()
+                };
+
+                let hash = best_block_index
+                    .map_or(&*finalized_block, |idx| &tree[idx])
+                    .hash;
+
+                log!(
+                    &background.platform,
+                    Debug,
+                    &background.log_target,
+                    "output-chain-best-block-update",
+                    block_hash = HashDisplay(&hash),
+                );
+
+                let notif = Notification::BestBlockChanged { hash };
+
+                let mut to_remove = Vec::new();
+                for (subscription_id, (sender, _)) in all_blocks_subscriptions.iter_mut() {
+                    if sender.try_send(notif.clone()).is_err() {
+                        to_remove.push(*subscription_id);
+                    }
+                }
+                for to_remove in to_remove {
+                    all_blocks_subscriptions.remove(&to_remove);
+                    let pinned_blocks_to_remove = pinned_blocks
+                        .range((to_remove, [0; 32])..=(to_remove, [0xff; 32]))
+                        .map(|((_, h), _)| *h)
+                        .collect::<Vec<_>>();
+                    for block in pinned_blocks_to_remove {
+                        pinned_blocks.remove(&(to_remove, block));
+                    }
+                }
+
+                // There might be other updates.
+                background.must_update_tree_and_notify_subscribers = true;
+            }
+
+            WakeUpReason::MustAdvanceTreeFinalizedUnknown(async_tree::OutputUpdate::Block(_))
+            | WakeUpReason::MustAdvanceTreeFinalizedUnknown(
+                async_tree::OutputUpdate::BestBlockChanged { .. },
+            ) => {
+                // There might be other updates.
+                background.must_update_tree_and_notify_subscribers = true;
+                continue;
+            }
+            WakeUpReason::MustAdvanceTreeFinalizedUnknown(
+                async_tree::OutputUpdate::Finalized {
+                    user_data: new_finalized,
+                    former_finalized_async_op_user_data,
+                    best_block_index,
+                    ..
+                },
+            ) => {
+                let Tree::FinalizedBlockRuntimeUnknown { tree, .. } = &mut background.tree else {
+                    unreachable!()
+                };
+
+                // Make sure that this is the first finalized block whose runtime is
+                // known, otherwise there's a pretty big bug somewhere.
+                debug_assert!(former_finalized_async_op_user_data.is_none());
+
+                let best_block_hash =
+                    best_block_index.map_or(new_finalized.hash, |idx| tree[idx].hash);
+                log!(
+                    &background.platform,
+                    Debug,
+                    &background.log_target,
+                    "output-chain-initialized",
+                    finalized_block_hash = HashDisplay(&new_finalized.hash),
+                    best_block_hash = HashDisplay(&best_block_hash)
+                );
+
+                // Substitute `tree` with a dummy empty tree just in order to extract
+                // the value. The `tree` only contains "async op user datas" equal
+                // to `Some` (they're inserted manually when a download finishes)
+                // except for the finalized block which has now just been extracted.
+                // We can safely unwrap() all these user datas.
+                let new_tree = mem::replace(
+                    tree,
+                    async_tree::AsyncTree::new(async_tree::Config {
+                        finalized_async_user_data: None,
+                        retry_after_failed: Duration::new(0, 0),
+                        blocks_capacity: 0,
+                    }),
+                )
+                .map_async_op_user_data(|runtime_index| runtime_index.unwrap());
+
+                // Change the state of `Background` to the "finalized runtime known" state.
+                background.tree = Tree::FinalizedBlockRuntimeKnown {
+                    all_blocks_subscriptions: hashbrown::HashMap::with_capacity_and_hasher(
+                        32,
+                        Default::default(),
+                    ), // TODO: capacity?
+                    pinned_blocks: BTreeMap::new(),
+                    tree: new_tree,
+                    finalized_block: new_finalized,
+                };
+
+                // There might be other updates.
+                background.must_update_tree_and_notify_subscribers = true;
             }
 
             WakeUpReason::MustSubscribe => {

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1156,9 +1156,11 @@ async fn run_background<TPlat: PlatformRef>(
                         }
                         Some(async_tree::OutputUpdate::Block(block)) => {
                             let block_index = block.index;
-                            let block_runtime = block.async_op_user_data.clone();
-                            let block_hash = block.user_data.hash;
-                            let scale_encoded_header = block.user_data.scale_encoded_header.clone();
+                            let block_runtime =
+                                tree.block_async_user_data(block_index).unwrap().clone();
+                            let block_hash = tree[block_index].hash;
+                            let scale_encoded_header =
+                                tree[block_index].scale_encoded_header.clone();
                             let is_new_best = block.is_new_best;
 
                             let (block_number, state_trie_root_hash) = {

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -908,7 +908,7 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                         .async_tree
                         .async_op_finished(async_op_id, Some(parahead))
                     {
-                        let hash = runtime_subscription.async_tree.block_user_data(block);
+                        let hash = &runtime_subscription.async_tree[block];
                         runtime_subscription
                             .relay_chain_subscribe_all
                             .unpin_block(*hash)

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -565,11 +565,15 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                 // `block` borrows `async_tree`. We need to mutably access `async_tree`
                                 // below, so deconstruct `block` beforehand.
                                 let is_new_best = block.is_new_best;
-                                let scale_encoded_header: Vec<u8> =
-                                    block.async_op_user_data.clone().unwrap();
+                                let block_index = block.index;
+                                let scale_encoded_header: Vec<u8> = runtime_subscription
+                                    .async_tree
+                                    .block_async_user_data(block.index)
+                                    .unwrap()
+                                    .clone()
+                                    .unwrap();
                                 let parahash =
                                     header::hash_from_scale_encoded_header(&scale_encoded_header);
-                                let block_index = block.index;
 
                                 // Do not report anything to subscriptions if no finalized parahead is
                                 // known yet.

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -411,11 +411,17 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
 
                         match update {
                             async_tree::OutputUpdate::Finalized {
-                                async_op_user_data: new_finalized_parahead,
                                 former_finalized_async_op_user_data: former_finalized_parahead,
                                 pruned_blocks,
                                 ..
-                            } if *new_finalized_parahead != former_finalized_parahead => {
+                            } if *runtime_subscription
+                                .async_tree
+                                .output_finalized_async_user_data()
+                                != former_finalized_parahead =>
+                            {
+                                let new_finalized_parahead = runtime_subscription
+                                    .async_tree
+                                    .output_finalized_async_user_data();
                                 debug_assert!(new_finalized_parahead.is_some());
 
                                 // If this is the first time a finalized parahead is known, any

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -739,14 +739,15 @@ impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
                                 Debug,
                                 &self.log_target,
                                 "parahead-fetch-operation-started",
-                                relay_block_hash = HashDisplay(op.block_user_data),
+                                relay_block_hash =
+                                    HashDisplay(&runtime_subscription.async_tree[op.block_index]),
                             );
 
                             runtime_subscription.in_progress_paraheads.push({
                                 let relay_chain_sync = self.relay_chain_sync.clone();
                                 let subscription_id =
                                     runtime_subscription.relay_chain_subscribe_all.id();
-                                let block_hash = *op.block_user_data;
+                                let block_hash = runtime_subscription.async_tree[op.block_index];
                                 let async_op_id = op.id;
                                 let parachain_id = self.parachain_id;
                                 Box::pin(async move {


### PR DESCRIPTION
This PR removes the lifetimes from the structs returned by the `AsyncTree`, making it more flexible to use.
As such, we can simplify the `runtime_service` code a bit by flattening match block variants.