### PR TITLE
Clean up standalone sync service processing handling

### DIFF
--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -130,25 +130,10 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
     // into small chunks, and each iteration of the loop processes at most one of these chunks and
     // processes one foreground message.
     loop {
-        // Try to perform some CPU-heavy operations.
-        // If any CPU-heavy verification was performed, then `queue_empty` will be `false`, in
-        // which case we will loop again as soon as possible.
-        // TODO: integrate this within WakeUpReason, see https://github.com/smol-dot/smoldot/issues/1382 this is however complicated because process_one() moves out from sync, and that sync doesn't impl Sync, a refactor of AllSync might be necessary
-        let queue_empty = {
-            // TODO: handle obsolete requests
-
-            // The sync state machine can be in a few various states. At the time of writing:
-            // idle, verifying header, verifying block, verifying grandpa warp sync proof,
-            // verifying storage proof.
-            // If the state is one of the "verifying" states, perform the actual verification
-            // and set ̀`queue_empty` to `false`.
-            let (task_update, has_done_verif) = task.process_one_verification_queue().await;
-            task = task_update;
-            !has_done_verif
-        };
-
         // Yield at every loop in order to provide better tasks granularity.
         futures_lite::future::yield_now().await;
+
+        // TODO: handle obsolete requests
 
         // Now waiting for some event to happen: a network event, a request from the frontend
         // of the sync service, or a request being finished.
@@ -163,7 +148,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
             StartRequest(all::SourceId, all::DesiredRequest),
             RequestFinished(all::RequestId, Result<RequestOutcome, future::Aborted>),
             WarpSyncTakingLongTimeWarning,
-            MustLoopAgain,
         }
 
         let wake_up_reason = {
@@ -248,17 +232,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                         future::pending().await
                     }
                 }
-            })
-            .or(async {
-                // If the list of CPU-heavy operations to perform is potentially non-empty,
-                // then we wait for a future that is always instantly ready, in order to loop
-                // again and perform the next CPU-heavy operation.
-                // Note that if any of the other futures is ready, then that other ready
-                // future will take precedence.
-                if queue_empty {
-                    future::pending::<()>().await;
-                }
-                WakeUpReason::MustLoopAgain
             })
             .await
         };
@@ -962,8 +935,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                     }
                 };
             }
-
-            WakeUpReason::MustLoopAgain => {}
         }
     }
 }


### PR DESCRIPTION
cc https://github.com/smol-dot/smoldot/issues/1382

This PR removes the hack where we call `process_one` ahead of time. Instead, the processing is done within the loop itself.
Beyond making the flow a bit easier to read, it also lowers the priority of processing behind more important tasks (in particular, lower priority than starting new requests), which should lower the time to warp sync and to answering frontend requests.
