### PR TITLE
Fix `best_output_block_updated` erroneously remaining at `false`

### DIFF
--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix panic in transactions service when the runtime service resets after having lost track of the head of the chain.
+- Fix panic in transactions service when the runtime service resets after having lost track of the head of the chain. ([#2029](https://github.com/smol-dot/smoldot/pull/2029))
 
 ## 2.0.30 - 2024-08-16
 

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix panic in transactions service when the runtime service resets after having lost track of the head of the chain.
+
 ## 2.0.30 - 2024-08-16
 
 ### Added


### PR DESCRIPTION
Fix #2023 
Fix #1941

Work time: 20mn