### PR TITLE
Replace cloudflare-ipfs.com with ipfs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Where "crash" includes: Rust panics, JavaScript exceptions (except for the ones 
 
 In order to run the wasm light node, you must have installed [rustup](https://rustup.rs/).
 
-The wasm light node can be tested with `cd wasm-node/javascript` and `npm install; npm start`. This will compile the smoldot wasm light node and start a WebSocket server capable of answering JSON-RPC requests. This demo will print a list of URLs that you can navigate to in order to connect to a certain chain. For example you can navigate to <https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2Fwestend2> in order to interact with the Westend chain.
+The wasm light node can be tested with `cd wasm-node/javascript` and `npm install; npm start`. This will compile the smoldot wasm light node and start a WebSocket server capable of answering JSON-RPC requests. This demo will print a list of URLs that you can navigate to in order to connect to a certain chain. For example you can navigate to <https://ipfs.io/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2Fwestend2> in order to interact with the Westend chain.
 
 > Note: The `npm start` command starts a small JavaScript shim, on top of the wasm light node, that hard codes the chain to Westend and starts the WebSocket server. The wasm light node itself can connect to a variety of different chains (not only Westend) and doesn't start any server.
 

--- a/full-node/bin/main.rs
+++ b/full-node/bin/main.rs
@@ -408,7 +408,7 @@ async fn run(cli_options: cli::CliOptionsRun) {
             smoldot_full_node::LogLevel::Info,
             format!(
                 "JSON-RPC server listening on {addr}. Visit \
-                <https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=ws%3A%2F%2F{addr}> in order to \
+                <https://ipfs.io/ipns/dotapps.io/?rpc=ws%3A%2F%2F{addr}> in order to \
                 interact with the node."
             ),
         );

--- a/lib/src/json_rpc.rs
+++ b/lib/src/json_rpc.rs
@@ -35,7 +35,7 @@
 //! applications are connected to the node using the JSON-RPC protocol.
 //!
 //! > **Note**: An example application that can be put on top of a node is
-//! >           [PolkadotJS Apps](https://cloudflare-ipfs.com/ipns/dotapps.io/).
+//! >           [PolkadotJS Apps](https://ipfs.io/ipns/dotapps.io/).
 //!
 //! Contrary to the traffic with the blockchain network, the communication between the JSON-RPC
 //! client (i.e. the application) and the JSON-RPC server (i.e. the node) is not trustless. In

--- a/wasm-node/javascript/demo/demo-deno.ts
+++ b/wasm-node/javascript/demo/demo-deno.ts
@@ -51,7 +51,7 @@ client.addChain({ chainSpec, disableJsonRpc: true });
 
 // Now spawn a WebSocket server in order to handle JSON-RPC clients.
 console.log('JSON-RPC server now listening on port 9944');
-console.log('Please visit: https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944');
+console.log('Please visit: https://ipfs.io/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944');
 
 const conn = Deno.listen({ port: 9944 });
 const httpConn = Deno.serveHttp(await conn.accept());

--- a/wasm-node/javascript/demo/demo.mjs
+++ b/wasm-node/javascript/demo/demo.mjs
@@ -127,7 +127,7 @@ let wsServer = new WebSocketServer({
 console.log('JSON-RPC server now listening on port 9944');
 console.log('Please visit one of:');
 for (const chainId in chainSpecsById) {
-    console.log('- ' + chainId + ': https://cloudflare-ipfs.com/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2F' + chainId);
+    console.log('- ' + chainId + ': https://ipfs.io/ipns/dotapps.io/?rpc=ws%3A%2F%2F127.0.0.1%3A9944%2F' + chainId);
 }
 console.log('');
 


### PR DESCRIPTION
CloudFlare's IPFS portal is very slow, and they have announced shutting down in the future.