### PR TITLE
Update to Rust 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add wasm32-unknown-unknown
@@ -66,7 +66,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -100,7 +100,7 @@ jobs:
   check-no-std:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add thumbv7m-none-eabi
@@ -112,7 +112,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -121,7 +121,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -176,7 +176,7 @@ jobs:
   wasm-node-versions-match:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
       - run: apt-get update && apt install -y jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,7 +217,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: 1.81
+          toolchain: 1.82
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
   build-js-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
   build-rust-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - run: apt update && apt install -y jq
       - run: rustup component add llvm-tools-preview
@@ -174,7 +174,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
@@ -244,7 +244,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
       - uses: actions/checkout@v4
       - run: cargo publish --dry-run --locked

--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-update:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.81
+      image: rust:1.82
     steps:
     - uses: actions/checkout@v4
     # Note: `cargo update --workspace` doesn't seem to have any effect.

--- a/lib/src/executor/host/tests/hash_algorithms.rs
+++ b/lib/src/executor/host/tests/hash_algorithms.rs
@@ -33,7 +33,7 @@ extern "C" {
     fn ext_hashing_keccak_256_version_1(ptrsz: i64) -> i32;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn test(_param_ptr: i32, _param_sz: i32) -> i64 {
     let slice = b"hello world";
     let ptrsz = u64::from(slice.len() as u32) << 32 | u64::from(slice.as_ptr() as usize as u32);
@@ -77,7 +77,7 @@ macro_rules! gen_test {
                     fn ext_hashing_keccak_256_version_1(ptrsz: i64) -> i32;
                 }
 
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 extern "C" fn test(_param_ptr: i32, _param_sz: i32) -> i64 {
                     let slice = b"hello world";
                     let ptrsz = u64::from(slice.len() as u32) << 32 | u64::from(slice.as_ptr() as usize as u32);

--- a/lib/src/executor/host/tests/run.rs
+++ b/lib/src/executor/host/tests/run.rs
@@ -92,7 +92,7 @@ fn function_to_run_invalid_params() {
 fn input_provided_correctly() {
     /* Source code:
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_param_ptr: i32, _param_sz: i32) -> i64 {
             let inparam: &[u8] = unsafe {
                 core::slice::from_raw_parts(
@@ -299,7 +299,7 @@ fn input_provided_correctly() {
 fn large_input_provided_correctly() {
     /* Source code:
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_param_ptr: i32, _param_sz: i32) -> i64 {
             let inparam: &[u8] = unsafe {
                 core::slice::from_raw_parts(
@@ -413,7 +413,7 @@ fn return_value_works() {
 
         static OUT: &[u8] = b"hello world";
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_: i32, _: i32) -> i64 {
             let ptr = OUT.as_ptr() as usize as u32;
             let sz = OUT.len() as u32;
@@ -482,7 +482,7 @@ fn return_value_works() {
 fn bad_return_value() {
     /* Source code:
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_: i32, _: i32) -> i32 {
             0
         }
@@ -546,7 +546,7 @@ fn bad_return_value() {
 fn returned_ptr_out_of_range() {
     /* Source code:
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_: i32, _: i32) -> i64 {
             let ptr = 0xffff_fff0usize as u32;
             let sz = 5 as u32;
@@ -613,7 +613,7 @@ fn returned_ptr_out_of_range() {
 fn returned_size_out_of_range() {
     /* Source code:
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_: i32, _: i32) -> i64 {
             let ptr = 5 as u32;
             let sz = 0xffff_fff0usize as u32;
@@ -683,7 +683,7 @@ fn unresolved_host_function_called() {
             fn host_function_that_doesnt_exist();
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "C" fn test(_: i32, _: i32) -> i64 {
             unsafe {
                 host_function_that_doesnt_exist()

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -102,14 +102,12 @@ fn add_chain(
             // updated regularly to account for changes in the implementation.
             if allocator::total_alloc_bytes() >= usize::MAX - 400 * 1024 * 1024 {
                 client_lock.chains.remove(outer_chain_id);
-                unsafe {
-                    let error = "Wasm node is running low on memory and will prevent any new chain from being added";
-                    bindings::chain_initialized(
-                        outer_chain_id_u32,
-                        u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
-                        u32::try_from(error.as_bytes().len()).unwrap(),
-                    );
-                }
+                let error = "Wasm node is running low on memory and will prevent any new chain from being added";
+                bindings::chain_initialized(
+                    outer_chain_id_u32,
+                    u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
+                    u32::try_from(error.as_bytes().len()).unwrap(),
+                );
                 return;
             }
 
@@ -141,14 +139,12 @@ fn add_chain(
                 Ok(c) => c,
                 Err(error) => {
                     client_lock.chains.remove(outer_chain_id);
-                    unsafe {
                         let error = error.to_string();
                         bindings::chain_initialized(
                             outer_chain_id_u32,
                             u32::try_from(error.as_bytes().as_ptr() as usize).unwrap(),
                             u32::try_from(error.as_bytes().len()).unwrap(),
                         );
-                    }
                     return;
                 }
             };
@@ -180,10 +176,7 @@ fn add_chain(
                 *json_rpc_responses_rx = json_rpc_responses;
             }
 
-            unsafe {
-                bindings::chain_initialized(outer_chain_id_u32, 0, 0);
-            }
-
+            bindings::chain_initialized(outer_chain_id_u32, 0, 0);
         },
     );
 
@@ -331,7 +324,7 @@ struct JsonRpcResponsesNonEmptyWaker {
 
 impl alloc::task::Wake for JsonRpcResponsesNonEmptyWaker {
     fn wake(self: Arc<Self>) {
-        unsafe { bindings::json_rpc_responses_non_empty(self.chain_id) }
+        bindings::json_rpc_responses_non_empty(self.chain_id)
     }
 }
 
@@ -350,8 +343,6 @@ fn advance_execution() {
     runnable.run();
 
     if !TASKS_QUEUE.is_empty() {
-        unsafe {
-            bindings::advance_execution_ready();
-        }
+        bindings::advance_execution_ready();
     }
 }

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -52,11 +52,11 @@ fn init(max_log_level: u32) {
 }
 
 fn add_chain(
-    chain_spec: Vec<u8>,
-    database_content: Vec<u8>,
+    chain_spec: Box<[u8]>,
+    database_content: Box<[u8]>,
     json_rpc_max_pending_requests: u32,
     json_rpc_max_subscriptions: u32,
-    potential_relay_chains: Vec<u8>,
+    potential_relay_chains: Box<[u8]>,
 ) -> u32 {
     let mut client_lock = CLIENT.try_lock().unwrap();
 
@@ -212,9 +212,9 @@ fn remove_chain(chain_id: u32) {
     }
 }
 
-fn json_rpc_send(json_rpc_request: Vec<u8>, chain_id: u32) -> u32 {
+fn json_rpc_send(json_rpc_request: Box<[u8]>, chain_id: u32) -> u32 {
     // As mentioned in the documentation, the bytes *must* be valid UTF-8.
-    let json_rpc_request: String = String::from_utf8(json_rpc_request)
+    let json_rpc_request: String = String::from_utf8(json_rpc_request.to_vec())
         .unwrap_or_else(|_| panic!("non-UTF-8 JSON-RPC request"));
 
     let mut client_lock = CLIENT.try_lock().unwrap();

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -975,7 +975,7 @@ struct Stream {
 
 pub(crate) fn connection_multi_stream_set_handshake_info(
     connection_id: u32,
-    handshake_ty: Vec<u8>,
+    handshake_ty: Box<[u8]>,
 ) {
     let (_, local_tls_certificate_sha256) = nom::sequence::preceded(
         nom::bytes::streaming::tag::<_, _, nom::error::Error<&[u8]>>(&[0]),
@@ -1033,7 +1033,7 @@ pub(crate) fn stream_writable_bytes(connection_id: u32, stream_id: u32, bytes: u
     stream.something_happened.notify(usize::MAX);
 }
 
-pub(crate) fn stream_message(connection_id: u32, stream_id: u32, message: Vec<u8>) {
+pub(crate) fn stream_message(connection_id: u32, stream_id: u32, message: Box<[u8]>) {
     let mut lock = STATE.try_lock().unwrap();
 
     let connection = lock.connections.get_mut(&connection_id).unwrap();
@@ -1088,7 +1088,7 @@ pub(crate) fn stream_message(connection_id: u32, stream_id: u32, message: Vec<u8
     }
 
     stream.messages_queue_total_size += message.len();
-    stream.messages_queue.push_back(message.into_boxed_slice());
+    stream.messages_queue.push_back(message);
     stream.something_happened.notify(usize::MAX);
 }
 
@@ -1132,7 +1132,7 @@ pub(crate) fn connection_stream_opened(connection_id: u32, stream_id: u32, outbo
     }
 }
 
-pub(crate) fn connection_reset(connection_id: u32, message: Vec<u8>) {
+pub(crate) fn connection_reset(connection_id: u32, message: Box<[u8]>) {
     let message = str::from_utf8(&message)
         .unwrap_or_else(|_| panic!("non-UTF-8 message"))
         .to_owned();
@@ -1173,7 +1173,7 @@ pub(crate) fn connection_reset(connection_id: u32, message: Vec<u8>) {
     }
 }
 
-pub(crate) fn stream_reset(connection_id: u32, stream_id: u32, message: Vec<u8>) {
+pub(crate) fn stream_reset(connection_id: u32, stream_id: u32, message: Box<[u8]>) {
     let message: String = str::from_utf8(&message)
         .unwrap_or_else(|_| panic!("non-UTF-8 message"))
         .to_owned();

--- a/wasm-node/rust/src/timers.rs
+++ b/wasm-node/rust/src/timers.rs
@@ -47,12 +47,12 @@ pub struct Delay {
 
 impl Delay {
     pub fn new(after: Duration) -> Self {
-        let now = unsafe { Duration::from_micros(bindings::monotonic_clock_us()) };
+        let now = Duration::from_micros(bindings::monotonic_clock_us());
         Self::new_inner(now + after, now)
     }
 
     pub fn new_at_monotonic_clock(when: Duration) -> Self {
-        let now = unsafe { Duration::from_micros(bindings::monotonic_clock_us()) };
+        let now = Duration::from_micros(bindings::monotonic_clock_us());
         Self::new_inner(when, now)
     }
 
@@ -200,7 +200,7 @@ fn process_timers() {
     let mut lock = TIMERS.try_lock().unwrap();
     let lock = &mut *lock;
 
-    let now = unsafe { Duration::from_micros(bindings::monotonic_clock_us()) };
+    let now = Duration::from_micros(bindings::monotonic_clock_us());
 
     // Note that this function can be called spuriously.
     // For example, `process_timers` can be scheduled twice from two different timers, and the
@@ -270,5 +270,5 @@ fn start_timer(duration: Duration) {
     // Note that ideally `duration` should be rounded up in order to make sure that it is not
     // truncated, but the precision of an `f64` is so high and the precision of the operating
     // system generally so low that this is not worth dealing with.
-    unsafe { bindings::start_timer(duration.as_secs_f64() * 1000.0) }
+    bindings::start_timer(duration.as_secs_f64() * 1000.0)
 }


### PR DESCRIPTION
This PR updates to Rust 1.82.

The main change is in the safety of the bindings with the JS.

After some thinking, it seems to me that all functions where the JS reads memory from the Rust are safe. Yes the JS might throw an exception for example if the pointer is out of range, but that's similar to a Rust panic and not something unsafe.

The functions where the JS writes to the Rust memory are, of course, unsafe. Calling `buffer_copy(0, rand::random())` is a very bad idea.

Work time: 30mn