### PR TITLE
Revert "Bump typescript from 5.4.5 to 5.6.3 in /wasm-node/javascript"

### DIFF
--- a/wasm-node/javascript/package-lock.json
+++ b/wasm-node/javascript/package-lock.json
@@ -18,7 +18,7 @@
         "ava": "^6.0.0",
         "dtslint": "^4.0.6",
         "typedoc": "^0.25.4",
-        "typescript": "^5.6.3"
+        "typescript": "^5.3.2"
       }
     },
     "node_modules/@definitelytyped/header-parser": {
@@ -3908,9 +3908,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/wasm-node/javascript/package.json
+++ b/wasm-node/javascript/package.json
@@ -81,6 +81,6 @@
     "ava": "^6.0.0",
     "dtslint": "^4.0.6",
     "typedoc": "^0.25.4",
-    "typescript": "^5.6.3"
+    "typescript": "^5.3.2"
   }
 }


### PR DESCRIPTION
Reverts smol-dot/smoldot#1993

I don't know what's wrong again with NPM that it can't resolve dependencies, but it's tiring.
