### PR TITLE
Update Rust to v1.76 and fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add wasm32-unknown-unknown
@@ -66,7 +66,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -100,7 +100,7 @@ jobs:
   check-no-std:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add thumbv7m-none-eabi
@@ -112,7 +112,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -121,7 +121,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -176,7 +176,7 @@ jobs:
   wasm-node-versions-match:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
       - run: apt-get update && apt install -y jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
   build-js-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
   build-rust-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - run: apt update && apt install -y jq
       - run: rustup component add llvm-tools-preview
@@ -174,7 +174,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
@@ -217,7 +217,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: 1.74
+          toolchain: 1.76
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
@@ -244,7 +244,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
       - uses: actions/checkout@v4
       - run: cargo publish --dry-run --locked

--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-update:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.74
+      image: rust:1.76
     steps:
     - uses: actions/checkout@v4
     # Note: `cargo update --workspace` doesn't seem to have any effect.

--- a/full-node/src/database_thread.rs
+++ b/full-node/src/database_thread.rs
@@ -23,7 +23,7 @@ use smol::{channel, lock::Mutex, stream::StreamExt as _};
 use smoldot::database::full_sqlite::SqliteFullDatabase;
 use std::{pin::pin, thread};
 
-pub use smoldot::database::full_sqlite::{CorruptedError, StorageAccessError};
+pub use smoldot::database::full_sqlite::StorageAccessError;
 
 /// Handle to the thread were the database accesses are performed.
 ///

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -47,8 +47,6 @@ use smoldot::{
 mod parachain;
 mod standalone;
 
-pub use network_service::EncodedMerkleProof;
-
 /// Configuration for a [`SyncService`].
 pub struct Config<TPlat: PlatformRef> {
     /// Name of the chain, for logging purposes.

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Smoldot is no longer compiled with the `bulk-memory-operations` and `sign-extensions-ops` WebAssembly features enabled due to the Rust compiler considering target features as unstable.
+
 ## 2.0.22 - 2024-03-04
 
 ### Fixed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Smoldot is no longer compiled with the `bulk-memory-operations` and `sign-extensions-ops` WebAssembly features enabled due to the Rust compiler considering target features as unstable.
+- Smoldot is no longer compiled with the `bulk-memory-operations` and `sign-extensions-ops` WebAssembly features enabled due to the Rust compiler considering target features as unstable. ([#1716](https://github.com/smol-dot/smoldot/pull/1716))
 
 ## 2.0.22 - 2024-03-04
 

--- a/wasm-node/javascript/prepare.mjs
+++ b/wasm-node/javascript/prepare.mjs
@@ -36,25 +36,14 @@ if (buildProfile != 'debug' && buildProfile != 'min-size-release')
 
 // The important step in this script is running `cargo build --target wasm32-unknown-unknown` on
 // the Rust code. This generates a `wasm` file in `target/wasm32-unknown-unknown`.
-// Some optional Wasm features are enabled during the compilation in order to speed up the
-// execution of smoldot.
-// SIMD is intentionally not enabled, because WASM engines seem to allow only SIMD instructions
-// on specific hardware. See for example <https://bugzilla.mozilla.org/show_bug.cgi?id=1625130#c11>
+// No optional Wasm features is enabled due to being an unstable part of the Rust compiler.
+// Additionally, SIMD should not be enabled, because WASM engines seem to allow only SIMD
+// instructions on specific hardware. See for example <https://bugzilla.mozilla.org/show_bug.cgi?id=1625130#c11>
 // and <https://bugzilla.mozilla.org/show_bug.cgi?id=1840710>.
-//
-// Note that this doesn't enable these features in the Rust standard library (which comes
-// precompiled), but the missing optimizations shouldn't be too much of a problem. The Rust
-// standard library could be compiled with these features using the `-Z build-std` flag, but at
-// the time of the writing of this comment this would require an unstable version of Rust.
-// Use `rustc --print target-features --target wasm32-unknown-unknown` to see the list of target
-// features.
-// See <https://webassembly.org/roadmap/> to know which version of which engine supports which
-// feature.
-// See also the issue: <https://github.com/smol-dot/smoldot/issues/350>
 child_process.execSync(
     "cargo build --package smoldot-light-wasm --target wasm32-unknown-unknown --no-default-features " +
     (buildProfile == 'debug' ? '' : ("--profile " + buildProfile)),
-    { 'stdio': 'inherit', 'env': { 'RUSTFLAGS': '-C target-feature=+bulk-memory,+sign-ext', ...process.env } }
+    { 'stdio': 'inherit' }
 );
 const rustOutput = "../../target/wasm32-unknown-unknown/" + buildProfile + "/smoldot_light_wasm.wasm";
 


### PR DESCRIPTION
Nothing relevant to smoldot has been added to Rust 1.75 and 1.76.
This PR fixes a few warnings that have appeared.

Notably, we no longer enable Wasm features, as they are considered unstable.
