### PR TITLE
Accept `request_bodies: true` when `download_bodies: false`

### DIFF
--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -722,7 +722,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                 request_headers: true,
                 request_bodies,
                 request_justification: true,
-            } if request_bodies == self.shared.download_bodies => {
+            } if request_bodies || !self.shared.download_bodies => {
                 let Some(all_forks) = &mut self.all_forks else {
                     unreachable!()
                 };


### PR DESCRIPTION
There's no reason to "refuse" requests that download block bodies just because we don't care about block bodies.