### PR TITLE
Fix bounded channel being too small

### DIFF
--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -70,6 +70,7 @@ pub struct Config<TPlat: PlatformRef> {
     ///
     /// This parameter is necessary in order to prevent users from using up too much memory within
     /// the client.
+    // TODO: unused at the moment
     pub max_pending_requests: NonZeroU32,
 
     /// Maximum number of active subscriptions. Any additional subscription will be immediately
@@ -77,14 +78,8 @@ pub struct Config<TPlat: PlatformRef> {
     ///
     /// This parameter is necessary in order to prevent users from using up too much memory within
     /// the client.
-    pub max_subscriptions: u32,
-
-    /// Maximum number of JSON-RPC requests that can be processed simultaneously.
-    ///
-    /// This parameter is necessary in order to prevent users from using up too much memory within
-    /// the client.
     // TODO: unused at the moment
-    pub max_parallel_requests: NonZeroU32,
+    pub max_subscriptions: u32,
 }
 
 /// Creates a new JSON-RPC service with the given configuration.
@@ -96,7 +91,7 @@ pub struct Config<TPlat: PlatformRef> {
 pub fn service<TPlat: PlatformRef>(config: Config<TPlat>) -> (Frontend<TPlat>, ServicePrototype) {
     let log_target = format!("json-rpc-{}", config.log_name);
 
-    let (requests_tx, requests_rx) = async_channel::bounded(32); // TODO: capacity?
+    let (requests_tx, requests_rx) = async_channel::unbounded(); // TODO: capacity?
     let (responses_tx, responses_rx) = async_channel::bounded(16); // TODO: capacity?
 
     let frontend = Frontend {

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -935,13 +935,6 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 log_name: log_name.clone(), // TODO: add a way to differentiate multiple different json-rpc services under the same chain
                 max_pending_requests,
                 max_subscriptions,
-                // Note that the settings below are intentionally not exposed in the publicly
-                // available configuration, as "good" values depend on the global number of tasks.
-                // In other words, these constants are relative to the number of other things that
-                // happen within the client rather than absolute values. Since the user isn't
-                // supposed to know what happens within the client, they can't rationally decide
-                // what value is appropriate.
-                max_parallel_requests: NonZeroU32::new(24).unwrap(),
             });
 
             service_starter.start(json_rpc_service::StartConfig {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix `QueueFullError` being thrown even when the number of requests is way below the value passed to `jsonRpcMaxPendingRequests`.
+
 ## 2.0.23 - 2024-03-20
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix `QueueFullError` being thrown even when the number of requests is way below the value passed to `jsonRpcMaxPendingRequests`.
+- Fix `QueueFullError` being thrown even when the number of requests is way below the value passed to `jsonRpcMaxPendingRequests`. ([#1747](https://github.com/smol-dot/smoldot/pull/1747))
 
 ## 2.0.23 - 2024-03-20
 


### PR DESCRIPTION
Fix https://github.com/smol-dot/smoldot/issues/1745

Fixes a left-over from https://github.com/smol-dot/smoldot/pull/1685

It's not clear to me what is the cleanest way to properly enforce `max_pending_requests`, but we can't do it before #1436 anyway.


Work time: 15mn
