### PR TITLE
feat: JSON-RPC responses async iterable iterator

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add `jsonRpcResponses` async iterable iterator to `Chain` connection
+
 ### Fixed
 
 - Fix potential panic in parachain syncing code. ([#1912](https://github.com/smol-dot/smoldot/pull/1912))

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `jsonRpcResponses` async iterable iterator to `Chain` connection
+- Add `jsonRpcResponses` async iterable iterator to `Chain`, as a more convenient alternative to the `nextJsonRpcResponse` function. ([#1937](https://github.com/smol-dot/smoldot/pull/1937))
 
 ### Fixed
 

--- a/wasm-node/javascript/demo/demo-deno.ts
+++ b/wasm-node/javascript/demo/demo-deno.ts
@@ -69,8 +69,7 @@ while(true) {
 
     (async () => {
         try {
-            while(true) {
-                const response = await chain.nextJsonRpcResponse();
+            for await (const response of chain.jsonRpcResponses) {
                 socket.send(response);
             }
         } catch(_error) {}

--- a/wasm-node/javascript/demo/demo.mjs
+++ b/wasm-node/javascript/demo/demo.mjs
@@ -162,8 +162,7 @@ wsServer.on('connection', function (connection, request) {
 
             (async () => {
                 try {
-                    while(true) {
-                        const response = await para.nextJsonRpcResponse();
+                    for await (const response of para.jsonRpcResponses) {
                         connection.send(response);
                     }
                 } catch(_error) {}
@@ -177,8 +176,7 @@ wsServer.on('connection', function (connection, request) {
 
             (async () => {
                 try {
-                    while(true) {
-                        const response = await relay.nextJsonRpcResponse();
+                    for await (const response of relay.jsonRpcResponses) {
                         connection.send(response);
                     }
                 } catch(_error) {}

--- a/wasm-node/javascript/src/public-types.ts
+++ b/wasm-node/javascript/src/public-types.ts
@@ -178,6 +178,20 @@ export interface Chain {
     nextJsonRpcResponse(): Promise<string>;
 
     /**
+     * JSON-RPC responses or notifications async iterable.
+     *
+     * Each chain contains a buffer of the responses waiting to be sent out. Iterating over this
+     * pulls one element from the buffer. If the iteration happen at a slower rate than
+     * responses are generated, then the buffer will eventually become full, at which point calling
+     * {@link Chain.sendJsonRpc} will throw an exception. The size of this buffer can be configured
+     * through {@link AddChainOptions.jsonRpcMaxPendingRequests}.
+     *
+     * @throws {@link JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.
+     * @throws {@link CrashError} If the background client has crashed.
+     */
+    readonly jsonRpcResponses: AsyncIterableIterator<string>
+
+    /**
      * Disconnects from the blockchain.
      *
      * Any on-going call to {@link Chain.nextJsonRpcResponse} is instantaneously aborted and will


### PR DESCRIPTION
Add support for the [`for await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) statement for handling responses.

Currently, to listen to all responses, you would use a `while` loop like this:

```ts
try {
  while (true) {
    const response = await chain.nextJsonRpcResponse();
    console.info(response);
  }
} catch (error) {
  if (error instanceof AlreadyDestroyedError) {
    console.info("No more responses");
  } else {
    console.error(error);
  }
}
```

This PR introduces a more concise syntax:

```ts
try {
  for await (const response of chain.jsonRpcResponses) {
    console.log(response);
  }
  console.info("No more responses");
} catch (error) {
  console.error(error);
}
```

In addition to the syntactic improvement and avoiding the `while` loop, this approach allows for closing the stream without requiring an error to be thrown.