### PR TITLE
Properly provide finalized block number after warp sync

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -953,7 +953,10 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     }
                 };
 
-                // TODO: also provide finality information
+                new_all_forks.update_source_finality_state(
+                    new_inner_source_id,
+                    warp_sync.source_finality_state(warp_sync_source_id),
+                );
 
                 self.shared.sources[outer_source_id.0].all_forks = new_inner_source_id;
             }

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -201,8 +201,8 @@ struct Source<TSrc> {
     /// source isn't malicious, we will able to make *some* progress in the finality.
     unverified_finality_proofs: SourcePendingJustificationProofs,
 
-    /// Height of the highest finalized block according to that source. `None` if unknown.
-    finalized_block_number: Option<u64>,
+    /// Height of the highest finalized block according to that source. `0` if unknown.
+    finalized_block_number: u64,
 
     /// Similar to [`Source::unverified_finality_proofs`]. Contains proofs that have been checked
     /// and have been determined to not be verifiable right now.
@@ -719,9 +719,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                             // We assume that all sources have the same finalized blocks and thus
                             // don't check hashes.
                             self.inner.blocks[*s].unverified_finality_proofs.is_none()
-                                && self.inner.blocks[*s]
-                                    .finalized_block_number
-                                    .map_or(false, |n| n >= block_height)
+                                && self.inner.blocks[*s].finalized_block_number >= block_height
                         })
                         .map(move |source_id| {
                             (
@@ -949,13 +947,8 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         finalized_block_height: u64,
     ) {
         let source = &mut self.inner.blocks[source_id];
-        source.finalized_block_number = Some(
-            source
-                .finalized_block_number
-                .map_or(finalized_block_height, |b| {
-                    cmp::max(b, finalized_block_height)
-                }),
-        );
+        source.finalized_block_number =
+            cmp::max(source.finalized_block_number, finalized_block_height);
     }
 
     /// Update the state machine with a Grandpa commit message received from the network.
@@ -984,11 +977,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
         // The finalized block number of the source is increased even if the commit message
         // isn't known to be valid yet.
-        source.finalized_block_number = Some(
-            source
-                .finalized_block_number
-                .map_or(block_number, |b| cmp::max(b, block_number)),
-        );
+        source.finalized_block_number = cmp::max(source.finalized_block_number, block_number);
 
         source.unverified_finality_proofs.insert(
             block_number,
@@ -1802,7 +1791,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceOldBlock<'a, TBl, TRq, TSrc> {
             Source {
                 user_data: source_user_data,
                 unverified_finality_proofs: SourcePendingJustificationProofs::None,
-                finalized_block_number: None,
+                finalized_block_number: 0,
                 pending_finality_proofs: SourcePendingJustificationProofs::None,
             },
             self.best_block_number,
@@ -1849,7 +1838,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceKnown<'a, TBl, TRq, TSrc> {
             Source {
                 user_data: source_user_data,
                 unverified_finality_proofs: SourcePendingJustificationProofs::None,
-                finalized_block_number: None,
+                finalized_block_number: 0,
                 pending_finality_proofs: SourcePendingJustificationProofs::None,
             },
             self.best_block_number,
@@ -1885,7 +1874,7 @@ impl<'a, TBl, TRq, TSrc> AddSourceUnknown<'a, TBl, TRq, TSrc> {
             Source {
                 user_data: source_user_data,
                 unverified_finality_proofs: SourcePendingJustificationProofs::None,
-                finalized_block_number: None,
+                finalized_block_number: 0,
                 pending_finality_proofs: SourcePendingJustificationProofs::None,
             },
             self.best_block_number,

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -748,6 +748,18 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
         *stored_height = finalized_block_height;
     }
 
+    /// Gets the finalized block height of the given source.
+    ///
+    /// Equal to 0 if [`WarpSync::set_source_finality_state`] hasn't been called.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `source_id` is invalid.
+    ///
+    pub fn source_finality_state(&self, source_id: SourceId) -> u64 {
+        self.sources[source_id.0].finalized_block_height
+    }
+
     /// Returns a list of requests that should be started in order to drive the warp syncing
     /// process to completion.
     ///


### PR DESCRIPTION
Fixes a TODO

I don't know whether this fixes any bug, but it's more correct to do it this way.