### PR TITLE
Clean up adding a source and notifying of a block announce

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1436,8 +1436,8 @@ impl SyncBackground {
                     // TODO: log the outcome
                     match self.sync.block_announce(id, scale_encoded_header, is_best) {
                         all::BlockAnnounceOutcome::TooOld { .. } => {}
-                        all::BlockAnnounceOutcome::AlreadyInChain(_)
-                        | all::BlockAnnounceOutcome::Known(_) => {}
+                        all::BlockAnnounceOutcome::AlreadyVerified(_)
+                        | all::BlockAnnounceOutcome::AlreadyPending(_) => {}
                         all::BlockAnnounceOutcome::Unknown(unknown) => {
                             unknown.insert_and_update_source(NonFinalizedBlock::NotVerified)
                         }

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1436,8 +1436,10 @@ impl SyncBackground {
                     // TODO: log the outcome
                     match self.sync.block_announce(id, scale_encoded_header, is_best) {
                         all::BlockAnnounceOutcome::TooOld { .. } => {}
-                        all::BlockAnnounceOutcome::AlreadyVerified(_)
-                        | all::BlockAnnounceOutcome::AlreadyPending(_) => {}
+                        all::BlockAnnounceOutcome::AlreadyVerified(known)
+                        | all::BlockAnnounceOutcome::AlreadyPending(known) => {
+                            known.update_source_and_block();
+                        }
                         all::BlockAnnounceOutcome::Unknown(unknown) => {
                             unknown.insert_and_update_source(NonFinalizedBlock::NotVerified)
                         }

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -1435,12 +1435,12 @@ impl SyncBackground {
                     let id = *self.peers_source_id_map.get(&peer_id).unwrap();
                     // TODO: log the outcome
                     match self.sync.block_announce(id, scale_encoded_header, is_best) {
-                        all::BlockAnnounceOutcome::HeaderVerify => {}
                         all::BlockAnnounceOutcome::TooOld { .. } => {}
-                        all::BlockAnnounceOutcome::AlreadyInChain => {}
-                        all::BlockAnnounceOutcome::NotFinalizedChain => {}
-                        all::BlockAnnounceOutcome::Discarded => {}
-                        all::BlockAnnounceOutcome::StoredForLater {} => {}
+                        all::BlockAnnounceOutcome::AlreadyInChain(_)
+                        | all::BlockAnnounceOutcome::Known(_) => {}
+                        all::BlockAnnounceOutcome::Unknown(unknown) => {
+                            unknown.insert_and_update_source(NonFinalizedBlock::NotVerified)
+                        }
                         all::BlockAnnounceOutcome::InvalidHeader(_) => unreachable!(), // TODO: ?!?! why unreachable? also, ban the peer
                     }
                 }
@@ -2475,19 +2475,14 @@ impl SyncBackground {
 
         // The next step is to import the block in `self.sync`. This is done by pretending that
         // the local node is a source of block similar to networking peers.
-        match self.sync.block_announce(
+        let all::BlockAnnounceOutcome::Unknown(block_insert) = self.sync.block_announce(
             self.block_author_sync_source,
             new_block_header.clone(),
             true, // Since the new block is a child of the current best block, it always becomes the new best.
-        ) {
-            all::BlockAnnounceOutcome::HeaderVerify
-            | all::BlockAnnounceOutcome::StoredForLater
-            | all::BlockAnnounceOutcome::Discarded => {}
-            all::BlockAnnounceOutcome::TooOld { .. }
-            | all::BlockAnnounceOutcome::AlreadyInChain
-            | all::BlockAnnounceOutcome::NotFinalizedChain
-            | all::BlockAnnounceOutcome::InvalidHeader(_) => unreachable!(),
-        }
+        ) else {
+            unreachable!();
+        };
+        block_insert.insert_and_update_source(NonFinalizedBlock::NotVerified);
 
         debug_assert!(self.authored_block.is_none());
         self.authored_block = Some((

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1619,6 +1619,21 @@ pub struct AnnouncedBlockKnown<'a, TRq, TSrc, TBl> {
 }
 
 impl<'a, TRq, TSrc, TBl> AnnouncedBlockKnown<'a, TRq, TSrc, TBl> {
+    /// Returns the parent hash of the announced block.
+    pub fn parent_hash(&self) -> &[u8; 32] {
+        self.inner.parent_hash()
+    }
+
+    /// Returns the height of the announced block.
+    pub fn height(&self) -> u64 {
+        self.inner.height()
+    }
+
+    /// Returns the hash of the announced block.
+    pub fn hash(&self) -> &[u8; 32] {
+        self.inner.hash()
+    }
+
     /// Gives access to the user data of the block.
     pub fn user_data_mut(&mut self) -> &mut TBl {
         // TODO: /!\
@@ -1645,6 +1660,21 @@ pub struct AnnouncedBlockUnknown<'a, TRq, TSrc, TBl> {
 }
 
 impl<'a, TRq, TSrc, TBl> AnnouncedBlockUnknown<'a, TRq, TSrc, TBl> {
+    /// Returns the parent hash of the announced block.
+    pub fn parent_hash(&self) -> &[u8; 32] {
+        self.inner.parent_hash()
+    }
+
+    /// Returns the height of the announced block.
+    pub fn height(&self) -> u64 {
+        self.inner.height()
+    }
+
+    /// Returns the hash of the announced block.
+    pub fn hash(&self) -> &[u8; 32] {
+        self.inner.hash()
+    }
+
     /// Inserts the block in the state machine and keeps track of the fact that this source knows
     /// this block.
     ///

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1078,14 +1078,14 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     marker: PhantomData,
                 })
             }
-            all_forks::BlockAnnounceOutcome::Known(inner) => {
-                BlockAnnounceOutcome::Known(AnnouncedBlockKnown {
+            all_forks::BlockAnnounceOutcome::AlreadyPending(inner) => {
+                BlockAnnounceOutcome::AlreadyPending(AnnouncedBlockKnown {
                     inner,
                     marker: PhantomData,
                 })
             }
-            all_forks::BlockAnnounceOutcome::AlreadyInChain(inner) => {
-                BlockAnnounceOutcome::AlreadyInChain(AnnouncedBlockKnown {
+            all_forks::BlockAnnounceOutcome::AlreadyVerified(inner) => {
+                BlockAnnounceOutcome::AlreadyVerified(AnnouncedBlockKnown {
                     inner,
                     marker: PhantomData,
                 })
@@ -1598,10 +1598,10 @@ pub enum BlockAnnounceOutcome<'a, TRq, TSrc, TBl> {
 
     /// Announced block has already been successfully verified and is part of the non-finalized
     /// chain.
-    AlreadyInChain(AnnouncedBlockKnown<'a, TRq, TSrc, TBl>),
+    AlreadyVerified(AnnouncedBlockKnown<'a, TRq, TSrc, TBl>),
 
     /// Announced block is already known by the state machine but hasn't been verified yet.
-    Known(AnnouncedBlockKnown<'a, TRq, TSrc, TBl>),
+    AlreadyPending(AnnouncedBlockKnown<'a, TRq, TSrc, TBl>),
 
     /// Announced block isn't in the state machine.
     Unknown(AnnouncedBlockUnknown<'a, TRq, TSrc, TBl>),

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1188,6 +1188,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Panics if the [`RequestId`] doesn't correspond to any request, or corresponds to a request
     /// of a different type.
     ///
+    // TODO: refactor this function so that the user can know the state of each block
     pub fn blocks_request_response(
         &mut self,
         request_id: RequestId,

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -501,7 +501,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// Returns the current best block of the given source.
     ///
     /// This corresponds either the latest call to [`AllSync::block_announce`] where `is_best` was
-    /// `true`, or to the parameter passed to [`AllSync::add_source`].
+    /// `true`, or to the parameter passed to [`AllSync::prepare_add_source`].
     ///
     /// # Panic
     ///

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -1537,6 +1537,21 @@ pub struct AnnouncedBlockKnown<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AnnouncedBlockKnown<'a, TBl, TRq, TSrc> {
+    /// Returns the parent hash of the announced block.
+    pub fn parent_hash(&self) -> &[u8; 32] {
+        &self.announced_header_parent_hash
+    }
+
+    /// Returns the height of the announced block.
+    pub fn height(&self) -> u64 {
+        self.announced_header_number
+    }
+
+    /// Returns the hash of the announced block.
+    pub fn hash(&self) -> &[u8; 32] {
+        &self.announced_header_hash
+    }
+
     /// Gives access to the user data of the block.
     pub fn user_data_mut(&mut self) -> &mut TBl {
         if self.is_in_chain {
@@ -1631,6 +1646,21 @@ pub struct AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
 }
 
 impl<'a, TBl, TRq, TSrc> AnnouncedBlockUnknown<'a, TBl, TRq, TSrc> {
+    /// Returns the parent hash of the announced block.
+    pub fn parent_hash(&self) -> &[u8; 32] {
+        &self.announced_header_parent_hash
+    }
+
+    /// Returns the height of the announced block.
+    pub fn height(&self) -> u64 {
+        self.announced_header_number
+    }
+
+    /// Returns the hash of the announced block.
+    pub fn hash(&self) -> &[u8; 32] {
+        &self.announced_header_hash
+    }
+
     /// Inserts the block in the state machine and keeps track of the fact that this source knows
     /// this block.
     ///

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -894,7 +894,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
             .chain
             .contains_non_finalized_block(&announced_header_hash)
         {
-            return BlockAnnounceOutcome::AlreadyInChain(AnnouncedBlockKnown {
+            return BlockAnnounceOutcome::AlreadyVerified(AnnouncedBlockKnown {
                 inner: self,
                 announced_header_hash,
                 announced_header_number,
@@ -924,7 +924,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
                 is_best,
             })
         } else {
-            BlockAnnounceOutcome::Known(AnnouncedBlockKnown {
+            BlockAnnounceOutcome::AlreadyPending(AnnouncedBlockKnown {
                 inner: self,
                 announced_header_hash,
                 announced_header_number,
@@ -1511,10 +1511,10 @@ pub enum BlockAnnounceOutcome<'a, TBl, TRq, TSrc> {
 
     /// Announced block has already been successfully verified and is part of the non-finalized
     /// chain.
-    AlreadyInChain(AnnouncedBlockKnown<'a, TBl, TRq, TSrc>),
+    AlreadyVerified(AnnouncedBlockKnown<'a, TBl, TRq, TSrc>),
 
     /// Announced block is already known by the state machine but hasn't been verified yet.
-    Known(AnnouncedBlockKnown<'a, TBl, TRq, TSrc>),
+    AlreadyPending(AnnouncedBlockKnown<'a, TBl, TRq, TSrc>),
 
     /// Announced block isn't in the state machine.
     Unknown(AnnouncedBlockUnknown<'a, TBl, TRq, TSrc>),

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -743,19 +743,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                 let sync_source_id = *task.peers_source_id_map.get(&peer_id).unwrap();
                 let decoded = announce.decode();
 
-                // TODO: improve the logging here, requires some modifications to block_announce()
-                log!(
-                    &task.platform,
-                    Debug,
-                    &task.log_target,
-                    "block-announce",
-                    sender = peer_id,
-                    hash = HashDisplay(&header::hash_from_scale_encoded_header(
-                        decoded.scale_encoded_header
-                    )),
-                    is_best = decoded.is_best,
-                );
-
                 match task
                     .sync
                     .as_mut()
@@ -765,17 +752,83 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                         decoded.scale_encoded_header.to_owned(),
                         decoded.is_best,
                     ) {
-                    all::BlockAnnounceOutcome::TooOld { .. } => {}
+                    all::BlockAnnounceOutcome::TooOld {
+                        announce_block_height,
+                        ..
+                    } => {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "block-announce",
+                            sender = peer_id,
+                            hash = HashDisplay(&header::hash_from_scale_encoded_header(
+                                decoded.scale_encoded_header
+                            )),
+                            height = announce_block_height,
+                            is_best = decoded.is_best,
+                            outcome = "older-than-finalized-block",
+                        );
+                    }
                     all::BlockAnnounceOutcome::AlreadyVerified(known) => {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "block-announce",
+                            sender = peer_id,
+                            hash = HashDisplay(known.hash()),
+                            height = known.height(),
+                            parent_hash = HashDisplay(known.parent_hash()),
+                            is_best = decoded.is_best,
+                            outcome = "already-verified",
+                        );
                         known.update_source_and_block();
                     }
                     all::BlockAnnounceOutcome::AlreadyPending(known) => {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "block-announce",
+                            sender = peer_id,
+                            hash = HashDisplay(known.hash()),
+                            height = known.height(),
+                            parent_hash = HashDisplay(known.parent_hash()),
+                            is_best = decoded.is_best,
+                            outcome = "already-pending",
+                        );
                         known.update_source_and_block();
                     }
                     all::BlockAnnounceOutcome::Unknown(unknown) => {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "block-announce",
+                            sender = peer_id,
+                            hash = HashDisplay(unknown.hash()),
+                            height = unknown.height(),
+                            parent_hash = HashDisplay(unknown.parent_hash()),
+                            is_best = decoded.is_best,
+                            outcome = "previously-unknown",
+                        );
                         unknown.insert_and_update_source(());
                     }
-                    all::BlockAnnounceOutcome::InvalidHeader(_) => {
+                    all::BlockAnnounceOutcome::InvalidHeader(error) => {
+                        log!(
+                            &task.platform,
+                            Debug,
+                            &task.log_target,
+                            "block-announce",
+                            sender = peer_id,
+                            hash = HashDisplay(&header::hash_from_scale_encoded_header(
+                                decoded.scale_encoded_header
+                            )),
+                            is_best = decoded.is_best,
+                            outcome = "invalid-header",
+                            ?error,
+                        );
                         task.network_service
                             .ban_and_disconnect(
                                 peer_id,

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -765,6 +765,16 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                         decoded.scale_encoded_header.to_owned(),
                         decoded.is_best,
                     ) {
+                    all::BlockAnnounceOutcome::TooOld { .. } => {}
+                    all::BlockAnnounceOutcome::AlreadyVerified(known) => {
+                        known.update_source_and_block();
+                    }
+                    all::BlockAnnounceOutcome::AlreadyPending(known) => {
+                        known.update_source_and_block();
+                    }
+                    all::BlockAnnounceOutcome::Unknown(unknown) => {
+                        unknown.insert_and_update_source(());
+                    }
                     all::BlockAnnounceOutcome::InvalidHeader(_) => {
                         task.network_service
                             .ban_and_disconnect(
@@ -774,7 +784,6 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                             )
                             .await;
                     }
-                    _ => {}
                 }
             }
 

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -715,7 +715,8 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                     task.sync
                         .as_mut()
                         .unwrap_or_else(|| unreachable!())
-                        .add_source((peer_id, role), best_block_number, best_block_hash),
+                        .prepare_add_source(best_block_number, best_block_hash)
+                        .add_source((peer_id, role), ()),
                 );
             }
 


### PR DESCRIPTION
cc #96 

The `all_forks.rs` is able to track the state of each block individually, however `all.rs` completely bypasses this and adds a hacky layer of abstraction on top of this.

This PR reworks the APIs of adding a source and notifying of a block announce in order to make it possible to track the state of the best block of a source.

Work duration: 1h
