### PR TITLE
Always verify blocks before justifications

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix "Justification targets block not in the chain" errors, leading to peers being erroneously banned.
+
 ## 2.0.19 - 2024-01-26
 
 ### Fixed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix "Justification targets block not in the chain" errors, leading to peers being erroneously banned.
+- Fix "Justification targets block not in the chain" errors, leading to peers being erroneously banned. ([#1618](https://github.com/smol-dot/smoldot/pull/1618))
 
 ## 2.0.19 - 2024-01-26
 


### PR DESCRIPTION
This is a bugfix for "Justifications target blocks not in the chain".
It is a suboptimal bugfix, because verifying blocks first means that we might use more memory than strictly needed.
However, I'm not confident in my ability to fix this properly without tests, and so tests should be written first.