### PR TITLE
Make ECDSA signature verification customizable

### DIFF
--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -3503,6 +3503,9 @@ pub async fn runtime_call(
             runtime_call::RuntimeCall::SignatureVerification(sig) => {
                 call = sig.verify_and_resume();
             }
+            runtime_call::RuntimeCall::EcdsaPublicKeyRecover(sig) => {
+                call = sig.verify_and_resume();
+            }
             runtime_call::RuntimeCall::Offchain(_) => {
                 // Offchain storage calls are forbidden.
                 return Err(RuntimeCallError::ForbiddenHostFunction);

--- a/full-node/src/json_rpc_service/requests_handler.rs
+++ b/full-node/src/json_rpc_service/requests_handler.rs
@@ -473,6 +473,9 @@ pub fn spawn_requests_handler(config: Config) {
                                 executor::runtime_call::RuntimeCall::SignatureVerification(req) => {
                                     call = req.verify_and_resume();
                                 }
+                                executor::runtime_call::RuntimeCall::EcdsaPublicKeyRecover(req) => {
+                                    call = req.verify_and_resume();
+                                }
                                 executor::runtime_call::RuntimeCall::Offchain(_) => {
                                     request.fail(service::ErrorResponse::InternalError);
                                     break;

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -837,6 +837,9 @@ impl ChainInformationBuild {
                 runtime_call::RuntimeCall::SignatureVerification(sig) => {
                     call = sig.verify_and_resume();
                 }
+                runtime_call::RuntimeCall::EcdsaPublicKeyRecover(sig) => {
+                    call = sig.verify_and_resume();
+                }
                 runtime_call::RuntimeCall::OffchainStorageSet(req) => {
                     // Do nothing.
                     call = req.resume();

--- a/lib/src/executor/runtime_call/tests.rs
+++ b/lib/src/executor/runtime_call/tests.rs
@@ -116,6 +116,7 @@ fn execute_blocks() {
                     panic!("Error during test #{}: {:?}", test_num, err)
                 }
                 RuntimeCall::SignatureVerification(sig) => execution = sig.verify_and_resume(),
+                RuntimeCall::EcdsaPublicKeyRecover(sig) => execution = sig.verify_and_resume(),
                 RuntimeCall::ClosestDescendantMerkleValue(req) => execution = req.resume_unknown(),
                 RuntimeCall::StorageGet(get) => {
                     let value = storage

--- a/lib/src/transactions/validate/tests.rs
+++ b/lib/src/transactions/validate/tests.rs
@@ -95,6 +95,9 @@ fn validate_from_proof() {
             runtime_call::RuntimeCall::SignatureVerification(r) => {
                 validation_in_progress = r.verify_and_resume()
             }
+            runtime_call::RuntimeCall::EcdsaPublicKeyRecover(r) => {
+                validation_in_progress = r.verify_and_resume()
+            }
             runtime_call::RuntimeCall::LogEmit(r) => validation_in_progress = r.resume(),
             runtime_call::RuntimeCall::OffchainStorageSet(r) => validation_in_progress = r.resume(),
             runtime_call::RuntimeCall::Offchain(_) => panic!(),

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -3153,6 +3153,13 @@ async fn runtime_call_single_attempt<TPlat: PlatformRef>(
                     platform.now() - runtime_call_duration_before;
                 continue;
             }
+            executor::runtime_call::RuntimeCall::EcdsaPublicKeyRecover(r) => {
+                let runtime_call_duration_before = platform.now();
+                call = r.verify_and_resume();
+                timing.virtual_machine_call_duration +=
+                    platform.now() - runtime_call_duration_before;
+                continue;
+            }
             executor::runtime_call::RuntimeCall::LogEmit(r) => {
                 // Logs are ignored.
                 let runtime_call_duration_before = platform.now();


### PR DESCRIPTION
Close https://github.com/smol-dot/smoldot/issues/2016

This adds a new variant to the runtime-call-enums, which this time concerns ECDSA signatures verification.
It works exactly the same way as `SignatureVerification`, except that you have to provide a public key on success. The possible errors are also more details than just "success" or "failure".

I went with panicking if the public key provided by the API user is invalid. This only concerns the case when `resume` instead of `verify_and_resume` is called. I don't want to expose the private types of `libsecp256k1`, and adding yet another type for parsing the public key seems cumbersome.

I haven't tested this code because I don't think that this is used in any of the relay chains, and I also don't know which parachain uses it and how to easily test this.
However, assuming that the code worked before (which isn't 100% sure for the same reasons), it should still work as the changes were pretty straight forward.


Work time: 1h