### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,12 +2493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "string-interner"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,13 +2648,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "d09466de2fbca05ea830e16e62943f26607ab2148fb72b642505541711d99ad2"
 
 [[package]]
 name = "typenum"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -75,7 +75,7 @@ sha3 = { version = "0.10.8", default-features = false }
 siphasher = { version = "1.0.1", default-features = false }
 slab = { version = "0.4.8", default-features = false }
 smallvec = { version = "1.13.2", default-features = false }
-twox-hash = { version = "1.6.3", default-features = false }
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
 wasmi = { version = "0.38.0", default-features = false }
 x25519-dalek = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "precomputed-tables", "static_secrets", "zeroize"] }
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -1794,27 +1794,24 @@ impl ReadyToRun {
                     .alloc_write_and_return_pointer(host_fn.name(), iter::once(out.as_bytes()))
             }
             HostFunction::ext_hashing_twox_64_version_1 => {
-                let mut h0 = twox_hash::XxHash::with_seed(0);
+                let r0 =
                 {
                     let data = expect_pointer_size!(0);
-                    h0.write(data.as_ref());
-                }
-                let r0 = h0.finish();
+                    twox_hash::XxHash64::oneshot(0, data.as_ref())
+                };
 
                 self.inner
                     .alloc_write_and_return_pointer(host_fn.name(), iter::once(&r0.to_le_bytes()))
             }
             HostFunction::ext_hashing_twox_128_version_1 => {
-                let mut h0 = twox_hash::XxHash::with_seed(0);
-                let mut h1 = twox_hash::XxHash::with_seed(1);
-                {
+                let [r0, r1] = {
                     let data = expect_pointer_size!(0);
                     let data = data.as_ref();
-                    h0.write(data);
-                    h1.write(data);
-                }
-                let r0 = h0.finish();
-                let r1 = h1.finish();
+                    [
+                        twox_hash::XxHash64::oneshot(0, data),
+                        twox_hash::XxHash64::oneshot(1, data),
+                    ]
+                };
 
                 self.inner.alloc_write_and_return_pointer(
                     host_fn.name(),
@@ -1822,22 +1819,16 @@ impl ReadyToRun {
                 )
             }
             HostFunction::ext_hashing_twox_256_version_1 => {
-                let mut h0 = twox_hash::XxHash::with_seed(0);
-                let mut h1 = twox_hash::XxHash::with_seed(1);
-                let mut h2 = twox_hash::XxHash::with_seed(2);
-                let mut h3 = twox_hash::XxHash::with_seed(3);
-                {
+                let [r0, r1, r2, r3] = {
                     let data = expect_pointer_size!(0);
                     let data = data.as_ref();
-                    h0.write(data);
-                    h1.write(data);
-                    h2.write(data);
-                    h3.write(data);
-                }
-                let r0 = h0.finish();
-                let r1 = h1.finish();
-                let r2 = h2.finish();
-                let r3 = h3.finish();
+                    [
+                        twox_hash::XxHash64::oneshot(0, data),
+                        twox_hash::XxHash64::oneshot(1, data),
+                        twox_hash::XxHash64::oneshot(2, data),
+                        twox_hash::XxHash64::oneshot(3, data),
+                    ]
+                };
 
                 self.inner.alloc_write_and_return_pointer(
                     host_fn.name(),

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -200,7 +200,7 @@ use super::{allocator, vm};
 use crate::{trie, util};
 
 use alloc::{borrow::ToOwned as _, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
-use core::{fmt, hash::Hasher as _, iter, str};
+use core::{fmt, iter, str};
 use functions::HostFunction;
 
 pub mod runtime_version;
@@ -1794,8 +1794,7 @@ impl ReadyToRun {
                     .alloc_write_and_return_pointer(host_fn.name(), iter::once(out.as_bytes()))
             }
             HostFunction::ext_hashing_twox_64_version_1 => {
-                let r0 =
-                {
+                let r0 = {
                     let data = expect_pointer_size!(0);
                     twox_hash::XxHash64::oneshot(0, data.as_ref())
                 };


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.