### PR TITLE
Fix runtime_call tests in no_std environment

### DIFF
--- a/lib/src/executor/runtime_call/tests.rs
+++ b/lib/src/executor/runtime_call/tests.rs
@@ -205,9 +205,13 @@ struct Block {
 #[derive(serde::Deserialize)]
 struct Storage {
     #[serde(rename = "mainTrie")]
-    main_trie: hashbrown::HashMap<HexString, HexString>,
+    main_trie: hashbrown::HashMap<HexString, HexString, fnv::FnvBuildHasher>,
     #[serde(rename = "childTries")]
-    child_tries: hashbrown::HashMap<HexString, hashbrown::HashMap<HexString, HexString>>,
+    child_tries: hashbrown::HashMap<
+        HexString,
+        hashbrown::HashMap<HexString, HexString, fnv::FnvBuildHasher>,
+        fnv::FnvBuildHasher,
+    >,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
It's not clear to me why CI doesn't catch this, but running `cargo test` currently fails due to the hasher not implementing the `Default` trait.
This PR fixes this.

Work time: 5mn