### PR TITLE
Perform chain initialization in a background task

### DIFF
--- a/wasm-node/javascript/src/internals/local-instance.ts
+++ b/wasm-node/javascript/src/internals/local-instance.ts
@@ -55,8 +55,9 @@ export interface Config {
 }
 
 export type Event =
-    { ty: "add-chain-result", success: true, chainId: number } |
-    { ty: "add-chain-result", success: false, error: string } |
+    { ty: "add-chain-id-allocated", chainId: number } |
+    { ty: "add-chain-result", chainId: number, success: true } |
+    { ty: "add-chain-result", chainId: number, success: false, error: string } |
     { ty: "log", level: number, target: string, message: string } |
     { ty: "json-rpc-responses-non-empty", chainId: number } |
     // Smoldot has crashed. Note that the public API of the instance can technically still be
@@ -80,6 +81,15 @@ export type ParsedMultiaddr =
 export interface Instance {
     request: (request: string, chainId: number) => number,
     peekJsonRpcResponse: (chainId: number) => string | null,
+    /**
+     * Later generates a `add-chain-id-allocated` event.
+     * If this function is called multiple times, the `add-chain-id-allocated` events are generated
+     * in the same order as the function calls.
+     *
+     * Then, later and asynchronously, a `add-chain-result` event is generated in order to
+     * indicate whether the initialization was actually successful. If `success` is `false`, then
+     * the `chainId` becomes unallocated.
+     */
     addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number) => void,
     removeChain: (chainId: number) => void,
     /**
@@ -502,7 +512,8 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
 
         addChain: (chainSpec: string, databaseContent: string, potentialRelayChains: number[], disableJsonRpc: boolean, jsonRpcMaxPendingRequests: number, jsonRpcMaxSubscriptions: number) => {
             if (!state.instance) {
-                eventCallback({ ty: "add-chain-result", success: false, error: "Smoldot has crashed" });
+                eventCallback({ ty: "add-chain-id-allocated", chainId: 0 });
+                eventCallback({ ty: "add-chain-result", chainId: 0, success: false, error: "Smoldot has crashed" });
                 return;
             }
 
@@ -528,14 +539,16 @@ export async function startLocalInstance(config: Config, wasmModule: WebAssembly
             delete state.bufferIndices[1]
             delete state.bufferIndices[2]
 
+            eventCallback({ ty: "add-chain-id-allocated", chainId });
+
             if (state.instance.exports.chain_is_ok(chainId) != 0) {
-                eventCallback({ ty: "add-chain-result", success: true, chainId });
+                eventCallback({ ty: "add-chain-result", chainId, success: true });
             } else {
                 const errorMsgLen = state.instance.exports.chain_error_len(chainId) >>> 0;
                 const errorMsgPtr = state.instance.exports.chain_error_ptr(chainId) >>> 0;
                 const errorMsg = buffer.utf8BytesToString(new Uint8Array(state.instance.exports.memory.buffer), errorMsgPtr, errorMsgLen);
                 state.instance.exports.remove_chain(chainId);
-                eventCallback({ ty: "add-chain-result", success: false, error: errorMsg });
+                eventCallback({ ty: "add-chain-result", chainId, success: false, error: errorMsg });
             }
         },
 

--- a/wasm-node/rust/src/bindings.rs
+++ b/wasm-node/rust/src/bindings.rs
@@ -83,6 +83,13 @@ extern "C" {
     /// behave like `abort` and prevent any further execution.
     pub fn panic(message_ptr: u32, message_len: u32);
 
+    /// Called in response to [`add_chain`] once the initialization of the chain is complete.
+    ///
+    /// If `error_msg_ptr` is equal to 0, then the chain initialization is successful. Otherwise,
+    /// `error_msg_ptr` and `error_msg_len` designate a buffer in the memory of the WebAssembly
+    /// virtual machine where a UTF-8 diagnostic error message can be found.
+    pub fn chain_initialized(chain_id: u32, error_msg_ptr: u32, error_msg_len: u32);
+
     /// Fills the buffer of the WebAssembly virtual machine with random data, starting at `ptr`
     /// and for `len` bytes.
     ///
@@ -365,11 +372,11 @@ pub extern "C" fn advance_execution() {
 /// If `json_rpc_max_pending_requests` is 0, then the value of `json_rpc_max_subscriptions` is
 /// ignored.
 ///
-/// If an error happens during the creation of the chain, a chain id will be allocated
-/// nonetheless, and must later be de-allocated by calling [`remove_chain`]. This allocated chain,
-/// however, will be in an erroneous state. Use [`chain_is_ok`] to determine whether this function
-/// was successful. If not, use [`chain_error_len`] and [`chain_error_ptr`] to obtain the error
-/// message.
+/// Calling this function allocates a chain id and starts the chain initialization in the
+/// background. Once the initialization is complete, the [`chain_initialized`] function will be
+/// called by smoldot.
+/// It is possible to call [`remove_chain`] while the initialization is still in progress in
+/// order to cancel it.
 #[no_mangle]
 pub extern "C" fn add_chain(
     chain_spec_buffer_index: u32,
@@ -390,40 +397,10 @@ pub extern "C" fn add_chain(
 /// Removes a chain previously added using [`add_chain`]. Instantly unsubscribes all the JSON-RPC
 /// subscriptions and cancels all in-progress requests corresponding to that chain.
 ///
-/// If the removed chain was an erroneous chain, calling this function will invalidate the pointer
-/// returned by [`chain_error_ptr`].
+/// Can be called on a chain which hasn't finished initializing yet.
 #[no_mangle]
 pub extern "C" fn remove_chain(chain_id: u32) {
     super::remove_chain(chain_id);
-}
-
-/// Returns `1` if creating this chain was successful. Otherwise, returns `0`.
-///
-/// If `0` is returned, use [`chain_error_len`] and [`chain_error_ptr`] to obtain an error
-/// message.
-#[no_mangle]
-pub extern "C" fn chain_is_ok(chain_id: u32) -> u32 {
-    super::chain_is_ok(chain_id)
-}
-
-/// Returns the length of the error message stored for this chain.
-///
-/// Must only be called on an erroneous chain. Use [`chain_is_ok`] to determine whether a chain is
-/// in an erroneous state. Returns `0` if the chain isn't erroneous.
-#[no_mangle]
-pub extern "C" fn chain_error_len(chain_id: u32) -> u32 {
-    super::chain_error_len(chain_id)
-}
-
-/// Returns a pointer to the error message stored for this chain. The error message is a UTF-8
-/// string starting at the memory offset returned by this function, and whose length can be
-/// determined by calling [`chain_error_len`].
-///
-/// Must only be called on an erroneous chain. Use [`chain_is_ok`] to determine whether a chain is
-/// in an erroneous state. Returns `0` if the chain isn't erroneous.
-#[no_mangle]
-pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
-    super::chain_error_ptr(chain_id)
 }
 
 /// Emit a JSON-RPC request or notification towards the given chain previously added using
@@ -444,8 +421,8 @@ pub extern "C" fn chain_error_ptr(chain_id: u32) -> u32 {
 /// Responses and notifications are notified using [`json_rpc_responses_non_empty`], and can
 /// be read with [`json_rpc_responses_peek`].
 ///
-/// It is forbidden to call this function on an erroneous chain or a chain that was created with
-/// `json_rpc_running` equal to 0.
+/// It is forbidden to call this function on a chain which hasn't finished initializing yet or a
+/// chain that was created with `json_rpc_running` equal to 0.
 ///
 /// This function returns:
 /// - 0 on success.
@@ -492,8 +469,8 @@ pub struct JsonRpcResponseInfo {
 /// Calling this function invalidates the pointer previously returned by a call to
 /// [`json_rpc_responses_peek`] with the same `chain_id`.
 ///
-/// It is forbidden to call this function on an erroneous chain or a chain that was created with
-/// `json_rpc_running` equal to 0.
+/// It is forbidden to call this function on a chain that hasn't finished initializing yet, or a
+/// chain that was created with `json_rpc_running` equal to 0.
 #[no_mangle]
 pub extern "C" fn json_rpc_responses_pop(chain_id: u32) {
     super::json_rpc_responses_pop(chain_id);

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -49,9 +49,7 @@ pub(crate) enum Chain {
         /// register doesn't get cleaned up.
         json_rpc_responses_rx: Option<stream::BoxStream<'static, String>>,
     },
-    Erroneous {
-        error: String,
-    },
+    Erroneous,
 }
 
 pub(crate) fn init(max_log_level: u32) {

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -31,7 +31,8 @@ pub(crate) struct Client<TPlat: smoldot_light::platform::PlatformRef, TChain> {
 }
 
 pub(crate) enum Chain {
-    Healthy {
+    Initializing,
+    Created {
         smoldot_chain_id: smoldot_light::ChainId,
 
         /// JSON-RPC responses that is at the front of the queue according to the API. If `Some`,
@@ -49,7 +50,6 @@ pub(crate) enum Chain {
         /// register doesn't get cleaned up.
         json_rpc_responses_rx: Option<stream::BoxStream<'static, String>>,
     },
-    Erroneous,
 }
 
 pub(crate) fn init(max_log_level: u32) {

--- a/wasm-node/rust/src/init.rs
+++ b/wasm-node/rust/src/init.rs
@@ -37,9 +37,9 @@ pub(crate) enum Chain {
 
         /// JSON-RPC responses that is at the front of the queue according to the API. If `Some`,
         /// a pointer to the string is referenced to within
-        /// [`Chain::Healthy::json_rpc_response_info`].
+        /// [`Chain::Created::json_rpc_response_info`].
         json_rpc_response: Option<String>,
-        /// Information about [`Chain::Healthy::json_rpc_response`]. A pointer to this struct is
+        /// Information about [`Chain::Created::json_rpc_response`]. A pointer to this struct is
         /// sent over the FFI layer to the JavaScript. As such, the pointer must never be
         /// invalidated.
         json_rpc_response_info: Box<bindings::JsonRpcResponseInfo>,

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -25,6 +25,7 @@ extern crate alloc;
 
 use alloc::{
     boxed::Box,
+    format,
     string::{String, ToString as _},
     sync::Arc,
     vec::Vec,
@@ -59,37 +60,15 @@ fn add_chain(
 ) -> u32 {
     let mut client_lock = CLIENT.try_lock().unwrap();
 
-    // Fail any new chain initialization if we're running low on memory space, which can
-    // realistically happen as Wasm is a 32 bits platform. This avoids potentially running into
-    // OOM errors. The threshold is completely empirical and should probably be updated
-    // regularly to account for changes in the implementation.
-    if allocator::total_alloc_bytes() >= usize::max_value() - 400 * 1024 * 1024 {
-        let outer_chain_id = client_lock.chains.insert(init::Chain::Erroneous);
-        let outer_chain_id_u32 = u32::try_from(outer_chain_id).unwrap();
-
-        // TODO: entry is never cleared from list of chains
-        platform::PLATFORM_REF.spawn_task("client-status-report".into(), async move {
-            unsafe {
-                let error = "Wasm node is running low on memory and will prevent any new chain from being added";
-                bindings::chain_initialized(
-                    outer_chain_id_u32,
-                    u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
-                    u32::try_from(error.as_bytes().len()).unwrap(),
-                );
-            }
-        });
-
-        return outer_chain_id_u32;
-    }
-
     // Retrieve the potential relay chains parameter passed through the FFI layer.
+    // TODO: this is kind of racy, as the API user could remove the relay chain while adding a parachain; it would be stupid to do that so this issue is low priority, and this code will likely change again in the future so it's not worth solving immediately
     let potential_relay_chains: Vec<_> = {
         assert_eq!(potential_relay_chains.len() % 4, 0);
         potential_relay_chains
             .chunks(4)
             .map(|c| u32::from_le_bytes(<[u8; 4]>::try_from(c).unwrap()))
             .filter_map(|c| {
-                if let Some(init::Chain::Healthy {
+                if let Some(init::Chain::Created {
                     smoldot_chain_id, ..
                 }) = client_lock.chains.get(usize::try_from(c).ok()?)
                 {
@@ -101,86 +80,112 @@ fn add_chain(
             .collect()
     };
 
-    // Insert the chain in the client.
-    let smoldot_light::AddChainSuccess {
-        chain_id: smoldot_chain_id,
-        json_rpc_responses,
-    } = match client_lock
-        .smoldot
-        .add_chain(smoldot_light::AddChainConfig {
-            user_data: (),
-            specification: str::from_utf8(&chain_spec)
-                .unwrap_or_else(|_| panic!("non-utf8 chain spec")),
-            database_content: str::from_utf8(&database_content)
-                .unwrap_or_else(|_| panic!("non-utf8 database content")),
-            json_rpc: if let Some(json_rpc_max_pending_requests) =
-                NonZeroU32::new(json_rpc_max_pending_requests)
-            {
-                smoldot_light::AddChainConfigJsonRpc::Enabled {
-                    max_pending_requests: json_rpc_max_pending_requests,
-                    // Note: the PolkadotJS UI is very heavy in terms of subscriptions.
-                    max_subscriptions: json_rpc_max_subscriptions,
-                }
-            } else {
-                smoldot_light::AddChainConfigJsonRpc::Disabled
-            },
-            potential_relay_chains: potential_relay_chains.into_iter(),
-        }) {
-        Ok(c) => c,
-        Err(error) => {
-            let outer_chain_id = client_lock.chains.insert(init::Chain::Erroneous);
-            let outer_chain_id_u32 = u32::try_from(outer_chain_id).unwrap();
+    // This function only allocates a "chain id", then spawns a task that performs the actual
+    // chain creation in the background.
+    // This makes it possible to measure the CPU usage of chain creation the same way as the CPU
+    // is measured for all other background tasks.
+    // It also makes it possible in the future to make chain creation asynchronous in the
+    // `light-base` crate, which will make it possible to periodically yield and avoid using too
+    // much CPU at once.
+    // TODO: act on that last sentence ^
+    let outer_chain_id = client_lock.chains.insert(init::Chain::Initializing);
+    let outer_chain_id_u32 = u32::try_from(outer_chain_id).unwrap();
 
-            // TODO: entry is never cleared from list of chains
-            platform::PLATFORM_REF.spawn_task("client-status-report".into(), async move {
+    platform::PLATFORM_REF.spawn_task(
+        format!("add-chain-{outer_chain_id_u32}").into(),
+        async move {
+            let mut client_lock = CLIENT.try_lock().unwrap();
+
+            // Fail any new chain initialization if we're running low on memory space, which can
+            // realistically happen as Wasm is a 32 bits platform. This avoids potentially running
+            // into OOM errors. The threshold is completely empirical and should probably be
+            // updated regularly to account for changes in the implementation.
+            if allocator::total_alloc_bytes() >= usize::max_value() - 400 * 1024 * 1024 {
+                client_lock.chains.remove(outer_chain_id);
                 unsafe {
-                    let error = error.to_string();
+                    let error = "Wasm node is running low on memory and will prevent any new chain from being added";
                     bindings::chain_initialized(
                         outer_chain_id_u32,
                         u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
                         u32::try_from(error.as_bytes().len()).unwrap(),
                     );
                 }
+                return;
+            }
+
+            // Insert the chain in the client.
+            let smoldot_light::AddChainSuccess {
+                chain_id: smoldot_chain_id,
+                json_rpc_responses,
+            } = match client_lock
+                .smoldot
+                .add_chain(smoldot_light::AddChainConfig {
+                    user_data: (),
+                    specification: str::from_utf8(&chain_spec)
+                        .unwrap_or_else(|_| panic!("non-utf8 chain spec")),
+                    database_content: str::from_utf8(&database_content)
+                        .unwrap_or_else(|_| panic!("non-utf8 database content")),
+                    json_rpc: if let Some(json_rpc_max_pending_requests) =
+                        NonZeroU32::new(json_rpc_max_pending_requests)
+                    {
+                        smoldot_light::AddChainConfigJsonRpc::Enabled {
+                            max_pending_requests: json_rpc_max_pending_requests,
+                            // Note: the PolkadotJS UI is very heavy in terms of subscriptions.
+                            max_subscriptions: json_rpc_max_subscriptions,
+                        }
+                    } else {
+                        smoldot_light::AddChainConfigJsonRpc::Disabled
+                    },
+                    potential_relay_chains: potential_relay_chains.into_iter(),
+                }) {
+                Ok(c) => c,
+                Err(error) => {
+                    client_lock.chains.remove(outer_chain_id);
+                    unsafe {
+                        let error = error.to_string();
+                        bindings::chain_initialized(
+                            outer_chain_id_u32,
+                            u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
+                            u32::try_from(error.as_bytes().len()).unwrap(),
+                        );
+                    }
+                    return;
+                }
+            };
+
+            client_lock.chains[outer_chain_id] = init::Chain::Created {
+                smoldot_chain_id,
+                json_rpc_response: None,
+                json_rpc_response_info: Box::new(bindings::JsonRpcResponseInfo { ptr: 0, len: 0 }),
+                json_rpc_responses_rx: None,
+            };
+
+            // We wrap the JSON-RPC responses stream into a proper stream in order to be able to
+            // guarantee that `poll_next()` always operates on the same future.
+            let json_rpc_responses = json_rpc_responses.map(|json_rpc_responses| {
+                stream::unfold(json_rpc_responses, |mut json_rpc_responses| async {
+                    // The stream ends when we remove the chain. Once the chain is removed, the user
+                    // cannot poll the stream anymore. Therefore it is safe to unwrap the result here.
+                    let msg = json_rpc_responses.next().await.unwrap();
+                    Some((msg, json_rpc_responses))
+                })
+                .boxed()
             });
 
-            return outer_chain_id_u32;
-        }
-    };
+            if let init::Chain::Created {
+                json_rpc_responses_rx,
+                ..
+            } = client_lock.chains.get_mut(outer_chain_id).unwrap()
+            {
+                *json_rpc_responses_rx = json_rpc_responses;
+            }
 
-    let outer_chain_id = client_lock.chains.insert(init::Chain::Healthy {
-        smoldot_chain_id,
-        json_rpc_response: None,
-        json_rpc_response_info: Box::new(bindings::JsonRpcResponseInfo { ptr: 0, len: 0 }),
-        json_rpc_responses_rx: None,
-    });
+            unsafe {
+                bindings::chain_initialized(outer_chain_id_u32, 0, 0);
+            }
 
-    let outer_chain_id_u32 = u32::try_from(outer_chain_id).unwrap();
-
-    platform::PLATFORM_REF.spawn_task("client-status-report".into(), async move {
-        unsafe {
-            bindings::chain_initialized(outer_chain_id_u32, 0, 0);
-        }
-    });
-
-    // We wrap the JSON-RPC responses stream into a proper stream in order to be able to guarantee
-    // that `poll_next()` always operates on the same future.
-    let json_rpc_responses = json_rpc_responses.map(|json_rpc_responses| {
-        stream::unfold(json_rpc_responses, |mut json_rpc_responses| async {
-            // The stream ends when we remove the chain. Once the chain is removed, the user
-            // cannot poll the stream anymore. Therefore it is safe to unwrap the result here.
-            let msg = json_rpc_responses.next().await.unwrap();
-            Some((msg, json_rpc_responses))
-        })
-        .boxed()
-    });
-
-    if let init::Chain::Healthy {
-        json_rpc_responses_rx,
-        ..
-    } = client_lock.chains.get_mut(outer_chain_id).unwrap()
-    {
-        *json_rpc_responses_rx = json_rpc_responses;
-    }
+        },
+    );
 
     outer_chain_id_u32
 }
@@ -192,7 +197,7 @@ fn remove_chain(chain_id: u32) {
         .chains
         .remove(usize::try_from(chain_id).unwrap())
     {
-        init::Chain::Healthy {
+        init::Chain::Created {
             smoldot_chain_id,
             json_rpc_responses_rx,
             ..
@@ -210,7 +215,7 @@ fn remove_chain(chain_id: u32) {
 
             let () = client_lock.smoldot.remove_chain(smoldot_chain_id);
         }
-        init::Chain::Erroneous { .. } => {}
+        init::Chain::Initializing => {} // TODO: /!\
     }
 }
 
@@ -225,10 +230,10 @@ fn json_rpc_send(json_rpc_request: Vec<u8>, chain_id: u32) -> u32 {
         .get(usize::try_from(chain_id).unwrap())
         .unwrap()
     {
-        init::Chain::Healthy {
+        init::Chain::Created {
             smoldot_chain_id, ..
         } => *smoldot_chain_id,
-        init::Chain::Erroneous { .. } => panic!(),
+        init::Chain::Initializing => panic!(), // Forbidden.
     };
 
     match client_lock
@@ -247,7 +252,7 @@ fn json_rpc_responses_peek(chain_id: u32) -> u32 {
         .get_mut(usize::try_from(chain_id).unwrap())
         .unwrap()
     {
-        init::Chain::Healthy {
+        init::Chain::Created {
             json_rpc_response,
             json_rpc_responses_rx,
             json_rpc_response_info,
@@ -313,10 +318,10 @@ fn json_rpc_responses_pop(chain_id: u32) {
         .get_mut(usize::try_from(chain_id).unwrap())
         .unwrap()
     {
-        init::Chain::Healthy {
+        init::Chain::Created {
             json_rpc_response, ..
         } => *json_rpc_response = None,
-        _ => panic!(),
+        init::Chain::Initializing => panic!(), // Forbidden.
     }
 }
 


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/735

This PR modifies the bindings between the Wasm and the JavaScript in order to make the operation of adding a chain asynchronous.
When `add_chain` is called, an identifier is immediately returned, but the chain initialization is performed in the background, and a callback is called once this initialization has finished (successfully or not).
There is no change to the public API.

This is the first step for https://github.com/smol-dot/smoldot/issues/735, and unlocks https://github.com/smol-dot/smoldot/pull/931.
