### PR TITLE
Revert wasmi to v0.31 again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,12 +1550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multi-stash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
-
-[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,17 +1591,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -2725,13 +2708,10 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.32.0-beta.5"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b962e531cc387ce15b1da00f06f727f9a9063619e74d1499c3e443d940378b0"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
 dependencies = [
- "multi-stash",
- "num-derive",
- "num-traits",
  "smallvec",
  "spin",
  "wasmi_arena",
@@ -2747,9 +2727,9 @@ checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"
-version = "0.15.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac482df6761020b2b75c9aade41c105993c5b9f64156c349bb7ccad226a6ecd"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
  "downcast-rs",
  "libm",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -77,7 +77,7 @@ siphasher = { version = "1.0.0", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.13.1", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
-wasmi = { version = "0.32.0-beta.5", default-features = false }
+wasmi = { version = "0.31.0", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -25,7 +25,12 @@ use super::{
 use alloc::{borrow::ToOwned as _, string::ToString as _, sync::Arc, vec::Vec};
 use core::fmt;
 
-pub use wasmi::CompilationMode;
+// TODO: this enum is a small hack. It mimics the `CompilationMode` enum of wasmi 0.32 so that we don't have to change the API of this module when upgrading to 0.32
+// TODO: when upgrading: `pub use wasmi::CompilationMode;`
+pub enum CompilationMode {
+    Eager,
+    Lazy,
+}
 
 /// See [`super::VirtualMachinePrototype`].
 pub struct InterpreterPrototype {
@@ -54,7 +59,7 @@ impl InterpreterPrototype {
     /// See [`super::VirtualMachinePrototype::new`].
     pub fn new(
         module_bytes: &[u8],
-        compilation_mode: CompilationMode,
+        _compilation_mode: CompilationMode,
         symbols: &mut dyn FnMut(&str, &str, &Signature) -> Result<usize, ()>,
     ) -> Result<Self, NewErr> {
         let engine = {
@@ -69,7 +74,7 @@ impl InterpreterPrototype {
             config.wasm_mutable_global(false);
             config.wasm_saturating_float_to_int(false);
             config.wasm_tail_call(false);
-            config.compilation_mode(compilation_mode);
+            // TODO: when updating to wasmi 0.32: config.compilation_mode(compilation_mode);
 
             wasmi::Engine::new(&config)
         };
@@ -133,7 +138,8 @@ impl InterpreterPrototype {
                         &mut store,
                         func_type.clone(),
                         move |_caller, parameters, _ret| {
-                            Err(wasmi::Error::host(InterruptedTrap {
+                            // TODO: in wasmi v0.32, this is `wasmi::Error::host``
+                            Err(wasmi::core::Trap::from(InterruptedTrap {
                                 function_index,
                                 parameters: parameters
                                     .iter()

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fix "Justification targets block not in the chain" errors, leading to peers being erroneously banned. ([#1618](https://github.com/smol-dot/smoldot/pull/1618))
-- Reverted wasmi version to v0.31 due to performance issues with the experimental v0.32. The WebAssembly runtime is no longer compiled lazily as was the same since smoldot v2.0.17.
+- Revert wasmi version to v0.31 due to performance issues with the experimental v0.32. The WebAssembly runtime is no longer compiled lazily as was the same since smoldot v2.0.17. ([#1642](https://github.com/smol-dot/smoldot/pull/1624))
 
 ## 2.0.19 - 2024-01-26
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix "Justification targets block not in the chain" errors, leading to peers being erroneously banned. ([#1618](https://github.com/smol-dot/smoldot/pull/1618))
+- Reverted wasmi version to v0.31 due to performance issues with the experimental v0.32. The WebAssembly runtime is no longer compiled lazily as was the same since smoldot v2.0.17.
 
 ## 2.0.19 - 2024-01-26
 


### PR DESCRIPTION
cc https://github.com/paritytech/wasmi/issues/914

This time I'm not reverting the change to the `ExecHint` of smoldot, because it's a bit annoying.