### PR TITLE
Remove usage of `header::Header` in most of the `all_forks`

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -2866,8 +2866,7 @@ impl SyncBackground {
                         let new_finalized_hash = finalized_blocks_newest_to_oldest
                             .first()
                             .unwrap()
-                            .header
-                            .hash(self.sync.block_number_bytes());
+                            .block_hash;
                         self.log_callback.log(
                             LogLevel::Debug,
                             format!(
@@ -2901,7 +2900,7 @@ impl SyncBackground {
                         self.pending_notification = Some(Notification::Finalized {
                             finalized_blocks_newest_to_oldest: finalized_blocks_newest_to_oldest
                                 .iter()
-                                .map(|b| b.header.hash(self.sync.block_number_bytes()))
+                                .map(|b| b.block_hash)
                                 .collect::<Vec<_>>(),
                             pruned_blocks_hashes: pruned_blocks.clone(),
                             best_block_hash: self.sync.best_block_hash(),

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -591,6 +591,7 @@ impl<'a, T> Iterator for SetFinalizedBlockIter<'a, T> {
 
         Some(RemovedBlock {
             block_hash: pruned.user_data.hash,
+            block_number: pruned.user_data.number,
             scale_encoded_header: pruned.user_data.header,
             user_data: pruned.user_data.user_data,
             ty: if pruned.is_prune_target_ancestor {
@@ -625,6 +626,8 @@ pub enum SetFinalizedError {
 pub struct RemovedBlock<T> {
     /// Hash of the block.
     pub block_hash: [u8; 32],
+    /// Height of the block.
+    pub block_number: u64,
     /// User data that was associated with that block in the [`NonFinalizedTree`].
     pub user_data: T,
     /// Reason why the block was removed.

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1725,7 +1725,10 @@ pub enum GrandpaCommitMessageOutcome {
 #[derive(Debug, Clone)]
 pub struct Block<TBl> {
     /// Header of the block.
-    pub header: header::Header,
+    pub header: Vec<u8>,
+
+    /// Hash of the block.
+    pub block_hash: [u8; 32],
 
     /// SCALE-encoded justifications of this block, if any.
     pub justifications: Vec<([u8; 4], Vec<u8>)>,
@@ -1967,20 +1970,19 @@ impl<TRq, TSrc, TBl> FinalityProofVerify<TRq, TSrc, TBl> {
                 },
             ) => (
                 sync,
+                // TODO: weird conversions
                 FinalityProofVerifyOutcome::NewFinalized {
                     finalized_blocks_newest_to_oldest: finalized_blocks_newest_to_oldest
                         .into_iter()
                         .map(|b| Block {
                             full: None, // TODO: wrong
-                            header: b.0,
+                            header: b.scale_encoded_header,
+                            block_hash: b.block_hash,
                             justifications: Vec::new(), // TODO: wrong
-                            user_data: b.1.unwrap(),
+                            user_data: b.user_data.unwrap(),
                         })
                         .collect(),
-                    pruned_blocks: pruned_blocks
-                        .into_iter()
-                        .map(|b| b.0.hash(self.shared.block_number_bytes))
-                        .collect(),
+                    pruned_blocks: pruned_blocks.into_iter().map(|b| b.block_hash).collect(),
                     updates_best_block,
                 },
             ),

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1182,7 +1182,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 if let Some(blocks_append) = all_forks_blocks_append {
                     // TODO: many of the errors don't properly translate here, needs some refactoring
                     match blocks_append.add_block(
-                        &block.scale_encoded_header,
+                        block.scale_encoded_header,
                         block.scale_encoded_extrinsics,
                         block
                             .scale_encoded_justifications
@@ -1768,7 +1768,7 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
     }
 
     /// Returns the SCALE-encoded header of the block about to be verified.
-    pub fn scale_encoded_header(&self) -> Vec<u8> {
+    pub fn scale_encoded_header(&self) -> &[u8] {
         self.inner.scale_encoded_header()
     }
 

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -2394,7 +2394,7 @@ pub struct RemovedBlock<TBl> {
     pub block_hash: [u8; 32],
     /// Height of the block.
     pub block_number: u64,
-    /// User data that was associated with that block in the [`NonFinalizedTree`].
+    /// User data that was associated with that block.
     pub user_data: TBl,
     /// SCALE-encoded header of the block.
     pub scale_encoded_header: Vec<u8>,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1318,10 +1318,12 @@ impl<TPlat: PlatformRef> Task<TPlat> {
                         self.network_up_to_date_finalized = false;
                         // Invalidate the cache of the runtime of the finalized blocks if any
                         // of the finalized blocks indicates that a runtime update happened.
-                        if finalized_blocks_newest_to_oldest
-                            .iter()
-                            .any(|b| b.header.digest.has_runtime_environment_updated())
-                        {
+                        if finalized_blocks_newest_to_oldest.iter().any(|b| {
+                            header::decode(&b.header, self.sync.block_number_bytes())
+                                .unwrap()
+                                .digest
+                                .has_runtime_environment_updated()
+                        }) {
                             self.known_finalized_runtime = None;
                         }
                         self.dispatch_all_subscribers(Notification::Finalized {


### PR DESCRIPTION
This removes the necessity for copying things around.

Note that this adds a `TODO` when finalizing due to the necessity for cloning. This should be fixed after the logic of the `all_forks` has been completely fleshed out, as it adds complexity.