### PR TITLE
`DesiredRequest::first_block_hash` is no longer optional

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -959,15 +959,7 @@ impl SyncBackground {
                                     match (request_details, &self.authored_block) {
                                         (
                                             all::DesiredRequest::BlocksRequest {
-                                                first_block_hash: None,
-                                                first_block_height,
-                                                ..
-                                            },
-                                            Some((authored_height, _, _, _)),
-                                        ) if first_block_height == authored_height => true,
-                                        (
-                                            all::DesiredRequest::BlocksRequest {
-                                                first_block_hash: Some(first_block_hash),
+                                                first_block_hash,
                                                 first_block_height,
                                                 ..
                                             },
@@ -1526,11 +1518,7 @@ impl SyncBackground {
                         peer_id,
                         self.network_chain_id,
                         network::codec::BlocksRequestConfig {
-                            start: if let Some(first_block_hash) = first_block_hash {
-                                network::codec::BlocksRequestConfigStart::Hash(first_block_hash)
-                            } else {
-                                network::codec::BlocksRequestConfigStart::Number(first_block_height)
-                            },
+                            start: network::codec::BlocksRequestConfigStart::Hash(first_block_hash),
                             desired_count: NonZeroU32::new(
                                 u32::try_from(num_blocks.get()).unwrap_or(u32::max_value()),
                             )

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -647,7 +647,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                                 ..
                             } => DesiredRequest::BlocksRequest {
                                 first_block_height: block_number,
-                                first_block_hash: Some(block_hash),
+                                first_block_hash: block_hash,
                                 num_blocks: NonZeroU64::new(1).unwrap(),
                                 request_headers: false,
                                 request_bodies: true,
@@ -717,7 +717,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         let all_forks_request_id = match detail {
             RequestDetail::BlocksRequest {
                 first_block_height,
-                first_block_hash: Some(first_block_hash),
+                first_block_hash,
                 num_blocks,
                 request_headers: true,
                 request_bodies,
@@ -759,7 +759,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 Some(inner_source_id),
                 RequestDetail::BlocksRequest {
                     first_block_height,
-                    first_block_hash: Some(first_block_hash),
+                    first_block_hash,
                     request_bodies: true,
                     ..
                 },
@@ -1409,8 +1409,8 @@ pub enum DesiredRequest {
     BlocksRequest {
         /// Height of the first block to request.
         first_block_height: u64,
-        /// Hash of the first block to request. `None` if not known.
-        first_block_hash: Option<[u8; 32]>,
+        /// Hash of the first block to request.
+        first_block_hash: [u8; 32],
         /// Number of blocks the request should return.
         ///
         /// Note that this is only an indication, and the source is free to give fewer blocks
@@ -1462,8 +1462,8 @@ pub enum RequestDetail {
     BlocksRequest {
         /// Height of the first block to request.
         first_block_height: u64,
-        /// Hash of the first block to request. `None` if not known.
-        first_block_hash: Option<[u8; 32]>,
+        /// Hash of the first block to request.
+        first_block_hash: [u8; 32],
         /// Number of blocks the request should return.
         ///
         /// Note that this is only an indication, and the source is free to give fewer blocks
@@ -2168,7 +2168,7 @@ fn all_forks_request_convert(
     download_body: bool,
 ) -> DesiredRequest {
     DesiredRequest::BlocksRequest {
-        first_block_hash: Some(rq_params.first_block_hash),
+        first_block_hash: rq_params.first_block_hash,
         first_block_height: rq_params.first_block_height,
         num_blocks: rq_params.num_blocks,
         request_bodies: download_body,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -1178,11 +1178,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                 let block_request = task.network_service.clone().blocks_request(
                     peer_id,
                     network::codec::BlocksRequestConfig {
-                        start: if let Some(first_block_hash) = first_block_hash {
-                            network::codec::BlocksRequestConfigStart::Hash(first_block_hash)
-                        } else {
-                            network::codec::BlocksRequestConfigStart::Number(first_block_height)
-                        },
+                        start: network::codec::BlocksRequestConfigStart::Hash(first_block_hash),
                         desired_count: NonZeroU32::new(
                             u32::try_from(num_blocks.get()).unwrap_or(u32::max_value()),
                         )


### PR DESCRIPTION
Change similar to https://github.com/smol-dot/smoldot/pull/1621

We never set the value to `None` anymore, so let's remove the `Option` altogether.
