### PR TITLE
Improve logs and clean up runtime service

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -1067,14 +1067,6 @@ async fn run_background<TPlat: PlatformRef>(
                             })
                         }
                         Err(error) => {
-                            // TODO: move log somewhere else
-                            log!(
-                                &background.platform,
-                                Warn,
-                                &background.log_target,
-                                format!("Failed to decode header from sync service: {}", error)
-                            );
-
                             Box::pin(async move {
                                 (download_id, Err(RuntimeDownloadError::InvalidHeader(error)))
                             })

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2178,7 +2178,7 @@ async fn run_background<TPlat: PlatformRef>(
                                 let output = finished.virtual_machine.value().as_ref().to_owned();
                                 log!(
                                     &background.platform,
-                                    Trace,
+                                    Debug,
                                     &background.log_target,
                                     "foreground-runtime-call-success",
                                     block_hash = HashDisplay(&operation.block_hash),
@@ -2198,7 +2198,7 @@ async fn run_background<TPlat: PlatformRef>(
                                 let error = RuntimeCallExecutionError::Execution(error.detail);
                                 log!(
                                     &background.platform,
-                                    Trace,
+                                    Debug,
                                     &background.log_target,
                                     "foreground-runtime-call-fail",
                                     block_hash = HashDisplay(&operation.block_hash),
@@ -2234,7 +2234,7 @@ async fn run_background<TPlat: PlatformRef>(
                                 // Forbidden host function called.
                                 log!(
                                     &background.platform,
-                                    Trace,
+                                    Debug,
                                     &background.log_target,
                                     "foreground-runtime-call-fail",
                                     block_hash = HashDisplay(&operation.block_hash),
@@ -2328,7 +2328,7 @@ async fn run_background<TPlat: PlatformRef>(
                     // This path is reached only if the call proof was invalid.
                     log!(
                         &background.platform,
-                        Trace,
+                        Debug,
                         &background.log_target,
                         "foreground-runtime-call-progress-invalid-call-proof",
                         block_hash = HashDisplay(&operation.block_hash),
@@ -2382,7 +2382,7 @@ async fn run_background<TPlat: PlatformRef>(
                     // No peer knows this block. Returning with a failure.
                     log!(
                         &background.platform,
-                        Trace,
+                        Debug,
                         &background.log_target,
                         "foreground-runtime-call-request-fail",
                         block_hash = HashDisplay(&operation.block_hash),

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2002,8 +2002,7 @@ async fn run_background<TPlat: PlatformRef>(
                     ?required_api_version,
                     parameters_vectored = HashDisplay(&parameters_vectored),
                     total_attempts,
-                    ?timeout_per_request,
-                    error = "invalid-runtime"
+                    ?timeout_per_request
                 );
 
                 let runtime = match &pinned_runtime.runtime {


### PR DESCRIPTION
Can be reviewed commit by commit.

Performs a bunch of clean ups to the runtime service, and cleans up the logging.
Trace logs can now be used in order to know everything that happens, while debug logs are less verbose.
