### PR TITLE
Update CI NodeJS version from 16 to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - uses: actions/setup-node@v4.0.3
       with:
-        node-version: '16'  # An old version is used to ensure compatibility
+        # Set to the oldest version still maintained, in order to ensure compatibility. See <https://nodejs.dev/en/about/releases/>
+        node-version: '18'
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,8 +180,8 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/setup-node@v4.0.3
         with:
-          # Set the oldest version still maintained, in order to ensure compatibility. See <https://nodejs.dev/en/about/releases/>
-          node-version: 16
+          # Set to the oldest version still maintained, in order to ensure compatibility. See <https://nodejs.dev/en/about/releases/>
+          node-version: 18
       - uses: Swatinem/rust-cache@v2
       - run: npm install
         working-directory: ./wasm-node/javascript
@@ -209,7 +209,8 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/setup-node@v4.0.3
         with:
-          node-version: 16
+          # Set to the oldest version still maintained, in order to ensure compatibility. See <https://nodejs.dev/en/about/releases/>
+          node-version: 18
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x


### PR DESCRIPTION
v16 has left long time support since September 2023.
https://github.com/nodejs/release?tab=readme-ov-file#release-schedule