### PR TITLE
Revert "fix `rpc_methods` return type (#1647)"

### DIFF
--- a/full-node/src/json_rpc_service/requests_handler.rs
+++ b/full-node/src/json_rpc_service/requests_handler.rs
@@ -92,11 +92,11 @@ pub fn spawn_requests_handler(config: Config) {
             match receiver.next().await {
                 Some(Message::Request(request)) => match request.request() {
                     methods::MethodCall::rpc_methods {} => {
-                        request.respond(methods::Response::rpc_methods(methods::RpcMethods(
-                            methods::MethodCall::method_names()
+                        request.respond(methods::Response::rpc_methods(methods::RpcMethods {
+                            methods: methods::MethodCall::method_names()
                                 .map(|n| n.into())
                                 .collect(),
-                        )));
+                        }));
                     }
 
                     methods::MethodCall::chainSpec_v1_chainName {} => {

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -949,7 +949,9 @@ pub struct HeaderDigest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RpcMethods(pub Vec<String>);
+pub struct RpcMethods {
+    pub methods: Vec<String>,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
@@ -1107,7 +1109,15 @@ impl serde::Serialize for RpcMethods {
     where
         S: serde::Serializer,
     {
-        self.0[..].serialize(serializer)
+        #[derive(serde::Serialize)]
+        struct SerdeRpcMethods<'a> {
+            methods: &'a [String],
+        }
+
+        SerdeRpcMethods {
+            methods: &self.methods,
+        }
+        .serialize(serializer)
     }
 }
 

--- a/light-base/src/json_rpc_service/background/getters.rs
+++ b/light-base/src/json_rpc_service/background/getters.rs
@@ -77,11 +77,11 @@ impl<TPlat: PlatformRef> Background<TPlat> {
 
     /// Handles a call to [`methods::MethodCall::rpc_methods`].
     pub(super) async fn rpc_methods(self: &Arc<Self>, request: service::RequestProcess) {
-        request.respond(methods::Response::rpc_methods(methods::RpcMethods(
-            methods::MethodCall::method_names()
+        request.respond(methods::Response::rpc_methods(methods::RpcMethods {
+            methods: methods::MethodCall::method_names()
                 .map(|n| n.into())
                 .collect(),
-        )));
+        }));
     }
 
     /// Handles a call to [`methods::MethodCall::sudo_unstable_version`].

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixed
-
-- The `rpc_methods` JSON-RPC function now properly returns an array of strings. ([#1647](https://github.com/smol-dot/smoldot/pull/1647))
-
 ## 2.0.20 - 2024-01-30
 
 ### Fixed


### PR DESCRIPTION
cc @josepot 
That PR broke PolkadotJS.

The point of `rpc_methods` was to be backwards compatible with the old JSON-RPC API.
If the JSON-RPC spec isn't backwards compatible, then it's the spec that is wrong.