### PR TITLE
Remove `ascending` field from block requests

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1502,7 +1502,6 @@ impl SyncBackground {
                         all::DesiredRequest::BlocksRequest {
                             first_block_hash,
                             first_block_height,
-                            ascending,
                             num_blocks,
                             request_headers,
                             request_bodies,
@@ -1536,11 +1535,9 @@ impl SyncBackground {
                                 u32::try_from(num_blocks.get()).unwrap_or(u32::max_value()),
                             )
                             .unwrap(),
-                            direction: if ascending {
-                                network::codec::BlocksRequestDirection::Ascending
-                            } else {
-                                network::codec::BlocksRequestDirection::Descending
-                            },
+                            // The direction is hardcoded based on the documentation of the syncing
+                            // state machine.
+                            direction: network::codec::BlocksRequestDirection::Descending,
                             fields: network::codec::BlocksRequestFields {
                                 header: true, // TODO: always set to true due to unwrapping the header when the response comes
                                 body: request_bodies,
@@ -1554,7 +1551,6 @@ impl SyncBackground {
                         all::DesiredRequest::BlocksRequest {
                             first_block_hash,
                             first_block_height,
-                            ascending,
                             num_blocks,
                             request_headers,
                             request_bodies,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -626,7 +626,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                 all::DesiredRequest::BlocksRequest {
                     first_block_hash,
                     first_block_height,
-                    ascending,
                     num_blocks,
                     request_headers,
                     request_bodies,
@@ -654,11 +653,9 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                             u32::try_from(num_blocks.get()).unwrap_or(u32::max_value()),
                         )
                         .unwrap(),
-                        direction: if ascending {
-                            network::codec::BlocksRequestDirection::Ascending
-                        } else {
-                            network::codec::BlocksRequestDirection::Descending
-                        },
+                        // The direction is hardcoded based on the documentation of the syncing
+                        // state machine.
+                        direction: network::codec::BlocksRequestDirection::Descending,
                         fields: network::codec::BlocksRequestFields {
                             header: request_headers,
                             body: request_bodies,
@@ -674,7 +671,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                     all::RequestDetail::BlocksRequest {
                         first_block_hash,
                         first_block_height,
-                        ascending,
                         num_blocks,
                         request_headers,
                         request_bodies,


### PR DESCRIPTION
After https://github.com/smol-dot/smoldot/issues/1409, the `ascending` field has always been hardcoded to `false`.
This PR removes this field altogether and mentions in the documentation how the blocks should be provided.
