### PR TITLE
Remove all usage of `#[doc(cfg(...))]`

### DIFF
--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -69,7 +69,6 @@
 // TODO: better docs
 
 #![cfg(feature = "database-sqlite")]
-#![cfg_attr(docsrs, doc(cfg(feature = "database-sqlite")))]
 
 use crate::{
     chain::chain_information,

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -906,24 +906,6 @@ pub enum ExecHint {
         ),
         feature = "wasmtime"
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(
-            any(
-                all(
-                    target_arch = "x86_64",
-                    any(
-                        target_os = "windows",
-                        all(target_os = "linux", target_env = "gnu"),
-                        target_os = "macos"
-                    )
-                ),
-                all(target_arch = "aarch64", all(target_os = "linux", target_env = "gnu")),
-                all(target_arch = "s390x", all(target_os = "linux", target_env = "gnu"))
-            ),
-            feature = "wasmtime"
-        )))
-    )]
     ForceWasmtime,
 }
 

--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -41,7 +41,6 @@
 //! >           This keystore, being newly-written, doesn't have to follow them.
 
 #![cfg(feature = "std")]
-#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use crate::{identity::seed_phrase, util::SipHasherBuild};
 

--- a/lib/src/libp2p/websocket.rs
+++ b/lib/src/libp2p/websocket.rs
@@ -19,7 +19,6 @@
 //! socket through the `AsyncRead` and `AsyncWrite` traits.
 
 #![cfg(feature = "std")]
-#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 use futures_util::{future, AsyncRead, AsyncWrite, Future as _};
 

--- a/lib/src/libp2p/with_buffers.rs
+++ b/lib/src/libp2p/with_buffers.rs
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg(feature = "std")]
-#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 //! Augments an implementation of `AsyncRead` and `AsyncWrite` with a read buffer and a write
 //! buffer.

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -24,7 +24,6 @@ use futures_util::future;
 pub use smoldot::libp2p::read_write;
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use smoldot::libp2p::with_buffers;
 
 // TODO: this module should probably not be public?
@@ -34,7 +33,6 @@ pub mod default;
 mod with_prefix;
 
 #[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use default::DefaultPlatform;
 
 pub use with_prefix::WithPrefix;

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg(feature = "std")]
-#![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 
 //! Implementation of the [`PlatformRef`] trait that leverages the operating system.
 //!


### PR DESCRIPTION
We are currently relying on the fact that `docs.rs` enables usage of `doc(cfg(...))` in order to show extra information about the fact that some pieces of code are feature-gated behind a certain Cargo feature. Unfortunately, this was a bit hacky, and it looks like they disabled it now.

Close #2081