### PR TITLE
Simplify creation of JSON-RPC service in light client

### DIFF
--- a/light-base/src/json_rpc_service.rs
+++ b/light-base/src/json_rpc_service.rs
@@ -117,8 +117,7 @@ pub struct Config<TPlat: PlatformRef> {
 
 /// Creates a new JSON-RPC service with the given configuration.
 ///
-/// Returns a handler that allows sending requests, and a [`ServicePrototype`] that must later
-/// be initialized using [`ServicePrototype::start`].
+/// Returns a handler that allows sending requests and receiving responses.
 ///
 /// Destroying the [`Frontend`] automatically shuts down the service.
 pub fn service<TPlat: PlatformRef>(config: Config<TPlat>) -> Frontend<TPlat> {

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -929,16 +929,11 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
             max_subscriptions,
         } = config.json_rpc
         {
-            // TODO: the JSON-RPC service splits between first creation and actual services starting because starting the service couldn't be done immediately, since this is now the case considering merging the two together again
-            let (frontend, service_starter) = json_rpc_service::service(json_rpc_service::Config {
+            let frontend = json_rpc_service::service(json_rpc_service::Config {
                 platform: self.platform.clone(),
                 log_name: log_name.clone(), // TODO: add a way to differentiate multiple different json-rpc services under the same chain
                 max_pending_requests,
                 max_subscriptions,
-            });
-
-            service_starter.start(json_rpc_service::StartConfig {
-                platform: self.platform.clone(),
                 sync_service: services.sync_service.clone(),
                 network_service: services.network_service.clone(),
                 transactions_service: services.transactions_service.clone(),
@@ -950,7 +945,6 @@ impl<TPlat: platform::PlatformRef, TChain> Client<TPlat, TChain> {
                 system_name: self.platform.client_name().into_owned(),
                 system_version: self.platform.client_version().into_owned(),
                 genesis_block_hash,
-                genesis_block_state_root,
             });
 
             Some(frontend)


### PR DESCRIPTION
This was previously done in two steps due to API issues in lib.rs. These are now solved and we can merge these two steps into one.

Work time: 20mn