### PR TITLE
Notify the warp_sync when the all_forks finalizes blocks

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - The `rpc_methods` JSON-RPC function now properly returns an array of strings. ([#1647](https://github.com/smol-dot/smoldot/pull/1647))
-- The warp syncing process no longer repeats itself every 32 blocks, which was causing unnecessary bandwidth usage.
+- The warp syncing process no longer repeats itself every 32 blocks, which was causing unnecessary bandwidth and CPU usage. ([#1656](https://github.com/smol-dot/smoldot/pull/1656))
 
 ## 2.0.20 - 2024-01-30
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The `rpc_methods` JSON-RPC function now properly returns an array of strings. ([#1647](https://github.com/smol-dot/smoldot/pull/1647))
+- The warp syncing process no longer repeats itself every 32 blocks, which was causing unnecessary bandwidth usage.
 
 ## 2.0.20 - 2024-01-30
 


### PR DESCRIPTION
Fix https://github.com/smol-dot/smoldot/issues/1651

Before this PR, the warp sync state machine would simply run in parallel completely in isolation and perform a warp sync every 32 blocks.
This PR fixes this by notifying the warp sync state machine when the all_forks state machine finalizes.
