### PR TITLE
implement transaction-index host functions

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2204,6 +2204,13 @@ impl ReadyToRun {
                     },
                 }
             }
+            HostFunction::ext_transaction_index_index_version_1
+            | HostFunction::ext_transaction_index_renew_version_1 => {
+                HostVm::ReadyToRun(ReadyToRun {
+                    inner: self.inner,
+                    resume_value: None,
+                })
+            }
         }
     }
 }

--- a/lib/src/executor/host/functions.rs
+++ b/lib/src/executor/host/functions.rs
@@ -155,6 +155,8 @@ host_functions! {
     ext_logging_log_version_1,
     ext_logging_max_level_version_1,
     ext_panic_handler_abort_on_panic_version_1,
+    ext_transaction_index_index_version_1,
+    ext_transaction_index_renew_version_1,
 }
 
 impl HostFunction {
@@ -451,6 +453,10 @@ impl HostFunction {
             }
             HostFunction::ext_panic_handler_abort_on_panic_version_1 => {
                 crate::signature!((vm::ValueType::I64) => ())
+            }
+            HostFunction::ext_transaction_index_index_version_1
+            | HostFunction::ext_transaction_index_renew_version_1 => {
+                crate::signature!((vm::ValueType::I32, vm::ValueType::I32, vm::ValueType::I32) => ())
             }
         }
     }


### PR DESCRIPTION
There're [2 pallets](https://github.com/search?q=repo%3Aparitytech%2Fpolkadot-sdk%20sp_io%3A%3Atransaction_index%3A%3Aindex&type=code) using [transaction-index](https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/frame/remark/src/lib.rs#L73) and some parachains seems to use it. It seems transaction-index is used only in [std](https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/primitives/state-machine/src/overlayed_changes/mod.rs#L584) so I guess an empty implementation will be fine.