### PR TITLE
Publish v2.0.27 and new versions on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arrayvec 0.7.4",
  "async-lock",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-full-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-channel",
  "blake2-rfc",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light-wasm"
-version = "2.0.26"
+version = "2.0.27"
 dependencies = [
  "async-lock",
  "async-task",

--- a/full-node/Cargo.toml
+++ b/full-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-full-node"
-version = "0.8.0"
+version = "0.9.0"
 description = "Substrate/Polkadot full node using smoldot"
 authors.workspace = true
 license.workspace = true
@@ -37,6 +37,6 @@ serde_json = { version = "1.0.104", default-features = false, features = ["std"]
 siphasher = { version = "1.0.1", default-features = false }
 soketto = { version = "0.8.0", features = ["deflate"] }
 smol = "2.0.0"
-smoldot = { version = "0.17.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
+smoldot = { version = "0.18.0", path = "../lib", default-features = false, features = ["database-sqlite", "std", "wasmtime"] }
 terminal_size = "0.3.0"
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot"
-version = "0.17.0"
+version = "0.18.0"
 description = "Primitives to build a client for Substrate-based blockchains"
 documentation = "https://docs.rs/smoldot"
 keywords = ["blockchain", "peer-to-peer"]

--- a/light-base/Cargo.toml
+++ b/light-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light"
-version = "0.15.0"
+version = "0.16.0"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true
@@ -36,7 +36,7 @@ serde = { version = "1.0.183", default-features = false, features = ["alloc", "d
 serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 siphasher = { version = "1.0.1", default-features = false }
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "0.17.0", path = "../lib", default-features = false }
+smoldot = { version = "0.18.0", path = "../lib", default-features = false }
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }
 
 # `std` feature

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
-### Changed
+## 2.0.27 - 2024-05-29
+
+Maintenance release with no significant changes.
 
 ## 2.0.26 - 2024-05-07
+
+### Changed
 
 - When it comes to determining which peers know which block, smoldot now assumes that all parachain nodes know all paraheads found in the relay chain. This solves some issues when. ([#1812](https://github.com/smol-dot/smoldot/pull/1812))
 

--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smoldot",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smoldot",
-      "version": "2.0.26",
+      "version": "2.0.27",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoldot",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "Light client that connects to Polkadot and Substrate-based blockchains",
   "contributors": [
     "Parity Technologies <admin@parity.io>",

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smoldot-light-wasm"
-version = "2.0.26"
+version = "2.0.27"
 description = "Browser bindings to a light client for Substrate-based blockchains"
 authors.workspace = true
 license.workspace = true
@@ -29,5 +29,5 @@ hashbrown = { version = "0.14.0", default-features = false }
 nom = { version = "7.1.3", default-features = false }
 pin-project = "1.1.5"
 slab = { version = "0.4.8", default-features = false }
-smoldot = { version = "0.17.0", path = "../../lib", default-features = false }
-smoldot-light = { version = "0.15.0", path = "../../light-base", default-features = false }
+smoldot = { version = "0.18.0", path = "../../lib", default-features = false }
+smoldot-light = { version = "0.16.0", path = "../../light-base", default-features = false }


### PR DESCRIPTION
Since some people that don't use Cargo.lock files properly had problems with the wasmi beta version, I'm publishing a new version of smoldot now that wasmi is properly released.