### PR TITLE
Yield at every loop in every service

### DIFF
--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -243,6 +243,9 @@ pub(super) fn start<TPlat: PlatformRef>(
                 let rx = rx.clone();
                 async move {
                     loop {
+                        // Yield at every loop in order to provide better tasks granularity.
+                        futures_lite::future::yield_now().await;
+
                         match rx.recv().await {
                             Ok(either::Left(request_process)) => {
                                 me.handle_request(request_process).await;

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -173,6 +173,9 @@ pub(super) fn start<TPlat: PlatformRef>(
             let me = me.clone();
             async move {
                 loop {
+                    // Yield at every loop in order to provide better tasks granularity.
+                    futures_lite::future::yield_now().await;
+
                     match requests_processing_task.run_until_event().await {
                         service::Event::HandleRequest {
                             task,

--- a/light-base/src/json_rpc_service/background/chain_head.rs
+++ b/light-base/src/json_rpc_service/background/chain_head.rs
@@ -555,6 +555,9 @@ impl<TPlat: PlatformRef> ChainHeadFollowTask<TPlat> {
         mut messages_rx: service::DeliverReceiver<service::RequestProcess>,
     ) {
         loop {
+            // Yield at every loop in order to provide better tasks granularity.
+            futures_lite::future::yield_now().await;
+
             enum WakeUpReason {
                 SubscriptionDead,
                 NotificationWithRuntime(runtime_service::Notification),

--- a/light-base/src/json_rpc_service/background/legacy_state_sub.rs
+++ b/light-base/src/json_rpc_service/background/legacy_state_sub.rs
@@ -593,6 +593,9 @@ async fn run<TPlat: PlatformRef>(mut task: Task<TPlat>) {
             }
         }
 
+        // Yield at every loop in order to provide better tasks granularity.
+        futures_lite::future::yield_now().await;
+
         enum WakeUpReason<'a, TPlat: PlatformRef> {
             SubscriptionNotification {
                 notification: runtime_service::Notification,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -871,6 +871,9 @@ struct OpenGossipLinkState {
 
 async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
     loop {
+        // Yield at every loop in order to provide better tasks granularity.
+        futures_lite::future::yield_now().await;
+
         enum WakeUpReason<TPlat: PlatformRef> {
             ForegroundClosed,
             Message(ToBackground<TPlat>),

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -53,6 +53,9 @@ pub(super) async fn single_stream_connection_task<TPlat: PlatformRef>(
     let mut connection_task = Some(connection_task);
 
     loop {
+        // Yield at every loop in order to provide better tasks granularity.
+        futures_lite::future::yield_now().await;
+
         // Because only one message should be sent to the coordinator at a time, and that
         // processing the socket might generate a message, we only process the socket if no
         // message is currently being sent.

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -823,6 +823,9 @@ async fn run_background<TPlat: PlatformRef>(
 
     // Inner loop. Process incoming events.
     'background_main_loop: loop {
+        // Yield at every loop in order to provide better tasks granularity.
+        futures_lite::future::yield_now().await;
+
         enum WakeUpReason<TPlat: PlatformRef> {
             MustSubscribe,
             StartDownload(async_tree::AsyncOpId, async_tree::NodeIndex),

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -206,6 +206,9 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: PlatformRef> {
 impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {
     async fn run(mut self) {
         loop {
+            // Yield at every loop in order to provide better tasks granularity.
+            futures_lite::future::yield_now().await;
+
             // Wait until something interesting happens.
             enum WakeUpReason<TPlat: PlatformRef> {
                 ForegroundClosed,

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -769,6 +769,9 @@ async fn background_task<TPlat: PlatformRef>(
                 }
             }
 
+            // Yield at every loop in order to provide better tasks granularity.
+            futures_lite::future::yield_now().await;
+
             enum WakeUpReason {
                 Notification(Option<runtime_service::Notification>),
                 BlockDownloadFinished([u8; 32], Result<Vec<Vec<u8>>, ()>),


### PR DESCRIPTION
This should help avoid the CPU being blocked on an individual task for too long.