### PR TITLE
Extract from main match block the runtime call logic

### DIFF
--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2167,7 +2167,6 @@ async fn run_background<TPlat: PlatformRef>(
                 );
 
                 // Start the request.
-                // TODO: cancel request immediately if result_tx closes
                 background.progress_runtime_call_requests.push(Box::pin({
                     let call_proof_request_future =
                         background.network_service.clone().call_proof_request(

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -826,7 +826,7 @@ async fn run_background<TPlat: PlatformRef>(
     };
 
     // Inner loop. Process incoming events.
-    'background_main_loop: loop {
+    loop {
         // Yield at every loop in order to provide better tasks granularity.
         futures_lite::future::yield_now().await;
 
@@ -2029,284 +2029,84 @@ async fn run_background<TPlat: PlatformRef>(
 
                 // Process the call proof.
                 if let Some((call_proof, call_proof_sender)) = call_proof_and_sender {
-                    // Try to decode the proof. Succeed just means that the proof has the correct
-                    // encoding, and doesn't guarantee that the proof has all the necessary
-                    // entries.
-                    let call_proof =
-                        trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
-                            proof: call_proof.decode(),
-                        });
-
-                    // Keep track of the total time taken by the runtime call attempt.
-                    let mut virtual_machine_call_duration = Duration::new(0, 0);
-                    let mut proof_access_duration = Duration::new(0, 0);
-
-                    // Attempt the runtime call.
-                    // If the call succeed, we interrupt the flow and `continue`.
-                    let runtime_call_duration_before = background.platform.now();
-                    let mut call =
-                        match executor::runtime_call::run(executor::runtime_call::Config {
-                            virtual_machine: operation.runtime.clone(),
-                            function_to_call: &operation.function_name,
-                            parameter: iter::once(&operation.parameters_vectored),
-                            storage_main_trie_changes: Default::default(),
-                            max_log_level: 0,
-                            calculate_trie_changes: false,
-                        }) {
-                            Ok(call) => call,
-                            Err((error, _)) => {
-                                // If starting the execution triggers an error, then the runtime
-                                // call cannot possibly succeed.
-                                // This can happen for example because the requested function
-                                // doesn't exist.
-                                let error = RuntimeCallExecutionError::Start(error);
-                                log!(
-                                    &background.platform,
-                                    Debug,
-                                    &background.log_target,
-                                    "foreground-runtime-call-fail",
-                                    block_hash = HashDisplay(&operation.block_hash),
-                                    function_name = operation.function_name,
-                                    parameters_vectored =
-                                        HashDisplay(&operation.parameters_vectored),
-                                    error = ?error,
-                                );
-                                let _ = operation
-                                    .result_tx
-                                    .send(Err(RuntimeCallError::Execution(error)));
-                                continue 'background_main_loop;
-                            }
-                        };
-                    virtual_machine_call_duration +=
-                        background.platform.now() - runtime_call_duration_before;
-
-                    let error = loop {
-                        let call_proof = match &call_proof {
-                            Ok(p) => p,
-                            Err(error) => {
-                                break RuntimeCallInaccessibleError::InvalidCallProof(
-                                    error.clone(),
-                                );
-                            }
-                        };
-
-                        // Yield once at every iteration. This avoids monopolizing the CPU for
-                        // too long.
-                        futures_lite::future::yield_now().await;
-
-                        let child_trie = match call {
-                            executor::runtime_call::RuntimeCall::Finished(Ok(finished)) => {
-                                // Execution finished successfully.
-                                // This is the happy path.
-                                let output = finished.virtual_machine.value().as_ref().to_owned();
-                                log!(
-                                    &background.platform,
-                                    Debug,
-                                    &background.log_target,
-                                    "foreground-runtime-call-success",
-                                    block_hash = HashDisplay(&operation.block_hash),
-                                    function_name = operation.function_name,
-                                    parameters_vectored =
-                                        HashDisplay(&operation.parameters_vectored),
-                                    output = HashDisplay(&output),
-                                    ?virtual_machine_call_duration,
-                                    ?proof_access_duration,
-                                );
-                                let _ = operation.result_tx.send(Ok(RuntimeCallSuccess {
-                                    output,
-                                    api_version: operation.api_version,
-                                }));
-                                continue 'background_main_loop;
-                            }
-                            executor::runtime_call::RuntimeCall::Finished(Err(error)) => {
-                                // Execution finished with an error.
-                                let error = RuntimeCallExecutionError::Execution(error.detail);
-                                log!(
-                                    &background.platform,
-                                    Debug,
-                                    &background.log_target,
-                                    "foreground-runtime-call-fail",
-                                    block_hash = HashDisplay(&operation.block_hash),
-                                    function_name = operation.function_name,
-                                    parameters_vectored =
-                                        HashDisplay(&operation.parameters_vectored),
-                                    error = ?error,
-                                    ?virtual_machine_call_duration,
-                                    ?proof_access_duration,
-                                );
-                                let _ = operation
-                                    .result_tx
-                                    .send(Err(RuntimeCallError::Execution(error)));
-                                continue 'background_main_loop;
-                            }
-                            executor::runtime_call::RuntimeCall::StorageGet(ref get) => {
-                                get.child_trie().map(|c| c.as_ref().to_owned()) // TODO: overhead
-                            }
-                            executor::runtime_call::RuntimeCall::ClosestDescendantMerkleValue(
-                                ref mv,
-                            ) => mv.child_trie().map(|c| c.as_ref().to_owned()), // TODO: overhead
-                            executor::runtime_call::RuntimeCall::NextKey(ref nk) => {
-                                nk.child_trie().map(|c| c.as_ref().to_owned()) // TODO: overhead
-                            }
-                            executor::runtime_call::RuntimeCall::SignatureVerification(r) => {
-                                let runtime_call_duration_before = background.platform.now();
-                                call = r.verify_and_resume();
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                                continue;
-                            }
-                            executor::runtime_call::RuntimeCall::LogEmit(r) => {
-                                // Logs are ignored.
-                                let runtime_call_duration_before = background.platform.now();
-                                call = r.resume();
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                                continue;
-                            }
-                            executor::runtime_call::RuntimeCall::Offchain(_) => {
-                                // Forbidden host function called.
-                                log!(
-                                    &background.platform,
-                                    Debug,
-                                    &background.log_target,
-                                    "foreground-runtime-call-fail",
-                                    block_hash = HashDisplay(&operation.block_hash),
-                                    function_name = operation.function_name,
-                                    parameters_vectored =
-                                        HashDisplay(&operation.parameters_vectored),
-                                    error = ?RuntimeCallExecutionError::ForbiddenHostFunction,
-                                    ?virtual_machine_call_duration,
-                                    ?proof_access_duration,
-                                );
-                                let _ = operation.result_tx.send(Err(RuntimeCallError::Execution(
-                                    RuntimeCallExecutionError::ForbiddenHostFunction,
-                                )));
-                                continue 'background_main_loop;
-                            }
-                            executor::runtime_call::RuntimeCall::OffchainStorageSet(r) => {
-                                // Ignore offchain storage writes.
-                                let runtime_call_duration_before = background.platform.now();
-                                call = r.resume();
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                                continue;
-                            }
-                        };
-
-                        let proof_access_duration_before = background.platform.now();
-                        let trie_root = if let Some(child_trie) = child_trie {
-                            // TODO: allocation here, but probably not problematic
-                            const PREFIX: &[u8] = b":child_storage:default:";
-                            let mut key = Vec::with_capacity(PREFIX.len() + child_trie.len());
-                            key.extend_from_slice(PREFIX);
-                            key.extend_from_slice(child_trie.as_ref());
-                            match call_proof
-                                .storage_value(&operation.block_state_trie_root_hash, &key)
-                            {
-                                Err(_) => break RuntimeCallInaccessibleError::MissingProofEntry,
-                                Ok(None) => None,
-                                Ok(Some((value, _))) => match <[u8; 32]>::try_from(value) {
-                                    Ok(hash) => Some(hash),
-                                    Err(_) => {
-                                        break RuntimeCallInaccessibleError::MissingProofEntry
-                                    }
-                                },
-                            }
-                        } else {
-                            Some(operation.block_state_trie_root_hash)
-                        };
-
-                        match call {
-                            executor::runtime_call::RuntimeCall::StorageGet(get) => {
-                                let storage_value = if let Some(trie_root) = trie_root {
-                                    call_proof.storage_value(&trie_root, get.key().as_ref())
-                                } else {
-                                    Ok(None)
-                                };
-                                let Ok(storage_value) = storage_value else {
-                                    break RuntimeCallInaccessibleError::MissingProofEntry;
-                                };
-                                proof_access_duration +=
-                                    background.platform.now() - proof_access_duration_before;
-
-                                let runtime_call_duration_before = background.platform.now();
-                                call = get.inject_value(
-                                    storage_value.map(|(val, vers)| (iter::once(val), vers)),
-                                );
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                            }
-                            executor::runtime_call::RuntimeCall::ClosestDescendantMerkleValue(
-                                mv,
-                            ) => {
-                                let merkle_value = if let Some(trie_root) = trie_root {
-                                    call_proof.closest_descendant_merkle_value(&trie_root, mv.key())
-                                } else {
-                                    Ok(None)
-                                };
-                                let Ok(merkle_value) = merkle_value else {
-                                    break RuntimeCallInaccessibleError::MissingProofEntry;
-                                };
-                                proof_access_duration +=
-                                    background.platform.now() - proof_access_duration_before;
-
-                                let runtime_call_duration_before = background.platform.now();
-                                call = mv.inject_merkle_value(merkle_value);
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                            }
-                            executor::runtime_call::RuntimeCall::NextKey(nk) => {
-                                let next_key = if let Some(trie_root) = trie_root {
-                                    call_proof.next_key(
-                                        &trie_root,
-                                        nk.key(),
-                                        nk.or_equal(),
-                                        nk.prefix(),
-                                        nk.branch_nodes(),
-                                    )
-                                } else {
-                                    Ok(None)
-                                };
-                                let Ok(next_key) = next_key else {
-                                    break RuntimeCallInaccessibleError::MissingProofEntry;
-                                };
-                                proof_access_duration +=
-                                    background.platform.now() - proof_access_duration_before;
-
-                                let runtime_call_duration_before = background.platform.now();
-                                call = nk.inject_key(next_key);
-                                virtual_machine_call_duration +=
-                                    background.platform.now() - runtime_call_duration_before;
-                            }
-                            _ => unreachable!(),
-                        }
-                    };
-
-                    // This path is reached only if the call proof was invalid.
-                    log!(
+                    match runtime_call_single_attempt(
                         &background.platform,
-                        Debug,
-                        &background.log_target,
-                        "foreground-runtime-call-progress-invalid-call-proof",
-                        block_hash = HashDisplay(&operation.block_hash),
-                        function_name = operation.function_name,
-                        parameters_vectored = HashDisplay(&operation.parameters_vectored),
-                        remaining_attempts = usize::try_from(operation.total_attempts).unwrap()
-                            - operation.inaccessible_errors.len()
-                            - 1,
-                        ?error,
-                        ?virtual_machine_call_duration,
-                        ?proof_access_duration,
-                    );
-                    operation.inaccessible_errors.push(error);
-                    background
-                        .network_service
-                        .ban_and_disconnect(
-                            call_proof_sender,
-                            network_service::BanSeverity::High,
-                            "invalid-call-proof",
-                        )
-                        .await;
+                        operation.runtime.clone(),
+                        &operation.function_name,
+                        &operation.parameters_vectored,
+                        &operation.block_state_trie_root_hash,
+                        call_proof.decode(),
+                    )
+                    .await
+                    {
+                        (timing, Ok(output)) => {
+                            // Execution finished successfully.
+                            // This is the happy path.
+                            log!(
+                                &background.platform,
+                                Debug,
+                                &background.log_target,
+                                "foreground-runtime-call-success",
+                                block_hash = HashDisplay(&operation.block_hash),
+                                function_name = operation.function_name,
+                                parameters_vectored = HashDisplay(&operation.parameters_vectored),
+                                output = HashDisplay(&output),
+                                virtual_machine_call_duration = ?timing.virtual_machine_call_duration,
+                                proof_access_duration = ?timing.proof_access_duration,
+                            );
+                            let _ = operation.result_tx.send(Ok(RuntimeCallSuccess {
+                                output,
+                                api_version: operation.api_version,
+                            }));
+                            continue;
+                        }
+                        (timing, Err(SingleRuntimeCallAttemptError::Execution(error))) => {
+                            log!(
+                                &background.platform,
+                                Debug,
+                                &background.log_target,
+                                "foreground-runtime-call-fail",
+                                block_hash = HashDisplay(&operation.block_hash),
+                                function_name = operation.function_name,
+                                parameters_vectored = HashDisplay(&operation.parameters_vectored),
+                                ?error,
+                                virtual_machine_call_duration = ?timing.virtual_machine_call_duration,
+                                proof_access_duration = ?timing.proof_access_duration,
+                            );
+                            let _ = operation
+                                .result_tx
+                                .send(Err(RuntimeCallError::Execution(error)));
+                            continue;
+                        }
+                        (timing, Err(SingleRuntimeCallAttemptError::Inaccessible(error))) => {
+                            // This path is reached only if the call proof was invalid.
+                            log!(
+                                &background.platform,
+                                Debug,
+                                &background.log_target,
+                                "foreground-runtime-call-progress-invalid-call-proof",
+                                block_hash = HashDisplay(&operation.block_hash),
+                                function_name = operation.function_name,
+                                parameters_vectored = HashDisplay(&operation.parameters_vectored),
+                                remaining_attempts = usize::try_from(operation.total_attempts)
+                                    .unwrap()
+                                    - operation.inaccessible_errors.len()
+                                    - 1,
+                                ?error,
+                                virtual_machine_call_duration = ?timing.virtual_machine_call_duration,
+                                proof_access_duration = ?timing.proof_access_duration,
+                            );
+                            operation.inaccessible_errors.push(error);
+                            background
+                                .network_service
+                                .ban_and_disconnect(
+                                    call_proof_sender,
+                                    network_service::BanSeverity::High,
+                                    "invalid-call-proof",
+                                )
+                                .await;
+                        }
+                    }
                 }
 
                 // If we have failed to obtain a valid proof several times, abort the runtime
@@ -2318,7 +2118,7 @@ async fn run_background<TPlat: PlatformRef>(
                     let _ = operation.result_tx.send(Err(RuntimeCallError::Inaccessible(
                         operation.inaccessible_errors,
                     )));
-                    continue 'background_main_loop;
+                    continue;
                 }
 
                 // This can be reached if the call proof was invalid or absent. We must start a
@@ -2352,7 +2152,7 @@ async fn run_background<TPlat: PlatformRef>(
                     let _ = operation.result_tx.send(Err(RuntimeCallError::Inaccessible(
                         operation.inaccessible_errors,
                     )));
-                    continue 'background_main_loop;
+                    continue;
                 };
 
                 log!(
@@ -3151,4 +2951,269 @@ fn download_runtime<TPlat: PlatformRef>(
             }
         }
     }
+}
+
+/// Tries to perform a runtime call using the given call proof.
+///
+/// This function can have three possible outcomes: success, failure because the call proof is
+/// invalid/incomplete, or failure because the execution fails.
+///
+/// This function is async in order to periodically yield during the execution.
+async fn runtime_call_single_attempt<TPlat: PlatformRef>(
+    platform: &TPlat,
+    runtime: executor::host::HostVmPrototype,
+    function_name: &str,
+    parameters_vectored: &[u8],
+    block_state_trie_root_hash: &[u8; 32],
+    call_proof: &[u8],
+) -> (
+    SingleRuntimeCallTiming,
+    Result<Vec<u8>, SingleRuntimeCallAttemptError>,
+) {
+    // Try to decode the proof. Succeed just means that the proof has the correct
+    // encoding, and doesn't guarantee that the proof has all the necessary
+    // entries.
+    let call_proof = trie::proof_decode::decode_and_verify_proof(trie::proof_decode::Config {
+        proof: call_proof,
+    });
+
+    // Keep track of the total time taken by the runtime call attempt.
+    let mut timing = SingleRuntimeCallTiming {
+        virtual_machine_call_duration: Duration::new(0, 0),
+        proof_access_duration: Duration::new(0, 0),
+    };
+
+    // Attempt the runtime call.
+    // If the call succeed, we interrupt the flow and `continue`.
+    let runtime_call_duration_before = platform.now();
+    let mut call = match executor::runtime_call::run(executor::runtime_call::Config {
+        virtual_machine: runtime,
+        function_to_call: function_name,
+        parameter: iter::once(parameters_vectored),
+        storage_main_trie_changes: Default::default(),
+        max_log_level: 0,
+        calculate_trie_changes: false,
+    }) {
+        Ok(call) => call,
+        Err((error, _)) => {
+            // If starting the execution triggers an error, then the runtime call cannot
+            // possibly succeed.
+            // This can happen for example because the requested function doesn't exist.
+            return (
+                timing,
+                Err(SingleRuntimeCallAttemptError::Execution(
+                    RuntimeCallExecutionError::Start(error),
+                )),
+            );
+        }
+    };
+    timing.virtual_machine_call_duration += platform.now() - runtime_call_duration_before;
+
+    loop {
+        let call_proof = match &call_proof {
+            Ok(p) => p,
+            Err(error) => {
+                return (
+                    timing,
+                    Err(SingleRuntimeCallAttemptError::Inaccessible(
+                        RuntimeCallInaccessibleError::InvalidCallProof(error.clone()),
+                    )),
+                );
+            }
+        };
+
+        // Yield once at every iteration. This avoids monopolizing the CPU for
+        // too long.
+        futures_lite::future::yield_now().await;
+
+        let child_trie = match call {
+            executor::runtime_call::RuntimeCall::Finished(Ok(finished)) => {
+                // Execution finished successfully.
+                // This is the happy path.
+                let output = finished.virtual_machine.value().as_ref().to_owned();
+                return (timing, Ok(output));
+            }
+            executor::runtime_call::RuntimeCall::Finished(Err(error)) => {
+                // Execution finished with an error.
+                return (
+                    timing,
+                    Err(SingleRuntimeCallAttemptError::Execution(
+                        RuntimeCallExecutionError::Execution(error.detail),
+                    )),
+                );
+            }
+            executor::runtime_call::RuntimeCall::StorageGet(ref get) => {
+                get.child_trie().map(|c| c.as_ref().to_owned()) // TODO: overhead
+            }
+            executor::runtime_call::RuntimeCall::ClosestDescendantMerkleValue(ref mv) => {
+                mv.child_trie().map(|c| c.as_ref().to_owned())
+            } // TODO: overhead
+            executor::runtime_call::RuntimeCall::NextKey(ref nk) => {
+                nk.child_trie().map(|c| c.as_ref().to_owned()) // TODO: overhead
+            }
+            executor::runtime_call::RuntimeCall::SignatureVerification(r) => {
+                let runtime_call_duration_before = platform.now();
+                call = r.verify_and_resume();
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+                continue;
+            }
+            executor::runtime_call::RuntimeCall::LogEmit(r) => {
+                // Logs are ignored.
+                let runtime_call_duration_before = platform.now();
+                call = r.resume();
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+                continue;
+            }
+            executor::runtime_call::RuntimeCall::Offchain(_) => {
+                // Forbidden host function called.
+                return (
+                    timing,
+                    Err(SingleRuntimeCallAttemptError::Execution(
+                        RuntimeCallExecutionError::ForbiddenHostFunction,
+                    )),
+                );
+            }
+            executor::runtime_call::RuntimeCall::OffchainStorageSet(r) => {
+                // Ignore offchain storage writes.
+                let runtime_call_duration_before = platform.now();
+                call = r.resume();
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+                continue;
+            }
+        };
+
+        let proof_access_duration_before = platform.now();
+        let trie_root = if let Some(child_trie) = child_trie {
+            // TODO: allocation here, but probably not problematic
+            const PREFIX: &[u8] = b":child_storage:default:";
+            let mut key = Vec::with_capacity(PREFIX.len() + child_trie.len());
+            key.extend_from_slice(PREFIX);
+            key.extend_from_slice(child_trie.as_ref());
+            match call_proof.storage_value(&block_state_trie_root_hash, &key) {
+                Err(_) => {
+                    return (
+                        timing,
+                        Err(SingleRuntimeCallAttemptError::Inaccessible(
+                            RuntimeCallInaccessibleError::MissingProofEntry,
+                        )),
+                    )
+                }
+                Ok(None) => None,
+                Ok(Some((value, _))) => match <&[u8; 32]>::try_from(value) {
+                    Ok(hash) => Some(hash),
+                    Err(_) => {
+                        return (
+                            timing,
+                            Err(SingleRuntimeCallAttemptError::Inaccessible(
+                                RuntimeCallInaccessibleError::MissingProofEntry,
+                            )),
+                        )
+                    }
+                },
+            }
+        } else {
+            Some(block_state_trie_root_hash)
+        };
+
+        match call {
+            executor::runtime_call::RuntimeCall::StorageGet(get) => {
+                let storage_value = if let Some(trie_root) = trie_root {
+                    call_proof.storage_value(&trie_root, get.key().as_ref())
+                } else {
+                    Ok(None)
+                };
+                let Ok(storage_value) = storage_value else {
+                    return (
+                        timing,
+                        Err(SingleRuntimeCallAttemptError::Inaccessible(
+                            RuntimeCallInaccessibleError::MissingProofEntry,
+                        )),
+                    );
+                };
+                timing.proof_access_duration += platform.now() - proof_access_duration_before;
+
+                let runtime_call_duration_before = platform.now();
+                call = get.inject_value(storage_value.map(|(val, vers)| (iter::once(val), vers)));
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+            }
+            executor::runtime_call::RuntimeCall::ClosestDescendantMerkleValue(mv) => {
+                let merkle_value = if let Some(trie_root) = trie_root {
+                    call_proof.closest_descendant_merkle_value(&trie_root, mv.key())
+                } else {
+                    Ok(None)
+                };
+                let Ok(merkle_value) = merkle_value else {
+                    return (
+                        timing,
+                        Err(SingleRuntimeCallAttemptError::Inaccessible(
+                            RuntimeCallInaccessibleError::MissingProofEntry,
+                        )),
+                    );
+                };
+                timing.proof_access_duration += platform.now() - proof_access_duration_before;
+
+                let runtime_call_duration_before = platform.now();
+                call = mv.inject_merkle_value(merkle_value);
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+            }
+            executor::runtime_call::RuntimeCall::NextKey(nk) => {
+                let next_key = if let Some(trie_root) = trie_root {
+                    call_proof.next_key(
+                        &trie_root,
+                        nk.key(),
+                        nk.or_equal(),
+                        nk.prefix(),
+                        nk.branch_nodes(),
+                    )
+                } else {
+                    Ok(None)
+                };
+                let Ok(next_key) = next_key else {
+                    return (
+                        timing,
+                        Err(SingleRuntimeCallAttemptError::Inaccessible(
+                            RuntimeCallInaccessibleError::MissingProofEntry,
+                        )),
+                    );
+                };
+                timing.proof_access_duration += platform.now() - proof_access_duration_before;
+
+                let runtime_call_duration_before = platform.now();
+                call = nk.inject_key(next_key);
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// See [`runtime_call_single_attempt`].
+#[derive(Debug, Clone)]
+struct SingleRuntimeCallTiming {
+    /// Time spent execution the virtual machine.
+    virtual_machine_call_duration: Duration,
+    /// Time spent accessing the call proof.
+    proof_access_duration: Duration,
+}
+
+/// See [`runtime_call_single_attempt`].
+#[derive(Debug, derive_more::Display, Clone)]
+enum SingleRuntimeCallAttemptError {
+    /// Error during the execution of the runtime.
+    ///
+    /// There is no point in trying the same call again, as it would result in the same error.
+    #[display(fmt = "Error during the execution of the runtime: {_0}")]
+    Execution(RuntimeCallExecutionError),
+
+    /// Error trying to access the storage required for the runtime call.
+    ///
+    /// Trying the same call again might succeed.
+    #[display(fmt = "Error trying to access the storage required for the runtime call: {_0}")]
+    Inaccessible(RuntimeCallInaccessibleError),
 }


### PR DESCRIPTION
Cleans up the runtime service by extracting to a separate function the logic of performing a runtime call using a call proof.

This should make the code more readable.