### PR TITLE
Revert `zeroize` to v1.7.0

### DIFF
--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -39,4 +39,4 @@ soketto = { version = "0.8.0", features = ["deflate"] }
 smol = "2.0.0"
 smoldot = { version = "0.17.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.3.0"
-zeroize = { version = "1.8.0", default-features = false, features = ["alloc"] }
+zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -78,7 +78,7 @@ smallvec = { version = "1.13.2", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
 wasmi = { version = "0.32.0-beta.10", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
-zeroize = { version = "1.8.0", default-features = false, features = ["alloc"] }
+zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }
 
 # `database-sqlite` feature
 rusqlite = { version = "0.31.0", optional = true, default-features = false, features = ["bundled"] }

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { version = "1.0.104", default-features = false, features = ["alloc
 siphasher = { version = "1.0.1", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smoldot = { version = "0.17.0", path = "../lib", default-features = false }
-zeroize = { version = "1.8.0", default-features = false, features = ["alloc"] }
+zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }
 
 # `std` feature
 # Add here the crates that cannot function without the help of the operating system or environment.


### PR DESCRIPTION
Apparently they yanked `zeroize` v1.8 (https://crates.io/crates/zeroize/versions) and this broke smoldot's CI.

Work time: 5mn