### PR TITLE
Remove `no-std-net` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,12 +1609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,7 +2300,6 @@ dependencies = [
  "libm",
  "libsecp256k1",
  "merlin",
- "no-std-net",
  "nom",
  "num-bigint",
  "num-rational",
@@ -2391,7 +2384,6 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "lru",
- "no-std-net",
  "parking_lot",
  "pin-project",
  "rand",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -59,7 +59,6 @@ libsecp256k1 = { version = "0.7.1", default-features = false, features = ["stati
 # The log` crate is forbidden, as it is very impolite to emit logs from a library.
 merlin = { version = "3.0", default-features = false }
 nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
-no-std-net = { version = "0.6.0", default-features = false }
 num-bigint = { version = "0.4.3", default-features = false }
 num-rational = { version = "0.4.1", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.18", default-features = false }

--- a/lib/src/libp2p/multiaddr.rs
+++ b/lib/src/libp2p/multiaddr.rs
@@ -20,7 +20,7 @@
 use alloc::{borrow::Cow, vec::Vec};
 use base64::Engine as _;
 use core::{
-    fmt, iter,
+    fmt, iter, net,
     str::{self, FromStr},
 };
 
@@ -250,13 +250,13 @@ impl<'a> Protocol<Cow<'a, [u8]>> {
             "ip4" => {
                 let string_ip = iter.next().ok_or(ParseError::UnexpectedEof)?;
                 let parsed =
-                    no_std_net::Ipv4Addr::from_str(string_ip).map_err(|_| ParseError::InvalidIp)?;
+                    net::Ipv4Addr::from_str(string_ip).map_err(|_| ParseError::InvalidIp)?;
                 Ok(Protocol::Ip4(parsed.octets()))
             }
             "ip6" => {
                 let string_ip = iter.next().ok_or(ParseError::UnexpectedEof)?;
                 let parsed =
-                    no_std_net::Ipv6Addr::from_str(string_ip).map_err(|_| ParseError::InvalidIp)?;
+                    net::Ipv6Addr::from_str(string_ip).map_err(|_| ParseError::InvalidIp)?;
                 Ok(Protocol::Ip6(parsed.octets()))
             }
             "p2p" => {
@@ -396,8 +396,8 @@ impl<T: AsRef<[u8]>> fmt::Display for Protocol<T> {
             Protocol::Dns4(addr) => write!(f, "/dns4/{addr}"),
             Protocol::Dns6(addr) => write!(f, "/dns6/{addr}"),
             Protocol::DnsAddr(addr) => write!(f, "/dnsaddr/{addr}"),
-            Protocol::Ip4(ip) => write!(f, "/ip4/{}", no_std_net::Ipv4Addr::from(*ip)),
-            Protocol::Ip6(ip) => write!(f, "/ip6/{}", no_std_net::Ipv6Addr::from(*ip)),
+            Protocol::Ip4(ip) => write!(f, "/ip4/{}", net::Ipv4Addr::from(*ip)),
+            Protocol::Ip6(ip) => write!(f, "/ip6/{}", net::Ipv6Addr::from(*ip)),
             Protocol::P2p(multihash) => {
                 // Base58 encoding doesn't have `/` in its characters set.
                 write!(f, "/p2p/{}", bs58::encode(multihash.as_ref()).into_string())

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -29,7 +29,6 @@ hashbrown = { version = "0.14.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 itertools = { version = "0.12.1", default-features = false, features = ["use_alloc"] }
 lru = { version = "0.12.0", default-features = false, features = ["hashbrown"] } # The `hashbrown` feature brings no-std compatibility.
-no-std-net = { version = "0.6.0", default-features = false }
 pin-project = "1.1.5"
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_chacha = { version = "0.3.1", default-features = false }


### PR DESCRIPTION
Since #1744, this dependency is no longer necessary.

Work time: 5mn