### PR TITLE
Update code base to Rust edition 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   test-64bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
   test-32bits:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - run: apt-get update && apt install -y libc6-dev-i386
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
   wasm-node-check:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add wasm32-unknown-unknown
@@ -67,7 +67,7 @@ jobs:
   check-features:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -101,7 +101,7 @@ jobs:
   check-no-std:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     - run: rustup target add thumbv7m-none-eabi
@@ -113,7 +113,7 @@ jobs:
   check-rustdoc-links:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
@@ -122,7 +122,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       # Checks `rustfmt` formatting
       - uses: actions/checkout@v4
@@ -136,7 +136,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
         # Since build artifacts are specific to a nightly version, we pin the specific nightly
@@ -177,7 +177,7 @@ jobs:
   wasm-node-versions-match:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
       - run: apt-get update && apt install -y jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
   build-js-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,7 +83,7 @@ jobs:
   build-rust-doc:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
   build-tests-coverage:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - run: apt update && apt install -y jq
       - run: rustup component add llvm-tools-preview
@@ -174,7 +174,7 @@ jobs:
   npm-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
@@ -218,7 +218,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Ideally we don't want to install any toolchain, but the GH action doesn't support this.
-          toolchain: 1.82
+          toolchain: 1.85
           profile: minimal
       - uses: Swatinem/rust-cache@v2
       - id: compute-tag  # Compute the tag that we might push.
@@ -245,7 +245,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
       - uses: actions/checkout@v4
       - run: cargo publish --dry-run --locked

--- a/.github/workflows/periodic-cargo-update.yml
+++ b/.github/workflows/periodic-cargo-update.yml
@@ -9,7 +9,7 @@ jobs:
   cargo-update:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.82
+      image: rust:1.85
     steps:
     - uses: actions/checkout@v4
     # Note: `cargo update --workspace` doesn't seem to have any effect.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/smol-dot/smoldot"
 include = ["**/*.rs"]  # Only Rust files are included, as anything else might be a test fixture.
 

--- a/full-node/bin/cli.rs
+++ b/full-node/bin/cli.rs
@@ -32,8 +32,8 @@
 use smoldot::{
     identity::seed_phrase,
     libp2p::{
-        multiaddr::{Multiaddr, Protocol},
         PeerId,
+        multiaddr::{Multiaddr, Protocol},
     },
 };
 use std::{io, net::SocketAddr, path::PathBuf};

--- a/full-node/src/consensus_service.rs
+++ b/full-node/src/consensus_service.rs
@@ -51,9 +51,7 @@ use smoldot::{
 use std::{
     array,
     borrow::Cow,
-    cmp,
-    future::Future,
-    iter,
+    cmp, iter,
     num::NonZero,
     pin::Pin,
     sync::Arc,

--- a/full-node/src/jaeger_service.rs
+++ b/full-node/src/jaeger_service.rs
@@ -36,9 +36,7 @@
 
 use smol::{future, net::UdpSocket};
 use smoldot::libp2p::PeerId;
-use std::{
-    convert::TryFrom as _, future::Future, io, net::SocketAddr, num::NonZero, pin::Pin, sync::Arc,
-};
+use std::{convert::TryFrom as _, io, net::SocketAddr, num::NonZero, pin::Pin, sync::Arc};
 
 /// Configuration for a [`JaegerService`].
 pub struct Config<'a> {

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -24,7 +24,6 @@ use smol::{
 };
 use smoldot::json_rpc::{methods, service};
 use std::{
-    future::Future,
     io, mem,
     net::SocketAddr,
     num::NonZero,

--- a/full-node/src/json_rpc_service.rs
+++ b/full-node/src/json_rpc_service.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{consensus_service, database_thread, network_service, LogCallback, LogLevel};
+use crate::{LogCallback, LogLevel, consensus_service, database_thread, network_service};
 use futures_channel::oneshot;
 use futures_util::FutureExt;
 use smol::{
@@ -30,8 +30,8 @@ use std::{
     num::NonZero,
     pin::Pin,
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc,
+        atomic::{AtomicU32, Ordering},
     },
     time::Duration,
 };
@@ -125,7 +125,7 @@ impl JsonRpcService {
                             return Err(InitError::ListenError {
                                 bind_address: *addr,
                                 error,
-                            })
+                            });
                         }
                     };
 
@@ -135,7 +135,7 @@ impl JsonRpcService {
                     return Err(InitError::ListenError {
                         bind_address: *addr,
                         error,
-                    })
+                    });
                 }
             },
             None => (None, None),

--- a/full-node/src/json_rpc_service/chain_head_subscriptions.rs
+++ b/full-node/src/json_rpc_service/chain_head_subscriptions.rs
@@ -25,7 +25,6 @@ use smoldot::{
     json_rpc::{methods, service},
 };
 use std::{
-    future::Future,
     num::NonZero,
     pin::{self, Pin},
     sync::Arc,

--- a/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
+++ b/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
@@ -662,7 +662,7 @@ impl SubscribeStorage {
 
     /// Returns the next storage change notification.
     pub async fn next_storage_update(
-        &'_ mut self,
+        &mut self,
     ) -> ([u8; 32], impl Iterator<Item = (Vec<u8>, Option<Vec<u8>>)>) {
         'main_subscription: loop {
             // Get the active consensus service subscription, or subscribe if necessary.

--- a/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
+++ b/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
@@ -19,7 +19,7 @@ use hashbrown::HashMap;
 use smol::stream::StreamExt as _;
 use smoldot::{
     chain::fork_tree,
-    executor::{host::HostVmPrototype, CoreVersion},
+    executor::{CoreVersion, host::HostVmPrototype},
     trie,
 };
 use std::{collections::BTreeSet, iter, mem, num::NonZero, ops, pin::Pin, sync::Arc};

--- a/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
+++ b/full-node/src/json_rpc_service/legacy_api_subscriptions.rs
@@ -663,10 +663,7 @@ impl SubscribeStorage {
     /// Returns the next storage change notification.
     pub async fn next_storage_update(
         &'_ mut self,
-    ) -> (
-        [u8; 32],
-        impl Iterator<Item = (Vec<u8>, Option<Vec<u8>>)> + '_,
-    ) {
+    ) -> ([u8; 32], impl Iterator<Item = (Vec<u8>, Option<Vec<u8>>)>) {
         'main_subscription: loop {
             // Get the active consensus service subscription, or subscribe if necessary.
             let subscription = match &mut self.subscription {

--- a/full-node/src/json_rpc_service/requests_handler.rs
+++ b/full-node/src/json_rpc_service/requests_handler.rs
@@ -30,9 +30,9 @@ use std::{
 };
 
 use crate::{
-    consensus_service, database_thread,
+    LogCallback, LogLevel, consensus_service, database_thread,
     json_rpc_service::{legacy_api_subscriptions, runtime_caches_service},
-    network_service, LogCallback, LogLevel,
+    network_service,
 };
 
 pub struct Config {

--- a/full-node/src/json_rpc_service/requests_handler.rs
+++ b/full-node/src/json_rpc_service/requests_handler.rs
@@ -23,7 +23,6 @@ use smoldot::{
     trie,
 };
 use std::{
-    future::Future,
     iter,
     pin::{self, Pin},
     sync::Arc,

--- a/full-node/src/lib.rs
+++ b/full-node/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 // TODO: #![deny(unused_crate_dependencies)] doesn't work because some deps are used only by the binary, figure if this can be fixed?
 
-use futures_util::{future, StreamExt as _};
+use futures_util::{StreamExt as _, future};
 use rand::RngCore as _;
 use smol::lock::Mutex;
 use smoldot::{

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -29,7 +29,7 @@
 
 use crate::{LogCallback, LogLevel, database_thread, jaeger_service};
 
-use core::{cmp, future::Future, mem, pin::Pin, task::Poll, time::Duration};
+use core::{cmp, mem, pin::Pin, task::Poll, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
 use futures_util::stream::{self, SelectAll};

--- a/full-node/src/network_service.rs
+++ b/full-node/src/network_service.rs
@@ -27,7 +27,7 @@
 // TODO: doc
 // TODO: re-review this once finished
 
-use crate::{database_thread, jaeger_service, LogCallback, LogLevel};
+use crate::{LogCallback, LogLevel, database_thread, jaeger_service};
 
 use core::{cmp, future::Future, mem, pin::Pin, task::Poll, time::Duration};
 use futures_channel::oneshot;
@@ -473,7 +473,7 @@ impl NetworkService {
                     loop {
                         match tcp_listener.accept().await {
                             Ok((socket, socket_addr)) => {
-                                break Some(((socket, socket_addr), tcp_listener))
+                                break Some(((socket, socket_addr), tcp_listener));
                             }
                             Err(error) => {
                                 // Errors here can happen if the accept failed, for example
@@ -930,7 +930,7 @@ async fn background_task(mut inner: Inner) {
                                     break 'search WakeUpReason::CanAssignSlot(
                                         peer_id.clone(),
                                         chain_id,
-                                    )
+                                    );
                                 }
                                 basic_peering_strategy::AssignablePeer::AllPeersBanned {
                                     next_unban,

--- a/full-node/src/network_service/tasks.rs
+++ b/full-node/src/network_service/tasks.rs
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{LogCallback, LogLevel};
-use core::future::Future;
 use futures_lite::future;
 use futures_util::StreamExt as _;
 use smol::{

--- a/full-node/src/network_service/tasks.rs
+++ b/full-node/src/network_service/tasks.rs
@@ -201,7 +201,7 @@ pub(super) async fn connection_task(
 /// protocols aren't supported.
 pub(super) fn multiaddr_to_socket(
     addr: &Multiaddr,
-) -> Result<impl Future<Output = Result<impl AsyncReadWrite, io::Error>>, ()> {
+) -> Result<impl Future<Output = Result<impl AsyncReadWrite + use<>, io::Error>> + use<>, ()> {
     let mut iter = addr.iter().fuse();
     let proto1 = iter.next().ok_or(())?;
     let proto2 = iter.next().ok_or(())?;

--- a/full-node/src/util.rs
+++ b/full-node/src/util.rs
@@ -24,7 +24,7 @@ pub fn truncated_str(input: impl Iterator<Item = char> + Clone, limit: usize) ->
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let mut counter = 0;
             for c in self.0.clone() {
                 f.write_char(c)?;

--- a/full-node/src/util.rs
+++ b/full-node/src/util.rs
@@ -21,9 +21,9 @@ use std::fmt::{self, Write as _};
 /// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
 /// the end.
 pub fn truncated_str<'a>(
-    input: impl Iterator<Item = char> + Clone + 'a,
+    input: impl Iterator<Item = char> + Clone + use<'a>,
     limit: usize,
-) -> impl fmt::Display + 'a {
+) -> impl fmt::Display + use<'a> {
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {

--- a/full-node/src/util.rs
+++ b/full-node/src/util.rs
@@ -20,10 +20,7 @@ use std::fmt::{self, Write as _};
 /// Returns an opaque object implementing the `fmt::Display` trait. Truncates the given `char`
 /// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
 /// the end.
-pub fn truncated_str<'a>(
-    input: impl Iterator<Item = char> + Clone + use<'a>,
-    limit: usize,
-) -> impl fmt::Display + use<'a> {
+pub fn truncated_str(input: impl Iterator<Item = char> + Clone, limit: usize) -> impl fmt::Display {
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {

--- a/full-node/tests/author.rs
+++ b/full-node/tests/author.rs
@@ -26,10 +26,9 @@ fn basic_block_generated() {
             chain: smoldot_full_node::ChainConfig {
                 chain_spec: (&include_bytes!("./substrate-node-template.json")[..]).into(),
                 additional_bootnodes: Vec::new(),
-                keystore_memory: vec![smoldot::identity::seed_phrase::decode_sr25519_private_key(
-                    "//Alice",
-                )
-                .unwrap()],
+                keystore_memory: vec![
+                    smoldot::identity::seed_phrase::decode_sr25519_private_key("//Alice").unwrap(),
+                ],
                 sqlite_database_path: None,
                 sqlite_cache_size: 256 * 1024 * 1024,
                 keystore_path: None,

--- a/lib/benches/header.rs
+++ b/lib/benches/header.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 fn benchmark_headers(c: &mut Criterion) {
     let mut group = c.benchmark_group("headers");

--- a/lib/benches/proof-decode.rs
+++ b/lib/benches/proof-decode.rs
@@ -17,7 +17,7 @@
 
 use std::iter;
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rand::Rng as _;
 
 fn benchmark_proof_decode(c: &mut Criterion) {

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -320,12 +320,12 @@ pub struct StorageGet(runtime::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -346,12 +346,12 @@ pub struct ClosestDescendantMerkleValue(runtime::ClosestDescendantMerkleValue, S
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -380,12 +380,12 @@ pub struct NextKey(runtime::NextKey, Shared);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -403,7 +403,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn prefix(&self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 
@@ -424,14 +424,14 @@ pub struct OffchainStorageSet(runtime::OffchainStorageSet, Shared);
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         self.0.value()
     }
 

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -320,12 +320,12 @@ pub struct StorageGet(runtime::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -346,12 +346,12 @@ pub struct ClosestDescendantMerkleValue(runtime::ClosestDescendantMerkleValue, S
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -380,12 +380,12 @@ pub struct NextKey(runtime::NextKey, Shared);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -403,7 +403,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 
@@ -424,14 +424,14 @@ pub struct OffchainStorageSet(runtime::OffchainStorageSet, Shared);
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.value()
     }
 

--- a/lib/src/author/build.rs
+++ b/lib/src/author/build.rs
@@ -536,7 +536,7 @@ impl Shared {
                             break BuilderAuthoring::Error {
                                 parent_runtime: block.parent_runtime,
                                 error: Error::InvalidHeaderGenerated,
-                            }
+                            };
                         }
                     };
 
@@ -559,7 +559,7 @@ impl Shared {
                     break BuilderAuthoring::Error {
                         parent_runtime,
                         error: Error::Runtime(error),
-                    }
+                    };
                 }
                 runtime::BlockBuild::InherentExtrinsics(a) => {
                     // Injecting the inherent is guaranteed to be done only once per block.
@@ -575,21 +575,21 @@ impl Shared {
                             inner: resume,
                             shared: self,
                         },
-                    }
+                    };
                 }
                 runtime::BlockBuild::StorageGet(inner) => {
-                    break BuilderAuthoring::StorageGet(StorageGet(inner, self))
+                    break BuilderAuthoring::StorageGet(StorageGet(inner, self));
                 }
                 runtime::BlockBuild::ClosestDescendantMerkleValue(inner) => {
                     break BuilderAuthoring::ClosestDescendantMerkleValue(
                         ClosestDescendantMerkleValue(inner, self),
-                    )
+                    );
                 }
                 runtime::BlockBuild::NextKey(inner) => {
-                    break BuilderAuthoring::NextKey(NextKey(inner, self))
+                    break BuilderAuthoring::NextKey(NextKey(inner, self));
                 }
                 runtime::BlockBuild::OffchainStorageSet(inner) => {
-                    break BuilderAuthoring::OffchainStorageSet(OffchainStorageSet(inner, self))
+                    break BuilderAuthoring::OffchainStorageSet(OffchainStorageSet(inner, self));
                 }
             }
         }

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -622,12 +622,12 @@ pub struct StorageGet(runtime_call::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -648,12 +648,12 @@ pub struct ClosestDescendantMerkleValue(runtime_call::ClosestDescendantMerkleVal
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -681,12 +681,12 @@ pub struct NextKey(runtime_call::NextKey, Shared);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -704,7 +704,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 
@@ -725,14 +725,14 @@ pub struct OffchainStorageSet(runtime_call::OffchainStorageSet, Shared);
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.value()
     }
 

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -177,7 +177,7 @@ pub fn build_block(config: Config) -> BlockBuild {
                         return BlockBuild::Finished(Err((
                             Error::BlockHeightOverflow,
                             config.parent_runtime,
-                        )))
+                        )));
                     }
                 },
                 extrinsics_root: &[0; 32],
@@ -276,7 +276,7 @@ impl BlockBuild {
                     return BlockBuild::Finished(Err((Error::WasmVm(err.detail), err.prototype)));
                 }
                 (Inner::Runtime(runtime_call::RuntimeCall::StorageGet(inner)), _) => {
-                    return BlockBuild::StorageGet(StorageGet(inner, shared))
+                    return BlockBuild::StorageGet(StorageGet(inner, shared));
                 }
                 (
                     Inner::Runtime(runtime_call::RuntimeCall::ClosestDescendantMerkleValue(inner)),
@@ -284,13 +284,13 @@ impl BlockBuild {
                 ) => {
                     return BlockBuild::ClosestDescendantMerkleValue(ClosestDescendantMerkleValue(
                         inner, shared,
-                    ))
+                    ));
                 }
                 (Inner::Runtime(runtime_call::RuntimeCall::NextKey(inner)), _) => {
-                    return BlockBuild::NextKey(NextKey(inner, shared))
+                    return BlockBuild::NextKey(NextKey(inner, shared));
                 }
                 (Inner::Runtime(runtime_call::RuntimeCall::OffchainStorageSet(inner)), _) => {
-                    return BlockBuild::OffchainStorageSet(OffchainStorageSet(inner, shared))
+                    return BlockBuild::OffchainStorageSet(OffchainStorageSet(inner, shared));
                 }
 
                 (
@@ -325,7 +325,7 @@ impl BlockBuild {
                             return BlockBuild::Finished(Err((
                                 err,
                                 success.virtual_machine.into_prototype(),
-                            )))
+                            )));
                         }
                     };
 
@@ -353,7 +353,7 @@ impl BlockBuild {
                     inner = Inner::Runtime(match init_result {
                         Ok(vm) => vm,
                         Err((err, proto)) => {
-                            return BlockBuild::Finished(Err((Error::VmInit(err), proto)))
+                            return BlockBuild::Finished(Err((Error::VmInit(err), proto)));
                         }
                     });
                 }
@@ -388,7 +388,7 @@ impl BlockBuild {
                             return BlockBuild::Finished(Err((
                                 Error::InherentExtrinsicDispatchError { extrinsic, error },
                                 success.virtual_machine.into_prototype(),
-                            )))
+                            )));
                         }
                         Ok(Err(error)) => {
                             return BlockBuild::Finished(Err((
@@ -397,13 +397,13 @@ impl BlockBuild {
                                     error,
                                 },
                                 success.virtual_machine.into_prototype(),
-                            )))
+                            )));
                         }
                         Err(err) => {
                             return BlockBuild::Finished(Err((
                                 err,
                                 success.virtual_machine.into_prototype(),
-                            )))
+                            )));
                         }
                     }
 
@@ -424,7 +424,7 @@ impl BlockBuild {
                             return BlockBuild::Finished(Err((
                                 err,
                                 success.virtual_machine.into_prototype(),
-                            )))
+                            )));
                         }
                     };
 

--- a/lib/src/author/runtime.rs
+++ b/lib/src/author/runtime.rs
@@ -622,12 +622,12 @@ pub struct StorageGet(runtime_call::StorageGet, Shared);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -648,12 +648,12 @@ pub struct ClosestDescendantMerkleValue(runtime_call::ClosestDescendantMerkleVal
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -681,12 +681,12 @@ pub struct NextKey(runtime_call::NextKey, Shared);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -704,7 +704,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn prefix(&self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 
@@ -725,14 +725,14 @@ pub struct OffchainStorageSet(runtime_call::OffchainStorageSet, Shared);
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         self.0.value()
     }
 

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -352,7 +352,7 @@ where
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         self.non_finalized_blocks.ancestors(node)
     }
 
@@ -362,7 +362,7 @@ where
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
         self.non_finalized_blocks.children(node)
     }
 
@@ -383,7 +383,7 @@ where
     /// guaranteed to be in an order in which the parents are found before their children.
     pub fn input_output_iter_ancestry_order(
         &'_ self,
-    ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> + '_ {
+    ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> {
         self.non_finalized_blocks
             .iter_ancestry_order()
             .map(move |(id, b)| {
@@ -410,7 +410,7 @@ where
     /// Does not include the finalized output block itself, but includes all descendants of it.
     pub fn input_output_iter_unordered(
         &'_ self,
-    ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> + '_ {
+    ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> {
         self.non_finalized_blocks
             .iter_unordered()
             .map(move |(id, b)| {

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -570,7 +570,7 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                    })
+                    });
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {
                     when_not_ready = match (when, when_not_ready.take()) {
@@ -594,7 +594,7 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                    })
+                    });
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {
                     when_not_ready = match (when, when_not_ready.take()) {
@@ -619,7 +619,7 @@ where
                     return NextNecessaryAsyncOp::Ready(AsyncOpParams {
                         id: async_op_id,
                         block_index,
-                    })
+                    });
                 }
                 NextNecessaryAsyncOpInternal::NotReady { when } => {
                     when_not_ready = match (when, when_not_ready.take()) {
@@ -661,7 +661,7 @@ where
             } => {
                 return NextNecessaryAsyncOpInternal::NotReady {
                     when: timeout.clone(),
-                }
+                };
             }
             _ => return NextNecessaryAsyncOpInternal::NotReady { when: None },
         };
@@ -736,10 +736,11 @@ where
         // When this block is inserted, value to use for `input_best_block_weight`.
         let input_best_block_weight = if is_new_best {
             let id = self.input_best_block_next_weight;
-            debug_assert!(self
-                .non_finalized_blocks
-                .iter_unordered()
-                .all(|(_, b)| b.input_best_block_weight < id));
+            debug_assert!(
+                self.non_finalized_blocks
+                    .iter_unordered()
+                    .all(|(_, b)| b.input_best_block_weight < id)
+            );
             self.input_best_block_next_weight += 1;
             id
         } else {
@@ -841,10 +842,11 @@ where
         }
 
         // Minor sanity checks.
-        debug_assert!(self
-            .non_finalized_blocks
-            .iter_unordered()
-            .all(|(_, b)| b.input_best_block_weight < self.input_best_block_next_weight));
+        debug_assert!(
+            self.non_finalized_blocks
+                .iter_unordered()
+                .all(|(_, b)| b.input_best_block_weight < self.input_best_block_next_weight)
+        );
     }
 
     /// Updates the state machine to take into account that the input of blocks has finalized the
@@ -865,11 +867,12 @@ where
         // otherwise the state of the tree will be corrupted.
         // This is checked with an `assert!` rather than a `debug_assert!`, as this constraint
         // is part of the public API of this method.
-        assert!(self
-            .input_best_block_index
-            .map_or(false, |current_input_best| self
-                .non_finalized_blocks
-                .is_ancestor(node_to_finalize, current_input_best)));
+        assert!(
+            self.input_best_block_index
+                .map_or(false, |current_input_best| self
+                    .non_finalized_blocks
+                    .is_ancestor(node_to_finalize, current_input_best))
+        );
 
         self.input_finalized_index = Some(node_to_finalize);
     }
@@ -955,11 +958,7 @@ where
                             // silently while the public API gives the impression that all
                             // `TAsync`s are always returned.
                             // TODO: solve that
-                            if reported {
-                                Some(user_data)
-                            } else {
-                                None
-                            }
+                            if reported { Some(user_data) } else { None }
                         }
                         _ => None,
                     };

--- a/lib/src/chain/async_tree.rs
+++ b/lib/src/chain/async_tree.rs
@@ -271,7 +271,7 @@ where
     ///
     /// Returns `None` if there is no best block. In terms of logic, this means that the best block
     /// is the finalized block, which is out of scope of this data structure.
-    pub fn output_best_block_index(&self) -> Option<(NodeIndex, &'_ TAsync)> {
+    pub fn output_best_block_index(&self) -> Option<(NodeIndex, &TAsync)> {
         self.output_best_block_index.map(|best_block_index| {
             (
                 best_block_index,
@@ -352,7 +352,7 @@ where
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    pub fn ancestors(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         self.non_finalized_blocks.ancestors(node)
     }
 
@@ -362,7 +362,7 @@ where
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
+    pub fn children(&self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
         self.non_finalized_blocks.children(node)
     }
 
@@ -382,7 +382,7 @@ where
     /// Similar to [`AsyncTree::input_output_iter_unordered`], except that the returned items are
     /// guaranteed to be in an order in which the parents are found before their children.
     pub fn input_output_iter_ancestry_order(
-        &'_ self,
+        &self,
     ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> {
         self.non_finalized_blocks
             .iter_ancestry_order()
@@ -409,7 +409,7 @@ where
     ///
     /// Does not include the finalized output block itself, but includes all descendants of it.
     pub fn input_output_iter_unordered(
-        &'_ self,
+        &self,
     ) -> impl Iterator<Item = InputIterItem<'_, TBl, TAsync>> {
         self.non_finalized_blocks
             .iter_unordered()

--- a/lib/src/chain/blocks_tree.rs
+++ b/lib/src/chain/blocks_tree.rs
@@ -246,7 +246,7 @@ impl<T> NonFinalizedTree<T> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn iter_unordered(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn iter_unordered(&self) -> impl Iterator<Item = header::HeaderRef> {
         self.blocks
             .iter_unordered()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())
@@ -256,7 +256,7 @@ impl<T> NonFinalizedTree<T> {
     ///
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
-    pub fn iter_ancestry_order(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn iter_ancestry_order(&self) -> impl Iterator<Item = header::HeaderRef> {
         self.blocks
             .iter_ancestry_order()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())

--- a/lib/src/chain/blocks_tree.rs
+++ b/lib/src/chain/blocks_tree.rs
@@ -246,7 +246,7 @@ impl<T> NonFinalizedTree<T> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn iter_unordered(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.blocks
             .iter_unordered()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())
@@ -256,7 +256,7 @@ impl<T> NonFinalizedTree<T> {
     ///
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
-    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn iter_ancestry_order(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.blocks
             .iter_ancestry_order()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())

--- a/lib/src/chain/blocks_tree.rs
+++ b/lib/src/chain/blocks_tree.rs
@@ -246,7 +246,7 @@ impl<T> NonFinalizedTree<T> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.blocks
             .iter_unordered()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())
@@ -256,7 +256,7 @@ impl<T> NonFinalizedTree<T> {
     ///
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
-    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.blocks
             .iter_ancestry_order()
             .map(move |(_, b)| header::decode(&b.header, self.block_number_bytes).unwrap())

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -47,8 +47,10 @@ impl<T> NonFinalizedTree<T> {
                 ops::Bound::Unbounded,
             ))
             .map(|(_prev_auth_change_trigger_number, block_index)| {
-                debug_assert!(_prev_auth_change_trigger_number
-                    .map_or(false, |n| n > self.finalized_block_number));
+                debug_assert!(
+                    _prev_auth_change_trigger_number
+                        .map_or(false, |n| n > self.finalized_block_number)
+                );
                 let block = self
                     .blocks
                     .get(*block_index)
@@ -157,10 +159,10 @@ impl<T> NonFinalizedTree<T> {
                 verify::CommitVerify::FinishedUnknown => {
                     return Err(CommitVerifyError::NotEnoughKnownBlocks {
                         target_block_number: decoded_commit.target_number,
-                    })
+                    });
                 }
                 verify::CommitVerify::Finished(Err(error)) => {
-                    return Err(CommitVerifyError::VerificationFailed(error))
+                    return Err(CommitVerifyError::VerificationFailed(error));
                 }
                 verify::CommitVerify::IsAuthority(is_authority) => {
                     let to_find = is_authority.authority_public_key();
@@ -241,10 +243,10 @@ impl<T> NonFinalizedTree<T> {
             } => {
                 match target_number.cmp(&self.finalized_block_number) {
                     cmp::Ordering::Equal if *target_hash == self.finalized_block_hash => {
-                        return Err(FinalityVerifyError::EqualToFinalized)
+                        return Err(FinalityVerifyError::EqualToFinalized);
                     }
                     cmp::Ordering::Equal => {
-                        return Err(FinalityVerifyError::EqualFinalizedHeightButInequalHash)
+                        return Err(FinalityVerifyError::EqualFinalizedHeightButInequalHash);
                     }
                     cmp::Ordering::Less => return Err(FinalityVerifyError::BelowFinalized),
                     _ => {}
@@ -334,9 +336,11 @@ impl<T> NonFinalizedTree<T> {
                 debug_assert!(
                     *after_finalized_block_authorities_set_id <= *after_block_authorities_set_id
                 );
-                debug_assert!(scheduled_change
-                    .as_ref()
-                    .map_or(true, |(n, _)| *n > new_finalized_block.number));
+                debug_assert!(
+                    scheduled_change
+                        .as_ref()
+                        .map_or(true, |(n, _)| *n > new_finalized_block.number)
+                );
 
                 *after_finalized_block_authorities_set_id = *after_block_authorities_set_id;
                 *finalized_triggered_authorities = triggered_authorities.clone();

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -223,14 +223,14 @@ impl<T> NonFinalizedTree<T> {
     /// Panics if the finality algorithm of the chain isn't Grandpa.
     ///
     fn verify_grandpa_finality_inner(
-        &'_ self,
+        &self,
         target_hash: &[u8; 32],
         target_number: u64,
     ) -> Result<
         (
             fork_tree::NodeIndex,
             u64,
-            impl Iterator<Item = &'_ [u8]> + Clone,
+            impl Iterator<Item = &[u8]> + Clone,
         ),
         FinalityVerifyError,
     > {

--- a/lib/src/chain/blocks_tree/finality.rs
+++ b/lib/src/chain/blocks_tree/finality.rs
@@ -230,7 +230,7 @@ impl<T> NonFinalizedTree<T> {
         (
             fork_tree::NodeIndex,
             u64,
-            impl Iterator<Item = &'_ [u8]> + Clone + '_,
+            impl Iterator<Item = &'_ [u8]> + Clone,
         ),
         FinalityVerifyError,
     > {

--- a/lib/src/chain/blocks_tree/verify.rs
+++ b/lib/src/chain/blocks_tree/verify.rs
@@ -21,8 +21,8 @@
 use crate::{chain::chain_information, header, verify};
 
 use super::{
-    fmt, Arc, BestScore, Block, BlockConsensus, BlockFinality, Duration, Finality,
-    FinalizedConsensus, NonFinalizedTree, Vec,
+    Arc, BestScore, Block, BlockConsensus, BlockFinality, Duration, Finality, FinalizedConsensus,
+    NonFinalizedTree, Vec, fmt,
 };
 
 impl<T> NonFinalizedTree<T> {
@@ -106,10 +106,12 @@ impl<T> NonFinalizedTree<T> {
                         ref finalized_scheduled_change,
                         ref finalized_triggered_authorities,
                     } => {
-                        debug_assert!(finalized_scheduled_change
-                            .as_ref()
-                            .map(|(n, _)| *n >= decoded_header.number)
-                            .unwrap_or(true));
+                        debug_assert!(
+                            finalized_scheduled_change
+                                .as_ref()
+                                .map(|(n, _)| *n >= decoded_header.number)
+                                .unwrap_or(true)
+                        );
                         BlockFinality::Grandpa {
                             prev_auth_change_trigger_number: None,
                             triggers_change: false,
@@ -159,7 +161,7 @@ impl<T> NonFinalizedTree<T> {
                     now_from_unix_epoch,
                 },
                 (FinalizedConsensus::Unknown, None) => {
-                    return Err(HeaderVerifyError::UnknownConsensusEngine)
+                    return Err(HeaderVerifyError::UnknownConsensusEngine);
                 }
                 _ => {
                     return Err(HeaderVerifyError::ConsensusMismatch);
@@ -420,14 +422,18 @@ impl<T> NonFinalizedTree<T> {
                 }
 
                 // Some sanity checks.
-                debug_assert!(scheduled_change
-                    .as_ref()
-                    .map(|(n, _)| *n > decoded_header.number)
-                    .unwrap_or(true));
-                debug_assert!(parent_prev_auth_change_trigger_number
-                    .as_ref()
-                    .map(|n| *n < decoded_header.number)
-                    .unwrap_or(true));
+                debug_assert!(
+                    scheduled_change
+                        .as_ref()
+                        .map(|(n, _)| *n > decoded_header.number)
+                        .unwrap_or(true)
+                );
+                debug_assert!(
+                    parent_prev_auth_change_trigger_number
+                        .as_ref()
+                        .map(|n| *n < decoded_header.number)
+                        .unwrap_or(true)
+                );
 
                 BlockFinality::Grandpa {
                     prev_auth_change_trigger_number: if *parent_triggers_change {

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -508,7 +508,7 @@ impl ChainInformationBuild {
                     return ChainInformationBuild::Finished {
                         result: Err(Error::WasmStart { call, error }),
                         virtual_machine,
-                    }
+                    };
                 }
             };
 
@@ -527,7 +527,7 @@ impl ChainInformationBuild {
                     return ChainInformationBuild::Finished {
                         result: Err(Error::MultipleConsensusAlgorithms),
                         virtual_machine: inner.virtual_machine.take().unwrap(),
-                    }
+                    };
                 }
                 (false, None, _) => chain_information::ChainInformationConsensus::Unknown,
                 (
@@ -665,7 +665,7 @@ impl ChainInformationBuild {
                     return ChainInformationBuild::Finished {
                         result: Err(Error::InvalidChainInformation(err)),
                         virtual_machine: inner.virtual_machine.take().unwrap(),
-                    }
+                    };
                 }
             };
 
@@ -815,24 +815,24 @@ impl ChainInformationBuild {
                             error: err.detail,
                         }),
                         virtual_machine: err.prototype,
-                    }
+                    };
                 }
                 runtime_call::RuntimeCall::StorageGet(call) => {
                     break ChainInformationBuild::InProgress(InProgress::StorageGet(StorageGet(
                         call, inner,
-                    )))
+                    )));
                 }
                 runtime_call::RuntimeCall::NextKey(call) => {
                     break ChainInformationBuild::InProgress(InProgress::NextKey(NextKey(
                         call, inner,
-                    )))
+                    )));
                 }
                 runtime_call::RuntimeCall::ClosestDescendantMerkleValue(call) => {
                     break ChainInformationBuild::InProgress(
                         InProgress::ClosestDescendantMerkleValue(ClosestDescendantMerkleValue(
                             call, inner,
                         )),
-                    )
+                    );
                 }
                 runtime_call::RuntimeCall::SignatureVerification(sig) => {
                     call = sig.verify_and_resume();

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -162,7 +162,7 @@ impl RuntimeCall {
     /// Returns the list of parameters to pass when making the call.
     ///
     /// The actual parameters are obtained by putting together all the returned buffers together.
-    pub fn parameter_vectored(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
+    pub fn parameter_vectored(&self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         iter::empty::<Vec<u8>>()
     }
 
@@ -268,12 +268,12 @@ pub struct StorageGet(runtime_call::StorageGet, ChainInformationBuildInner);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -302,12 +302,12 @@ pub struct ClosestDescendantMerkleValue(
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -342,12 +342,12 @@ pub struct NextKey(runtime_call::NextKey, ChainInformationBuildInner);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -365,7 +365,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn prefix(&self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 
@@ -1007,7 +1007,7 @@ fn decode_babe_configuration_output(
 /// Decodes the output of a call to `BabeApi_current_epoch` (`is_next_epoch` is `false`) or
 /// `BabeApi_next_epoch` (`is_next_epoch` is `true`).
 fn decode_babe_epoch_output(
-    scale_encoded: &'_ [u8],
+    scale_encoded: &[u8],
     is_next_epoch: bool,
 ) -> Result<chain_information::BabeEpochInformation, Error> {
     let mut combinator = nom::combinator::all_consuming(nom::combinator::map(
@@ -1073,7 +1073,7 @@ fn decode_babe_epoch_output(
         },
     ));
 
-    let result: Result<_, nom::Err<nom::error::Error<&'_ [u8]>>> = combinator(scale_encoded);
+    let result: Result<_, nom::Err<nom::error::Error<&[u8]>>> = combinator(scale_encoded);
     match result {
         Ok((_, info)) => Ok(info),
         Err(_) => Err(if is_next_epoch {

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -162,9 +162,7 @@ impl RuntimeCall {
     /// Returns the list of parameters to pass when making the call.
     ///
     /// The actual parameters are obtained by putting together all the returned buffers together.
-    pub fn parameter_vectored(
-        &'_ self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_ {
+    pub fn parameter_vectored(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         iter::empty::<Vec<u8>>()
     }
 
@@ -270,12 +268,12 @@ pub struct StorageGet(runtime_call::StorageGet, ChainInformationBuildInner);
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -304,12 +302,12 @@ pub struct ClosestDescendantMerkleValue(
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -344,12 +342,12 @@ pub struct NextKey(runtime_call::NextKey, ChainInformationBuildInner);
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.key()
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.0.child_trie()
     }
 
@@ -367,7 +365,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
         self.0.prefix()
     }
 

--- a/lib/src/chain/chain_information/build.rs
+++ b/lib/src/chain/chain_information/build.rs
@@ -389,7 +389,9 @@ impl NextKey {
 }
 
 impl ChainInformationBuild {
-    fn necessary_calls(inner: &ChainInformationBuildInner) -> impl Iterator<Item = RuntimeCall> {
+    fn necessary_calls(
+        inner: &ChainInformationBuildInner,
+    ) -> impl Iterator<Item = RuntimeCall> + use<> {
         let aura_api_authorities =
             if inner.runtime_has_aura && inner.aura_autorities_call_output.is_none() {
                 Some(RuntimeCall::AuraApiAuthorities)

--- a/lib/src/chain/fork_tree.rs
+++ b/lib/src/chain/fork_tree.rs
@@ -129,7 +129,7 @@ impl<T> ForkTree<T> {
 
     /// Returns an iterator to all the node values. The returned items are guaranteed to be in an
     /// order in which the parents are found before their children.
-    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = (NodeIndex, &'_ T)> {
+    pub fn iter_ancestry_order(&self) -> impl Iterator<Item = (NodeIndex, &T)> {
         iter::successors(self.first_root.map(NodeIndex), move |n| {
             self.ancestry_order_next(*n)
         })
@@ -209,7 +209,7 @@ impl<T> ForkTree<T> {
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
+    pub fn ancestors(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         iter::successors(Some(node), move |n| self.nodes[n.0].parent.map(NodeIndex)).skip(1)
     }
 
@@ -229,7 +229,7 @@ impl<T> ForkTree<T> {
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
+    pub fn children(&self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
         let first = match node {
             Some(n) => self.nodes[n.0].first_child,
             None => self.first_root,
@@ -386,7 +386,7 @@ impl<T> ForkTree<T> {
     /// Panics if one of the [`NodeIndex`]s is invalid.
     ///
     pub fn ascend_and_descend(
-        &'_ self,
+        &self,
         node1: NodeIndex,
         node2: NodeIndex,
     ) -> (
@@ -421,7 +421,7 @@ impl<T> ForkTree<T> {
     /// Panics if the [`NodeIndex`] is invalid.
     ///
     pub fn node_to_root_path(
-        &'_ self,
+        &self,
         node_index: NodeIndex,
     ) -> impl Iterator<Item = NodeIndex> + Clone {
         iter::successors(Some(node_index), move |n| {
@@ -436,7 +436,7 @@ impl<T> ForkTree<T> {
     /// Panics if the [`NodeIndex`] is invalid.
     ///
     pub fn root_to_node_path(
-        &'_ self,
+        &self,
         node_index: NodeIndex,
     ) -> impl Iterator<Item = NodeIndex> + Clone {
         debug_assert!(self.nodes.get(usize::MAX).is_none());

--- a/lib/src/chain/fork_tree.rs
+++ b/lib/src/chain/fork_tree.rs
@@ -129,7 +129,7 @@ impl<T> ForkTree<T> {
 
     /// Returns an iterator to all the node values. The returned items are guaranteed to be in an
     /// order in which the parents are found before their children.
-    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = (NodeIndex, &'_ T)> + '_ {
+    pub fn iter_ancestry_order(&'_ self) -> impl Iterator<Item = (NodeIndex, &'_ T)> {
         iter::successors(self.first_root.map(NodeIndex), move |n| {
             self.ancestry_order_next(*n)
         })
@@ -209,7 +209,7 @@ impl<T> ForkTree<T> {
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn ancestors(&'_ self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> {
         iter::successors(Some(node), move |n| self.nodes[n.0].parent.map(NodeIndex)).skip(1)
     }
 
@@ -229,7 +229,7 @@ impl<T> ForkTree<T> {
     ///
     /// Panics if the [`NodeIndex`] is invalid.
     ///
-    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn children(&'_ self, node: Option<NodeIndex>) -> impl Iterator<Item = NodeIndex> {
         let first = match node {
             Some(n) => self.nodes[n.0].first_child,
             None => self.first_root,
@@ -390,8 +390,8 @@ impl<T> ForkTree<T> {
         node1: NodeIndex,
         node2: NodeIndex,
     ) -> (
-        impl Iterator<Item = NodeIndex> + Clone + '_,
-        impl Iterator<Item = NodeIndex> + Clone + '_,
+        impl Iterator<Item = NodeIndex> + Clone,
+        impl Iterator<Item = NodeIndex> + Clone,
     ) {
         let common_ancestor = self.common_ancestor(node1, node2);
 
@@ -423,7 +423,7 @@ impl<T> ForkTree<T> {
     pub fn node_to_root_path(
         &'_ self,
         node_index: NodeIndex,
-    ) -> impl Iterator<Item = NodeIndex> + Clone + '_ {
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
         iter::successors(Some(node_index), move |n| {
             self.nodes[n.0].parent.map(NodeIndex)
         })
@@ -438,7 +438,7 @@ impl<T> ForkTree<T> {
     pub fn root_to_node_path(
         &'_ self,
         node_index: NodeIndex,
-    ) -> impl Iterator<Item = NodeIndex> + Clone + '_ {
+    ) -> impl Iterator<Item = NodeIndex> + Clone {
         debug_assert!(self.nodes.get(usize::MAX).is_none());
 
         // First element is an invalid key, each successor is the last element of

--- a/lib/src/chain/fork_tree.rs
+++ b/lib/src/chain/fork_tree.rs
@@ -622,10 +622,11 @@ impl<'a, T> Iterator for PruneAncestorsIter<'a, T> {
             }
 
             // Actually remove the node.
-            debug_assert!(self
-                .tree
-                .first_root
-                .map_or(true, |n| n != maybe_removed_node_index.0));
+            debug_assert!(
+                self.tree
+                    .first_root
+                    .map_or(true, |n| n != maybe_removed_node_index.0)
+            );
             let iter_node = self.tree.nodes.remove(maybe_removed_node_index.0);
 
             break Some(PrunedNode {
@@ -654,10 +655,11 @@ impl<'a, T> Drop for PruneAncestorsIter<'a, T> {
             debug_assert!(self.tree.first_root.is_some());
         }
 
-        debug_assert!(self
-            .tree
-            .first_root
-            .map_or(true, |fr| self.tree.nodes.contains(fr)));
+        debug_assert!(
+            self.tree
+                .first_root
+                .map_or(true, |fr| self.tree.nodes.contains(fr))
+        );
 
         debug_assert_eq!(self.uncles_only, self.tree.get(self.new_final).is_some());
 

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -236,7 +236,7 @@ impl ChainSpec {
     }
 
     /// Returns a list of hashes of block headers that should always be considered as invalid.
-    pub fn bad_blocks_hashes(&'_ self) -> impl Iterator<Item = &'_ [u8; 32]> {
+    pub fn bad_blocks_hashes(&self) -> impl Iterator<Item = &[u8; 32]> {
         self.client_spec
             .bad_blocks
             .as_ref()
@@ -249,7 +249,7 @@ impl ChainSpec {
     ///
     /// Bootnode addresses that have failed to be parsed are returned as well in the form of
     /// a [`Bootnode::UnrecognizedFormat`].
-    pub fn boot_nodes(&'_ self) -> impl ExactSizeIterator<Item = Bootnode<'_>> {
+    pub fn boot_nodes(&self) -> impl ExactSizeIterator<Item = Bootnode<'_>> {
         // Note that we intentionally don't expose types found in the `libp2p` module in order to
         // not tie the code that parses chain specifications to the libp2p code.
         self.client_spec.boot_nodes.iter().map(|unparsed| {
@@ -273,7 +273,7 @@ impl ChainSpec {
 
     /// Returns the list of libp2p multiaddresses of the default telemetry servers of the chain.
     // TODO: more strongly typed?
-    pub fn telemetry_endpoints(&'_ self) -> impl Iterator<Item = impl AsRef<str>> {
+    pub fn telemetry_endpoints(&self) -> impl Iterator<Item = impl AsRef<str>> {
         self.client_spec
             .telemetry_endpoints
             .as_ref()

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -36,8 +36,8 @@
 
 use crate::{
     chain::chain_information::{
-        build, BabeEpochInformation, ChainInformation, ChainInformationConsensus,
-        ChainInformationFinality, ValidChainInformation, ValidityError,
+        BabeEpochInformation, ChainInformation, ChainInformationConsensus,
+        ChainInformationFinality, ValidChainInformation, ValidityError, build,
     },
     executor, libp2p, trie,
 };
@@ -103,7 +103,7 @@ impl ChainSpec {
         let genesis_storage = match self.genesis_storage() {
             GenesisStorage::Items(items) => items,
             GenesisStorage::TrieRootHash(_) => {
-                return Err(FromGenesisStorageError::UnknownStorageItems)
+                return Err(FromGenesisStorageError::UnknownStorageItems);
             }
         };
 

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -417,7 +417,7 @@ impl<'a> GenesisStorageItems<'a> {
         key_before: impl Iterator<Item = u8>,
         or_equal: bool,
         prefix: impl Iterator<Item = u8>,
-    ) -> Option<impl Iterator<Item = u8> + 'a> {
+    ) -> Option<impl Iterator<Item = u8>> {
         let lower_bound = if or_equal {
             Bound::Included(structs::HexString(key_before.collect::<Vec<_>>()))
         } else {
@@ -489,7 +489,7 @@ impl LightSyncState {
             })
             .collect();
 
-        epochs.sort_unstable_by_key(|(&block_num, _)| block_num);
+        epochs.sort_unstable_by_key(|(block_num, _)| **block_num);
 
         // TODO: it seems that multiple identical epochs can be found in the list ; figure out why Substrate does that and fix it
         epochs.dedup_by_key(|(_, epoch)| epoch.epoch_index);

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -236,7 +236,7 @@ impl ChainSpec {
     }
 
     /// Returns a list of hashes of block headers that should always be considered as invalid.
-    pub fn bad_blocks_hashes(&'_ self) -> impl Iterator<Item = &'_ [u8; 32]> + '_ {
+    pub fn bad_blocks_hashes(&'_ self) -> impl Iterator<Item = &'_ [u8; 32]> {
         self.client_spec
             .bad_blocks
             .as_ref()
@@ -249,7 +249,7 @@ impl ChainSpec {
     ///
     /// Bootnode addresses that have failed to be parsed are returned as well in the form of
     /// a [`Bootnode::UnrecognizedFormat`].
-    pub fn boot_nodes(&'_ self) -> impl ExactSizeIterator<Item = Bootnode<'_>> + '_ {
+    pub fn boot_nodes(&'_ self) -> impl ExactSizeIterator<Item = Bootnode<'_>> {
         // Note that we intentionally don't expose types found in the `libp2p` module in order to
         // not tie the code that parses chain specifications to the libp2p code.
         self.client_spec.boot_nodes.iter().map(|unparsed| {
@@ -273,7 +273,7 @@ impl ChainSpec {
 
     /// Returns the list of libp2p multiaddresses of the default telemetry servers of the chain.
     // TODO: more strongly typed?
-    pub fn telemetry_endpoints(&'_ self) -> impl Iterator<Item = impl AsRef<str> + '_> + '_ {
+    pub fn telemetry_endpoints(&'_ self) -> impl Iterator<Item = impl AsRef<str>> {
         self.client_spec
             .telemetry_endpoints
             .as_ref()

--- a/lib/src/chain_spec.rs
+++ b/lib/src/chain_spec.rs
@@ -249,7 +249,7 @@ impl ChainSpec {
     ///
     /// Bootnode addresses that have failed to be parsed are returned as well in the form of
     /// a [`Bootnode::UnrecognizedFormat`].
-    pub fn boot_nodes(&self) -> impl ExactSizeIterator<Item = Bootnode<'_>> {
+    pub fn boot_nodes(&self) -> impl ExactSizeIterator<Item = Bootnode> {
         // Note that we intentionally don't expose types found in the `libp2p` module in order to
         // not tie the code that parses chain specifications to the libp2p code.
         self.client_spec.boot_nodes.iter().map(|unparsed| {

--- a/lib/src/chain_spec/tests.rs
+++ b/lib/src/chain_spec/tests.rs
@@ -108,8 +108,9 @@ fn relay_chain_para_id_either_both_present_or_absent() {
     )
     .unwrap();
 
-    assert!(ChainSpec::from_json_bytes(
-        r#"{
+    assert!(
+        ChainSpec::from_json_bytes(
+            r#"{
             "name": "Test",
             "id": "test",
             "bootNodes": [],
@@ -122,11 +123,13 @@ fn relay_chain_para_id_either_both_present_or_absent() {
             }
           }
           "#,
-    )
-    .is_err());
+        )
+        .is_err()
+    );
 
-    assert!(ChainSpec::from_json_bytes(
-        r#"{
+    assert!(
+        ChainSpec::from_json_bytes(
+            r#"{
             "name": "Test",
             "id": "test",
             "bootNodes": [],
@@ -139,8 +142,9 @@ fn relay_chain_para_id_either_both_present_or_absent() {
             }
           }
           "#,
-    )
-    .is_err());
+        )
+        .is_err()
+    );
 }
 
 #[test]

--- a/lib/src/database/finalized_serialize/defs.rs
+++ b/lib/src/database/finalized_serialize/defs.rs
@@ -85,7 +85,7 @@ pub(super) struct SerializedChainInformationV1 {
 
 impl SerializedChainInformationV1 {
     pub(super) fn new(
-        from: chain_information::ChainInformationRef<'_>,
+        from: chain_information::ChainInformationRef,
         block_number_bytes: usize,
         finalized_storage: Option<impl Iterator<Item = (impl AsRef<[u8]>, impl AsRef<[u8]>)>>,
     ) -> Self {

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -1464,7 +1464,7 @@ impl SqliteFullDatabase {
 }
 
 impl fmt::Debug for SqliteFullDatabase {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("SqliteFullDatabase").finish()
     }
 }

--- a/lib/src/database/full_sqlite.rs
+++ b/lib/src/database/full_sqlite.rs
@@ -81,7 +81,7 @@ use core::{fmt, iter};
 use parking_lot::Mutex;
 use rusqlite::OptionalExtension as _;
 
-pub use open::{open, Config, ConfigTy, DatabaseEmpty, DatabaseOpen};
+pub use open::{Config, ConfigTy, DatabaseEmpty, DatabaseOpen, open};
 
 mod open;
 mod tests;

--- a/lib/src/database/full_sqlite/tests.rs
+++ b/lib/src/database/full_sqlite/tests.rs
@@ -18,8 +18,8 @@
 #![cfg(test)]
 
 use super::{
-    open, Config, ConfigTy, DatabaseOpen, InsertTrieNode, InsertTrieNodeStorageValue,
-    StorageAccessError,
+    Config, ConfigTy, DatabaseOpen, InsertTrieNode, InsertTrieNodeStorageValue, StorageAccessError,
+    open,
 };
 use crate::{header, trie};
 
@@ -464,14 +464,15 @@ fn storage_get_partial() {
         Err(StorageAccessError::IncompleteStorage)
     ));
 
-    assert!(db
-        .block_storage_get(
+    assert!(
+        db.block_storage_get(
             &db.block_hash_by_number(0).unwrap().next().unwrap(),
             iter::empty::<iter::Empty<_>>(),
             [1, 1, 2].into_iter(),
         )
         .unwrap()
-        .is_none());
+        .is_none()
+    );
 
     assert!(matches!(
         db.block_storage_get(
@@ -524,34 +525,37 @@ fn storage_get_partial() {
         b"world"
     );
 
-    assert!(db
-        .block_storage_get(
+    assert!(
+        db.block_storage_get(
             &db.block_hash_by_number(0).unwrap().next().unwrap(),
             iter::empty::<iter::Empty<_>>(),
             [1, 1, 2].into_iter(),
         )
         .unwrap()
-        .is_none());
+        .is_none()
+    );
 
-    assert!(db
-        .block_storage_get(
+    assert!(
+        db.block_storage_get(
             &db.block_hash_by_number(0).unwrap().next().unwrap(),
             iter::empty::<iter::Empty<_>>(),
             [1, 1, 1, 2].into_iter(),
         )
         .unwrap()
-        .is_none());
+        .is_none()
+    );
 
     // The empty key is specifically tested due to SQLite having some weird behaviors mixing
     // null and empty bytes.
-    assert!(db
-        .block_storage_get(
+    assert!(
+        db.block_storage_get(
             &db.block_hash_by_number(0).unwrap().next().unwrap(),
             iter::empty::<iter::Empty<_>>(),
             [].into_iter(),
         )
         .unwrap()
-        .is_none());
+        .is_none()
+    );
 }
 
 #[test]

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -333,17 +333,17 @@ impl HostVmPrototype {
             Err(runtime_version::FindEmbeddedRuntimeVersionError::FindSections(err)) => {
                 return Err(NewErr::RuntimeVersion(
                     FindEmbeddedRuntimeVersionError::FindSections(err),
-                ))
+                ));
             }
             Err(runtime_version::FindEmbeddedRuntimeVersionError::RuntimeApisDecode(err)) => {
                 return Err(NewErr::RuntimeVersion(
                     FindEmbeddedRuntimeVersionError::RuntimeApisDecode(err),
-                ))
+                ));
             }
             Err(runtime_version::FindEmbeddedRuntimeVersionError::RuntimeVersionDecode) => {
                 return Err(NewErr::RuntimeVersion(
                     FindEmbeddedRuntimeVersionError::RuntimeVersionDecode,
-                ))
+                ));
             }
         };
 
@@ -428,7 +428,7 @@ impl HostVmPrototype {
                             match CoreVersion::from_slice(finished.value().as_ref().to_vec()) {
                                 Ok(v) => v,
                                 Err(_) => {
-                                    return Err(NewErr::CoreVersion(CoreVersionError::Decode))
+                                    return Err(NewErr::CoreVersion(CoreVersionError::Decode));
                                 }
                             };
 
@@ -444,7 +444,7 @@ impl HostVmPrototype {
                     HostVm::LogEmit(log) => vm = log.resume(),
 
                     HostVm::Error { error, .. } => {
-                        return Err(NewErr::CoreVersion(CoreVersionError::Run(error)))
+                        return Err(NewErr::CoreVersion(CoreVersionError::Run(error)));
                     }
 
                     // Getting the runtime version is a very core operation, and very few
@@ -813,7 +813,7 @@ impl ReadyToRun {
                 return HostVm::Error {
                     error: Error::Trap(err),
                     prototype: self.inner.into_prototype(),
-                }
+                };
             }
 
             Err(vm::RunErr::BadValueTy { .. }) => {
@@ -986,7 +986,7 @@ impl ReadyToRun {
                         return HostVm::Error {
                             error: Error::ParamDecodeError,
                             prototype: self.inner.into_prototype(),
-                        }
+                        };
                     }
                     // The signatures are checked at initialization and the Wasm VM ensures that
                     // the proper parameter types are provided.
@@ -1004,7 +1004,7 @@ impl ReadyToRun {
                         return HostVm::Error {
                             error: Error::ParamDecodeError,
                             prototype: self.inner.into_prototype(),
-                        }
+                        };
                     }
                     // The signatures are checked at initialization and the Wasm VM ensures that
                     // the proper parameter types are provided.
@@ -2164,7 +2164,7 @@ impl ReadyToRun {
                         return HostVm::Error {
                             error,
                             prototype: self.inner.into_prototype(),
-                        }
+                        };
                     }
                 };
 
@@ -2188,7 +2188,7 @@ impl ReadyToRun {
                         return HostVm::Error {
                             error: Error::FreeError { pointer },
                             prototype: self.inner.into_prototype(),
-                        }
+                        };
                     }
                 };
 
@@ -3807,7 +3807,7 @@ impl Inner {
                 return HostVm::Error {
                     error,
                     prototype: self.into_prototype(),
-                }
+                };
             }
         };
 
@@ -3858,7 +3858,7 @@ impl Inner {
                 return HostVm::Error {
                     error,
                     prototype: self.into_prototype(),
-                }
+                };
             }
         };
 
@@ -3901,7 +3901,7 @@ impl Inner {
                 return Err(Error::OutOfMemory {
                     function: function_name,
                     requested_size: size,
-                })
+                });
             }
         };
 

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -3640,13 +3640,13 @@ impl<'a> AsRef<[u8]> for LogEmitInfoHex<'a> {
 }
 
 impl<'a> fmt::Debug for LogEmitInfoHex<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.as_ref(), f)
     }
 }
 
 impl<'a> fmt::Display for LogEmitInfoHex<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&hex::encode(self.as_ref()), f)
     }
 }
@@ -3667,13 +3667,13 @@ impl<'a> AsRef<str> for LogEmitInfoStr<'a> {
 }
 
 impl<'a> fmt::Debug for LogEmitInfoStr<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self.as_ref(), f)
     }
 }
 
 impl<'a> fmt::Display for LogEmitInfoStr<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self.as_ref(), f)
     }
 }

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2301,7 +2301,7 @@ pub struct Finished {
 
 impl Finished {
     /// Returns the value the called function has returned.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn value(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.value_ptr, self.value_size)
@@ -2346,7 +2346,7 @@ pub struct ExternalStorageGet {
 
 impl ExternalStorageGet {
     /// Returns the key whose value must be provided back with [`ExternalStorageGet::resume`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2354,7 +2354,7 @@ impl ExternalStorageGet {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2562,7 +2562,7 @@ pub struct ExternalStorageSet {
 
 impl ExternalStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2575,7 +2575,7 @@ impl ExternalStorageSet {
     /// implicitly be created.
     /// If [`ExternalStorageSet::value`] returns `None` and this is the last entry in the child
     /// trie, it must implicitly be destroyed.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         match &self.child_trie_ptr_size {
             Some((ptr, size)) => {
                 let child_trie = self
@@ -2592,7 +2592,7 @@ impl ExternalStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         self.value.map(|(ptr, size)| {
             self.inner
                 .vm
@@ -2672,7 +2672,7 @@ pub struct ExternalStorageAppend {
 
 impl ExternalStorageAppend {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2685,13 +2685,13 @@ impl ExternalStorageAppend {
     ///
     /// > **Note**: At the moment, this function always returns None, as there is no host function
     /// >           that appends to a child trie storage.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         // Note that there is no equivalent of this host function for child tries.
         None::<&'static [u8]>
     }
 
     /// Returns the value to append.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn value(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.value_ptr, self.value_size)
@@ -2740,7 +2740,7 @@ pub struct ExternalStorageClearPrefix {
 
 impl ExternalStorageClearPrefix {
     /// Returns the prefix whose keys must be removed.
-    pub fn prefix(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn prefix(&'_ self) -> impl AsRef<[u8]> {
         if let Some((prefix_ptr, prefix_size)) = self.prefix_ptr_size {
             either::Left(
                 self.inner
@@ -2757,7 +2757,7 @@ impl ExternalStorageClearPrefix {
     ///
     /// If [`ExternalStorageClearPrefix::child_trie`] returns `Some` and all the entries of the
     /// child trie are removed, the child trie must implicitly be destroyed.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2848,7 +2848,7 @@ pub struct ExternalStorageRoot {
 
 impl ExternalStorageRoot {
     /// Returns the child trie whose root hash must be provided. `None` for the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2896,7 +2896,7 @@ pub struct ExternalStorageNextKey {
 
 impl ExternalStorageNextKey {
     /// Returns the key whose following key must be returned.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2904,7 +2904,7 @@ impl ExternalStorageNextKey {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2988,7 +2988,7 @@ enum SignatureVerificationAlgorithm {
 
 impl SignatureVerification {
     /// Returns the message that the signature is expected to sign.
-    pub fn message(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn message(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.message_ptr, self.message_size)
@@ -2999,7 +2999,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
     /// >           set of valid signatures.
-    pub fn signature(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn signature(&'_ self) -> impl AsRef<[u8]> {
         let signature_size = match self.algorithm {
             SignatureVerificationAlgorithm::Ed25519 => 64,
             SignatureVerificationAlgorithm::Sr25519V1 => 64,
@@ -3018,7 +3018,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
     /// >           set of valid public keys.
-    pub fn public_key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn public_key(&'_ self) -> impl AsRef<[u8]> {
         let public_key_size = match self.algorithm {
             SignatureVerificationAlgorithm::Ed25519 => 32,
             SignatureVerificationAlgorithm::Sr25519V1 => 32,
@@ -3184,7 +3184,7 @@ pub struct CallRuntimeVersion {
 
 impl CallRuntimeVersion {
     /// Returns the Wasm code whose runtime version must be provided.
-    pub fn wasm_code(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn wasm_code(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.wasm_blob_ptr, self.wasm_blob_size)
@@ -3237,7 +3237,7 @@ pub struct ExternalOffchainIndexSet {
 
 impl ExternalOffchainIndexSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3247,7 +3247,7 @@ impl ExternalOffchainIndexSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.value {
             Some(
                 self.inner
@@ -3293,7 +3293,7 @@ pub struct ExternalOffchainStorageSet {
 
 impl ExternalOffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3303,7 +3303,7 @@ impl ExternalOffchainStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.value {
             Some(
                 self.inner
@@ -3317,7 +3317,7 @@ impl ExternalOffchainStorageSet {
     }
 
     /// Returns the value the current value should be compared against. The operation is a no-op if they don't compare equal.
-    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.old_value {
             Some(
                 self.inner
@@ -3368,7 +3368,7 @@ pub struct ExternalOffchainStorageGet {
 
 impl ExternalOffchainStorageGet {
     /// Returns the key whose value must be loaded.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3470,7 +3470,7 @@ pub struct OffchainSubmitTransaction {
 
 impl OffchainSubmitTransaction {
     /// Returns the SCALE-encoded transaction to submit to the chain.
-    pub fn transaction(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn transaction(&'_ self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.tx_ptr, self.tx_size)

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -2301,7 +2301,7 @@ pub struct Finished {
 
 impl Finished {
     /// Returns the value the called function has returned.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> {
+    pub fn value(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.value_ptr, self.value_size)
@@ -2346,7 +2346,7 @@ pub struct ExternalStorageGet {
 
 impl ExternalStorageGet {
     /// Returns the key whose value must be provided back with [`ExternalStorageGet::resume`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2354,7 +2354,7 @@ impl ExternalStorageGet {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2562,7 +2562,7 @@ pub struct ExternalStorageSet {
 
 impl ExternalStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2575,7 +2575,7 @@ impl ExternalStorageSet {
     /// implicitly be created.
     /// If [`ExternalStorageSet::value`] returns `None` and this is the last entry in the child
     /// trie, it must implicitly be destroyed.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         match &self.child_trie_ptr_size {
             Some((ptr, size)) => {
                 let child_trie = self
@@ -2592,7 +2592,7 @@ impl ExternalStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         self.value.map(|(ptr, size)| {
             self.inner
                 .vm
@@ -2672,7 +2672,7 @@ pub struct ExternalStorageAppend {
 
 impl ExternalStorageAppend {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2685,13 +2685,13 @@ impl ExternalStorageAppend {
     ///
     /// > **Note**: At the moment, this function always returns None, as there is no host function
     /// >           that appends to a child trie storage.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         // Note that there is no equivalent of this host function for child tries.
         None::<&'static [u8]>
     }
 
     /// Returns the value to append.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> {
+    pub fn value(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.value_ptr, self.value_size)
@@ -2740,7 +2740,7 @@ pub struct ExternalStorageClearPrefix {
 
 impl ExternalStorageClearPrefix {
     /// Returns the prefix whose keys must be removed.
-    pub fn prefix(&'_ self) -> impl AsRef<[u8]> {
+    pub fn prefix(&self) -> impl AsRef<[u8]> {
         if let Some((prefix_ptr, prefix_size)) = self.prefix_ptr_size {
             either::Left(
                 self.inner
@@ -2757,7 +2757,7 @@ impl ExternalStorageClearPrefix {
     ///
     /// If [`ExternalStorageClearPrefix::child_trie`] returns `Some` and all the entries of the
     /// child trie are removed, the child trie must implicitly be destroyed.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2848,7 +2848,7 @@ pub struct ExternalStorageRoot {
 
 impl ExternalStorageRoot {
     /// Returns the child trie whose root hash must be provided. `None` for the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2896,7 +2896,7 @@ pub struct ExternalStorageNextKey {
 
 impl ExternalStorageNextKey {
     /// Returns the key whose following key must be returned.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -2904,7 +2904,7 @@ impl ExternalStorageNextKey {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((child_trie_ptr, child_trie_size)) = self.child_trie_ptr_size {
             let child_trie = self
                 .inner
@@ -2988,7 +2988,7 @@ enum SignatureVerificationAlgorithm {
 
 impl SignatureVerification {
     /// Returns the message that the signature is expected to sign.
-    pub fn message(&'_ self) -> impl AsRef<[u8]> {
+    pub fn message(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.message_ptr, self.message_size)
@@ -2999,7 +2999,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
     /// >           set of valid signatures.
-    pub fn signature(&'_ self) -> impl AsRef<[u8]> {
+    pub fn signature(&self) -> impl AsRef<[u8]> {
         let signature_size = match self.algorithm {
             SignatureVerificationAlgorithm::Ed25519 => 64,
             SignatureVerificationAlgorithm::Sr25519V1 => 64,
@@ -3018,7 +3018,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
     /// >           set of valid public keys.
-    pub fn public_key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn public_key(&self) -> impl AsRef<[u8]> {
         let public_key_size = match self.algorithm {
             SignatureVerificationAlgorithm::Ed25519 => 32,
             SignatureVerificationAlgorithm::Sr25519V1 => 32,
@@ -3184,7 +3184,7 @@ pub struct CallRuntimeVersion {
 
 impl CallRuntimeVersion {
     /// Returns the Wasm code whose runtime version must be provided.
-    pub fn wasm_code(&'_ self) -> impl AsRef<[u8]> {
+    pub fn wasm_code(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.wasm_blob_ptr, self.wasm_blob_size)
@@ -3237,7 +3237,7 @@ pub struct ExternalOffchainIndexSet {
 
 impl ExternalOffchainIndexSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3247,7 +3247,7 @@ impl ExternalOffchainIndexSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.value {
             Some(
                 self.inner
@@ -3293,7 +3293,7 @@ pub struct ExternalOffchainStorageSet {
 
 impl ExternalOffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3303,7 +3303,7 @@ impl ExternalOffchainStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.value {
             Some(
                 self.inner
@@ -3317,7 +3317,7 @@ impl ExternalOffchainStorageSet {
     }
 
     /// Returns the value the current value should be compared against. The operation is a no-op if they don't compare equal.
-    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn old_value(&self) -> Option<impl AsRef<[u8]>> {
         if let Some((ptr, size)) = self.old_value {
             Some(
                 self.inner
@@ -3368,7 +3368,7 @@ pub struct ExternalOffchainStorageGet {
 
 impl ExternalOffchainStorageGet {
     /// Returns the key whose value must be loaded.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.key_ptr, self.key_size)
@@ -3470,7 +3470,7 @@ pub struct OffchainSubmitTransaction {
 
 impl OffchainSubmitTransaction {
     /// Returns the SCALE-encoded transaction to submit to the chain.
-    pub fn transaction(&'_ self) -> impl AsRef<[u8]> {
+    pub fn transaction(&self) -> impl AsRef<[u8]> {
         self.inner
             .vm
             .read_memory(self.tx_ptr, self.tx_size)

--- a/lib/src/executor/host/runtime_version.rs
+++ b/lib/src/executor/host/runtime_version.rs
@@ -531,7 +531,7 @@ struct WasmSection<'a> {
 }
 
 /// Parses a Wasm section. If it is a custom section, returns its name and content.
-fn wasm_section(bytes: &[u8]) -> nom::IResult<&[u8], Option<WasmSection<'_>>> {
+fn wasm_section(bytes: &[u8]) -> nom::IResult<&[u8], Option<WasmSection>> {
     nom::branch::alt((
         nom::combinator::map(
             nom::combinator::map_parser(

--- a/lib/src/executor/host/runtime_version.rs
+++ b/lib/src/executor/host/runtime_version.rs
@@ -531,7 +531,7 @@ struct WasmSection<'a> {
 }
 
 /// Parses a Wasm section. If it is a custom section, returns its name and content.
-fn wasm_section(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], Option<WasmSection<'_>>> {
+fn wasm_section(bytes: &[u8]) -> nom::IResult<&[u8], Option<WasmSection<'_>>> {
     nom::branch::alt((
         nom::combinator::map(
             nom::combinator::map_parser(

--- a/lib/src/executor/host/runtime_version.rs
+++ b/lib/src/executor/host/runtime_version.rs
@@ -241,7 +241,7 @@ pub struct CoreVersionRef<'a> {
     pub state_version: Option<TrieEntryVersion>,
 }
 
-impl<'a> CoreVersionRef<'a> {
+impl CoreVersionRef<'_> {
     /// Returns the SCALE encoding of this data structure.
     pub fn scale_encoding_vec(&self) -> Vec<u8> {
         // See https://spec.polkadot.network/#defn-rt-core-version
@@ -367,7 +367,7 @@ impl<'a> CoreVersionApisRefIter<'a> {
     }
 }
 
-impl<'a> Iterator for CoreVersionApisRefIter<'a> {
+impl Iterator for CoreVersionApisRefIter<'_> {
     type Item = CoreVersionApi;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -388,7 +388,7 @@ impl<'a> Iterator for CoreVersionApisRefIter<'a> {
     }
 }
 
-impl<'a> PartialEq for CoreVersionApisRefIter<'a> {
+impl PartialEq for CoreVersionApisRefIter<'_> {
     fn eq(&self, other: &Self) -> bool {
         let mut a = self.clone();
         let mut b = other.clone();
@@ -402,9 +402,9 @@ impl<'a> PartialEq for CoreVersionApisRefIter<'a> {
     }
 }
 
-impl<'a> Eq for CoreVersionApisRefIter<'a> {}
+impl Eq for CoreVersionApisRefIter<'_> {}
 
-impl<'a> fmt::Debug for CoreVersionApisRefIter<'a> {
+impl fmt::Debug for CoreVersionApisRefIter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -495,7 +495,7 @@ fn decode(scale_encoded: &[u8]) -> Result<CoreVersionRef, ()> {
 
 fn core_version_apis<'a, E: nom::error::ParseError<&'a [u8]>>(
     bytes: &'a [u8],
-) -> nom::IResult<&'a [u8], CoreVersionApisRefIter, E> {
+) -> nom::IResult<&'a [u8], CoreVersionApisRefIter<'a>, E> {
     nom::combinator::map(
         nom::combinator::flat_map(crate::util::nom_scale_compact_usize, |num_elems| {
             nom::combinator::recognize(nom::multi::fold_many_m_n(

--- a/lib/src/executor/host/tests.rs
+++ b/lib/src/executor/host/tests.rs
@@ -17,7 +17,7 @@
 
 #![cfg(test)]
 
-use super::{vm::ExecHint, Config, HeapPages, HostVm, HostVmPrototype, StorageProofSizeBehavior};
+use super::{Config, HeapPages, HostVm, HostVmPrototype, StorageProofSizeBehavior, vm::ExecHint};
 
 mod hash_algorithms;
 mod initialization;

--- a/lib/src/executor/host/tests/hash_algorithms.rs
+++ b/lib/src/executor/host/tests/hash_algorithms.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::super::{
-    vm::ExecHint, Config, HeapPages, HostVm, HostVmPrototype, StorageProofSizeBehavior,
+    Config, HeapPages, HostVm, HostVmPrototype, StorageProofSizeBehavior, vm::ExecHint,
 };
 use super::with_core_version_custom_sections;
 
@@ -298,7 +298,9 @@ gen_test!(
 gen_test!(
     ext_hashing_twox_128_version_1,
     16,
-    [104, 105, 30, 178, 52, 103, 171, 69, 199, 183, 31, 36, 197, 3, 27, 176]
+    [
+        104, 105, 30, 178, 52, 103, 171, 69, 199, 183, 31, 36, 197, 3, 27, 176
+    ]
 );
 
 gen_test!(

--- a/lib/src/executor/host/tests/initialization.rs
+++ b/lib/src/executor/host/tests/initialization.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::super::{
-    vm, vm::ExecHint, Config, HeapPages, HostVmPrototype, ModuleFormatError, NewErr,
+    Config, HeapPages, HostVmPrototype, ModuleFormatError, NewErr, vm, vm::ExecHint,
 };
 use super::with_core_version_custom_sections;
 
@@ -217,13 +217,15 @@ fn rococo_genesis_works() {
     let module_bytes = &include_bytes!("./rococo-genesis.wasm")[..];
 
     for exec_hint in ExecHint::available_engines() {
-        assert!(HostVmPrototype::new(Config {
-            allow_unresolved_imports: true,
-            exec_hint,
-            heap_pages: HeapPages::new(1024),
-            module: &module_bytes,
-        })
-        .is_ok());
+        assert!(
+            HostVmPrototype::new(Config {
+                allow_unresolved_imports: true,
+                exec_hint,
+                heap_pages: HeapPages::new(1024),
+                module: &module_bytes,
+            })
+            .is_ok()
+        );
     }
 }
 

--- a/lib/src/executor/host/tests/run.rs
+++ b/lib/src/executor/host/tests/run.rs
@@ -16,8 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::super::{
-    vm, vm::ExecHint, Config, Error, HeapPages, HostVm, HostVmPrototype, NewErr, StartErr,
-    StorageProofSizeBehavior,
+    Config, Error, HeapPages, HostVm, HostVmPrototype, NewErr, StartErr, StorageProofSizeBehavior,
+    vm, vm::ExecHint,
 };
 use super::with_core_version_custom_sections;
 

--- a/lib/src/executor/runtime_call.rs
+++ b/lib/src/executor/runtime_call.rs
@@ -200,7 +200,7 @@ impl StorageChanges {
     /// >           changes made to the main trie.
     pub fn main_trie_storage_changes_iter_unordered(
         &'_ self,
-    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone + '_ {
+    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone {
         self.inner
             .trie_diffs
             .get(&None)
@@ -209,7 +209,7 @@ impl StorageChanges {
     }
 
     /// Returns the list of all child tries whose content has been modified in some way.
-    pub fn tries_with_storage_changes_unordered(&'_ self) -> impl Iterator<Item = &'_ [u8]> + '_ {
+    pub fn tries_with_storage_changes_unordered(&'_ self) -> impl Iterator<Item = &'_ [u8]> {
         self.inner.trie_diffs.keys().filter_map(|k| k.as_deref())
     }
 
@@ -225,7 +225,7 @@ impl StorageChanges {
     pub fn child_trie_storage_changes_iter_unordered(
         &'_ self,
         child_trie: &'_ [u8],
-    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone + '_ {
+    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone {
         self.inner
             .trie_diffs
             .get(&Some(child_trie.to_vec())) // TODO: annoying unnecessary overhead
@@ -239,7 +239,7 @@ impl StorageChanges {
     /// the underlying value.
     pub fn storage_changes_iter_unordered(
         &'_ self,
-    ) -> impl Iterator<Item = (Option<&'_ [u8]>, &'_ [u8], Option<&'_ [u8]>)> + Clone + '_ {
+    ) -> impl Iterator<Item = (Option<&'_ [u8]>, &'_ [u8], Option<&'_ [u8]>)> + Clone {
         self.inner.trie_diffs.iter().flat_map(|(trie, list)| {
             list.diff_iter_unordered()
                 .map(move |(k, v, ())| (trie.as_deref(), k, v))
@@ -472,7 +472,7 @@ pub struct SuccessVirtualMachine(host::Finished);
 
 impl SuccessVirtualMachine {
     /// Returns the value the called function has returned.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn value(&'_ self) -> impl AsRef<[u8]> {
         self.0.value()
     }
 
@@ -577,7 +577,7 @@ pub struct StorageGet {
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -616,7 +616,7 @@ impl StorageGet {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -709,7 +709,7 @@ pub struct NextKey {
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         if let Some(key_overwrite) = &self.key_overwrite {
             return either::Left(trie::bytes_to_nibbles(key_overwrite.iter().copied()));
         }
@@ -732,7 +732,7 @@ impl NextKey {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -773,7 +773,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
         match (&self.inner.vm, self.inner.root_calculation.as_ref()) {
             (host::HostVm::ExternalStorageClearPrefix(req), _) => {
                 either::Left(trie::bytes_to_nibbles(util::as_ref_iter(req.prefix())))
@@ -889,7 +889,7 @@ pub struct ClosestDescendantMerkleValue {
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
         let (_, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request)) =
             self.inner.root_calculation.as_ref().unwrap()
         else {
@@ -899,7 +899,7 @@ impl ClosestDescendantMerkleValue {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
         let (trie, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(_)) =
             self.inner.root_calculation.as_ref().unwrap()
         else {
@@ -957,7 +957,7 @@ pub struct SignatureVerification {
 
 impl SignatureVerification {
     /// Returns the message that the signature is expected to sign.
-    pub fn message(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn message(&'_ self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.message(),
             _ => unreachable!(),
@@ -968,7 +968,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
     /// >           set of valid signatures.
-    pub fn signature(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn signature(&'_ self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.signature(),
             _ => unreachable!(),
@@ -979,7 +979,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
     /// >           set of valid public keys.
-    pub fn public_key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn public_key(&'_ self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.public_key(),
             _ => unreachable!(),
@@ -1041,7 +1041,7 @@ pub struct OffchainStorageGet {
 
 impl OffchainStorageGet {
     /// Returns the key whose value must be passed to [`OffchainStorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageGet(req) => req.key(),
             // We only create a `OffchainStorageGet` if the state is one of the above.
@@ -1071,7 +1071,7 @@ pub struct OffchainStorageSet {
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::Finished(_) => {
                 self.inner
@@ -1088,7 +1088,7 @@ impl OffchainStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::Finished(_) => self
                 .inner
@@ -1124,7 +1124,7 @@ pub struct OffchainStorageCompareSet {
 
 impl OffchainStorageCompareSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn key(&'_ self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => either::Left(req.key()),
             host::HostVm::Finished(_) => either::Right(
@@ -1142,7 +1142,7 @@ impl OffchainStorageCompareSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => req.value().map(either::Left),
             host::HostVm::Finished(_) => self
@@ -1160,7 +1160,7 @@ impl OffchainStorageCompareSet {
     }
 
     /// Returns the value the current value should be compared against. The operation is a no-op if they don't compare equal.
-    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]> + '_> {
+    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => req.old_value(),
             host::HostVm::Finished(_) => None,
@@ -1236,7 +1236,7 @@ pub struct OffchainSubmitTransaction {
 
 impl OffchainSubmitTransaction {
     /// Returns the SCALE-encoded transaction that must be submitted.
-    pub fn transaction(&'_ self) -> impl AsRef<[u8]> + '_ {
+    pub fn transaction(&'_ self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::OffchainSubmitTransaction(req) => req.transaction(),
             // We only create a `OffchainSubmitTransaction` if the state is one of the above.

--- a/lib/src/executor/runtime_call.rs
+++ b/lib/src/executor/runtime_call.rs
@@ -253,7 +253,7 @@ impl StorageChanges {
     /// [`StorageChanges`] was created using [`StorageChanges::empty`].
     pub fn trie_changes_iter_ordered(
         &self,
-    ) -> Option<impl Iterator<Item = (Option<&[u8]>, &[Nibble], TrieChange<'_>)>> {
+    ) -> Option<impl Iterator<Item = (Option<&[u8]>, &[Nibble], TrieChange)>> {
         if !self.calculate_trie_changes {
             return None;
         }
@@ -324,7 +324,7 @@ impl StorageChanges {
 }
 
 impl fmt::Debug for StorageChanges {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(trie_changes) = self.trie_changes_iter_ordered() {
             f.debug_map()
                 .entries(trie_changes.map(|(child_trie, key, change)| {
@@ -409,7 +409,7 @@ pub enum TrieChange<'a> {
 }
 
 impl<'a> fmt::Debug for TrieChange<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TrieChange::Remove => f.debug_tuple("Remove").finish(),
             TrieChange::InsertUpdate {
@@ -451,7 +451,7 @@ pub enum TrieChangeStorageValue<'a> {
 }
 
 impl<'a> fmt::Debug for TrieChangeStorageValue<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TrieChangeStorageValue::Unmodified => f.debug_tuple("Unmodified").finish(),
             TrieChangeStorageValue::Modified { new_value: None } => {

--- a/lib/src/executor/runtime_call.rs
+++ b/lib/src/executor/runtime_call.rs
@@ -199,8 +199,8 @@ impl StorageChanges {
     /// >           [`StorageChanges::storage_changes_iter_unordered`], except that it only returns
     /// >           changes made to the main trie.
     pub fn main_trie_storage_changes_iter_unordered(
-        &'_ self,
-    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone {
+        &self,
+    ) -> impl Iterator<Item = (&[u8], Option<&[u8]>)> + Clone {
         self.inner
             .trie_diffs
             .get(&None)
@@ -209,7 +209,7 @@ impl StorageChanges {
     }
 
     /// Returns the list of all child tries whose content has been modified in some way.
-    pub fn tries_with_storage_changes_unordered(&'_ self) -> impl Iterator<Item = &'_ [u8]> {
+    pub fn tries_with_storage_changes_unordered(&self) -> impl Iterator<Item = &[u8]> {
         self.inner.trie_diffs.keys().filter_map(|k| k.as_deref())
     }
 
@@ -223,9 +223,9 @@ impl StorageChanges {
     /// >           [`StorageChanges::storage_changes_iter_unordered`], except that it only returns
     /// >           changes made to the given child trie.
     pub fn child_trie_storage_changes_iter_unordered(
-        &'_ self,
-        child_trie: &'_ [u8],
-    ) -> impl Iterator<Item = (&'_ [u8], Option<&'_ [u8]>)> + Clone {
+        &self,
+        child_trie: &[u8],
+    ) -> impl Iterator<Item = (&[u8], Option<&[u8]>)> + Clone {
         self.inner
             .trie_diffs
             .get(&Some(child_trie.to_vec())) // TODO: annoying unnecessary overhead
@@ -238,8 +238,8 @@ impl StorageChanges {
     /// Each value is either `Some` if the runtime overwrites this value, or `None` if it erases
     /// the underlying value.
     pub fn storage_changes_iter_unordered(
-        &'_ self,
-    ) -> impl Iterator<Item = (Option<&'_ [u8]>, &'_ [u8], Option<&'_ [u8]>)> + Clone {
+        &self,
+    ) -> impl Iterator<Item = (Option<&[u8]>, &[u8], Option<&[u8]>)> + Clone {
         self.inner.trie_diffs.iter().flat_map(|(trie, list)| {
             list.diff_iter_unordered()
                 .map(move |(k, v, ())| (trie.as_deref(), k, v))
@@ -252,8 +252,8 @@ impl StorageChanges {
     /// Returns `Some` if and only if [`Config::calculate_trie_changes`] was `true` or if the
     /// [`StorageChanges`] was created using [`StorageChanges::empty`].
     pub fn trie_changes_iter_ordered(
-        &'_ self,
-    ) -> Option<impl Iterator<Item = (Option<&'_ [u8]>, &'_ [Nibble], TrieChange<'_>)>> {
+        &self,
+    ) -> Option<impl Iterator<Item = (Option<&[u8]>, &[Nibble], TrieChange<'_>)>> {
         if !self.calculate_trie_changes {
             return None;
         }
@@ -472,7 +472,7 @@ pub struct SuccessVirtualMachine(host::Finished);
 
 impl SuccessVirtualMachine {
     /// Returns the value the called function has returned.
-    pub fn value(&'_ self) -> impl AsRef<[u8]> {
+    pub fn value(&self) -> impl AsRef<[u8]> {
         self.0.value()
     }
 
@@ -577,7 +577,7 @@ pub struct StorageGet {
 
 impl StorageGet {
     /// Returns the key whose value must be passed to [`StorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -616,7 +616,7 @@ impl StorageGet {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -709,7 +709,7 @@ pub struct NextKey {
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         if let Some(key_overwrite) = &self.key_overwrite {
             return either::Left(trie::bytes_to_nibbles(key_overwrite.iter().copied()));
         }
@@ -732,7 +732,7 @@ impl NextKey {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         enum Three<A, B, C> {
             A(A),
             B(B),
@@ -773,7 +773,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn prefix(&self) -> impl Iterator<Item = Nibble> {
         match (&self.inner.vm, self.inner.root_calculation.as_ref()) {
             (host::HostVm::ExternalStorageClearPrefix(req), _) => {
                 either::Left(trie::bytes_to_nibbles(util::as_ref_iter(req.prefix())))
@@ -889,7 +889,7 @@ pub struct ClosestDescendantMerkleValue {
 impl ClosestDescendantMerkleValue {
     /// Returns the key whose closest descendant Merkle value must be passed to
     /// [`ClosestDescendantMerkleValue::inject_merkle_value`].
-    pub fn key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn key(&self) -> impl Iterator<Item = Nibble> {
         let (_, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(request)) =
             self.inner.root_calculation.as_ref().unwrap()
         else {
@@ -899,7 +899,7 @@ impl ClosestDescendantMerkleValue {
     }
 
     /// If `Some`, read from the given child trie. If `None`, read from the main trie.
-    pub fn child_trie(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn child_trie(&self) -> Option<impl AsRef<[u8]>> {
         let (trie, trie_root_calculator::InProgress::ClosestDescendantMerkleValue(_)) =
             self.inner.root_calculation.as_ref().unwrap()
         else {
@@ -957,7 +957,7 @@ pub struct SignatureVerification {
 
 impl SignatureVerification {
     /// Returns the message that the signature is expected to sign.
-    pub fn message(&'_ self) -> impl AsRef<[u8]> {
+    pub fn message(&self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.message(),
             _ => unreachable!(),
@@ -968,7 +968,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this signature is untrusted input and might not be part of the
     /// >           set of valid signatures.
-    pub fn signature(&'_ self) -> impl AsRef<[u8]> {
+    pub fn signature(&self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.signature(),
             _ => unreachable!(),
@@ -979,7 +979,7 @@ impl SignatureVerification {
     ///
     /// > **Note**: Be aware that this public key is untrusted input and might not be part of the
     /// >           set of valid public keys.
-    pub fn public_key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn public_key(&self) -> impl AsRef<[u8]> {
         match self.inner.vm {
             host::HostVm::SignatureVerification(ref sig) => sig.public_key(),
             _ => unreachable!(),
@@ -1041,7 +1041,7 @@ pub struct OffchainStorageGet {
 
 impl OffchainStorageGet {
     /// Returns the key whose value must be passed to [`OffchainStorageGet::inject_value`].
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageGet(req) => req.key(),
             // We only create a `OffchainStorageGet` if the state is one of the above.
@@ -1071,7 +1071,7 @@ pub struct OffchainStorageSet {
 
 impl OffchainStorageSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::Finished(_) => {
                 self.inner
@@ -1088,7 +1088,7 @@ impl OffchainStorageSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::Finished(_) => self
                 .inner
@@ -1124,7 +1124,7 @@ pub struct OffchainStorageCompareSet {
 
 impl OffchainStorageCompareSet {
     /// Returns the key whose value must be set.
-    pub fn key(&'_ self) -> impl AsRef<[u8]> {
+    pub fn key(&self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => either::Left(req.key()),
             host::HostVm::Finished(_) => either::Right(
@@ -1142,7 +1142,7 @@ impl OffchainStorageCompareSet {
     /// Returns the value to set.
     ///
     /// If `None` is returned, the key should be removed from the storage entirely.
-    pub fn value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn value(&self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => req.value().map(either::Left),
             host::HostVm::Finished(_) => self
@@ -1160,7 +1160,7 @@ impl OffchainStorageCompareSet {
     }
 
     /// Returns the value the current value should be compared against. The operation is a no-op if they don't compare equal.
-    pub fn old_value(&'_ self) -> Option<impl AsRef<[u8]>> {
+    pub fn old_value(&self) -> Option<impl AsRef<[u8]>> {
         match &self.inner.vm {
             host::HostVm::ExternalOffchainStorageSet(req) => req.old_value(),
             host::HostVm::Finished(_) => None,
@@ -1236,7 +1236,7 @@ pub struct OffchainSubmitTransaction {
 
 impl OffchainSubmitTransaction {
     /// Returns the SCALE-encoded transaction that must be submitted.
-    pub fn transaction(&'_ self) -> impl AsRef<[u8]> {
+    pub fn transaction(&self) -> impl AsRef<[u8]> {
         match &self.inner.vm {
             host::HostVm::OffchainSubmitTransaction(req) => req.transaction(),
             // We only create a `OffchainSubmitTransaction` if the state is one of the above.

--- a/lib/src/executor/runtime_call/tests.rs
+++ b/lib/src/executor/runtime_call/tests.rs
@@ -25,7 +25,7 @@
 
 use core::{iter, ops};
 
-use super::{run, Config, RuntimeCall, StorageProofSizeBehavior};
+use super::{Config, RuntimeCall, StorageProofSizeBehavior, run};
 use crate::{executor::host, trie};
 use alloc::collections::BTreeMap;
 

--- a/lib/src/executor/storage_diff.rs
+++ b/lib/src/executor/storage_diff.rs
@@ -199,7 +199,7 @@ impl<T> TrieDiff<T> {
     ///
     pub fn storage_next_key<'a>(
         &'a self,
-        key: &'_ [u8],
+        key: &[u8],
         in_parent_next_key: Option<&'a [u8]>,
         or_equal: bool,
     ) -> StorageNextKey<'a> {

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -124,7 +124,7 @@ pub struct ClosestDescendant {
 impl ClosestDescendant {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose closest descendant must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.inner
             .current_node_full_key()
             .map(either::Left)
@@ -223,7 +223,7 @@ pub struct StorageValue(Box<Inner>);
 impl StorageValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose storage value must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.0.current_node_full_key()
     }
 
@@ -403,7 +403,7 @@ pub struct ClosestDescendantMerkleValue {
 impl ClosestDescendantMerkleValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose closest descendant Merkle value must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         // A `ClosestDescendantMerkleValue` is created directly in response to a `ClosestAncestor` without
         // updating the `Inner`.
         self.inner.current_node_full_key()
@@ -488,7 +488,7 @@ pub struct TrieNodeInsertUpdateEvent {
 
 impl TrieNodeInsertUpdateEvent {
     /// Returns the key of the trie node that was inserted or updated.
-    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.inner
             .current_node_full_key()
             .map(either::Left)
@@ -560,7 +560,7 @@ enum TrieNodeRemoveEventTy {
 
 impl TrieNodeRemoveEvent {
     /// Returns the key of the trie node that was removed.
-    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.inner
             .current_node_full_key()
             .map(either::Left)
@@ -691,7 +691,7 @@ impl Inner {
 
     /// Iterator of arrays which, when joined together, form the full key of the node currently
     /// being iterated.
-    fn current_node_full_key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]> + '_> + '_ {
+    fn current_node_full_key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.stack.iter().flat_map(move |node| {
             let maybe_child_nibble_u8 =
                 u8::try_from(node.children.len()).unwrap_or_else(|_| unreachable!());

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -146,11 +146,12 @@ impl ClosestDescendant {
         closest_descendant: Option<impl Iterator<Item = Nibble>>,
     ) -> InProgress {
         // We are after a call to `BaseTrieClosestDescendant`.
-        debug_assert!(self
-            .inner
-            .stack
-            .last()
-            .map_or(true, |n| n.children.len() != 16));
+        debug_assert!(
+            self.inner
+                .stack
+                .last()
+                .map_or(true, |n| n.children.len() != 16)
+        );
 
         // Length of the key of the currently-iterated node.
         let iter_key_len = self

--- a/lib/src/executor/trie_root_calculator.rs
+++ b/lib/src/executor/trie_root_calculator.rs
@@ -124,7 +124,7 @@ pub struct ClosestDescendant {
 impl ClosestDescendant {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose closest descendant must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
+    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.inner
             .current_node_full_key()
             .map(either::Left)
@@ -223,7 +223,7 @@ pub struct StorageValue(Box<Inner>);
 impl StorageValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose storage value must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
+    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.0.current_node_full_key()
     }
 
@@ -403,7 +403,7 @@ pub struct ClosestDescendantMerkleValue {
 impl ClosestDescendantMerkleValue {
     /// Returns an iterator of slices, which, when joined together, form the full key of the trie
     /// node whose closest descendant Merkle value must be fetched.
-    pub fn key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
+    pub fn key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         // A `ClosestDescendantMerkleValue` is created directly in response to a `ClosestAncestor` without
         // updating the `Inner`.
         self.inner.current_node_full_key()
@@ -691,7 +691,7 @@ impl Inner {
 
     /// Iterator of arrays which, when joined together, form the full key of the node currently
     /// being iterated.
-    fn current_node_full_key(&'_ self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
+    fn current_node_full_key(&self) -> impl Iterator<Item = impl AsRef<[Nibble]>> {
         self.stack.iter().flat_map(move |node| {
             let maybe_child_nibble_u8 =
                 u8::try_from(node.children.len()).unwrap_or_else(|_| unreachable!());

--- a/lib/src/executor/trie_root_calculator/tests.rs
+++ b/lib/src/executor/trie_root_calculator/tests.rs
@@ -17,7 +17,7 @@
 
 #![cfg(test)]
 
-use super::{trie_root_calculator, Config, InProgress, TrieEntryVersion};
+use super::{Config, InProgress, TrieEntryVersion, trie_root_calculator};
 use crate::{executor::storage_diff::TrieDiff, trie};
 use core::{iter, ops};
 

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -424,7 +424,7 @@ impl Prepare {
     ///
     /// Returns an error if the range is invalid or out of range.
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
@@ -689,7 +689,7 @@ impl VirtualMachine {
     ///
     /// Returns an error if the range is invalid or out of range.
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {

--- a/lib/src/executor/vm.rs
+++ b/lib/src/executor/vm.rs
@@ -427,7 +427,7 @@ impl Prepare {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         Ok(match &self.inner {
             #[cfg(all(
                 any(
@@ -692,7 +692,7 @@ impl VirtualMachine {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         Ok(match &self.inner {
             #[cfg(all(
                 any(

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -273,7 +273,7 @@ impl Prepare {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         let offset = usize::try_from(offset).map_err(|_| OutOfBoundsError)?;
 
         let max = offset
@@ -535,7 +535,7 @@ impl Interpreter {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         let offset = usize::try_from(offset).map_err(|_| OutOfBoundsError)?;
 
         let max = offset

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -96,7 +96,7 @@ impl InterpreterPrototype {
                                 return Err(NewErr::UnresolvedFunctionImport {
                                     module_name: import.module().to_owned(),
                                     function: import.name().to_owned(),
-                                })
+                                });
                             }
                         };
 
@@ -121,7 +121,7 @@ impl InterpreterPrototype {
                 }
                 wasmi::ExternType::Memory(_) => {}
                 wasmi::ExternType::Global(_) | wasmi::ExternType::Table(_) => {
-                    return Err(NewErr::ImportTypeNotSupported)
+                    return Err(NewErr::ImportTypeNotSupported);
                 }
             }
         }

--- a/lib/src/executor/vm/interpreter.rs
+++ b/lib/src/executor/vm/interpreter.rs
@@ -270,7 +270,7 @@ impl Prepare {
 
     /// See [`super::Prepare::read_memory`].
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
@@ -532,7 +532,7 @@ impl Interpreter {
 
     /// See [`super::VirtualMachine::read_memory`].
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -23,7 +23,7 @@ use super::{
 };
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{fmt, future, mem, pin, ptr, slice, task};
+use core::{fmt, future, mem, pin, slice, task};
 // TODO: we use std::sync::Mutex rather than parking_lot::Mutex due to issues with Cargo features, see <https://github.com/paritytech/smoldot/issues/2732>
 use std::sync::Mutex;
 
@@ -735,7 +735,7 @@ impl Jit {
         // execution might be able to progress, hence the lack of need for a waker.
         match Future::poll(
             function_call.as_mut(),
-            &mut task::Context::from_waker(&noop_waker()),
+            &mut task::Context::from_waker(task::Waker::noop()),
         ) {
             task::Poll::Ready((store, Ok(val))) => {
                 self.inner = JitInner::Done(store);
@@ -928,7 +928,7 @@ impl Jit {
                 // execution might be able to progress, hence the lack of need for a waker.
                 match Future::poll(
                     function_call.as_mut(),
-                    &mut task::Context::from_waker(&noop_waker()),
+                    &mut task::Context::from_waker(task::Waker::noop()),
                 ) {
                     task::Poll::Ready(_) => unreachable!(),
                     task::Poll::Pending => {

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -411,7 +411,7 @@ impl Prepare {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         let memory_slice = self.inner.memory.data(&self.inner.store);
 
         let start = usize::try_from(offset).map_err(|_| OutOfBoundsError)?;
@@ -807,7 +807,7 @@ impl Jit {
         &'_ self,
         offset: u32,
         size: u32,
-    ) -> Result<impl AsRef<[u8]> + '_, OutOfBoundsError> {
+    ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
         let memory_slice = match &self.inner {
             JitInner::NotStarted { store, .. } | JitInner::Done(store) => self.memory.data(store),
             JitInner::Executing(_) => {

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -115,7 +115,7 @@ impl JitPrototype {
                                     return Err(NewErr::UnresolvedFunctionImport {
                                         module_name: import.module().to_owned(),
                                         function: import.name().to_owned(),
-                                    })
+                                    });
                                 }
                             };
 

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -301,7 +301,7 @@ impl JitPrototype {
                 &base_components.module,
                 &imports
             )),
-            &mut task::Context::from_waker(&noop_waker()),
+            &mut task::Context::from_waker(task::Waker::noop()),
         ) {
             task::Poll::Pending => return Err(NewErr::StartFunctionNotSupported), // TODO: hacky error value, as the error could also be different
             task::Poll::Ready(Ok(i)) => i,
@@ -963,16 +963,3 @@ impl fmt::Debug for Jit {
 // anyway.
 // TODO: maybe find a way to remove this unsafe implementation
 unsafe impl Sync for Jit {}
-
-fn noop_waker() -> task::Waker {
-    // Safety: all the requirements in the documentation of wakers (e.g. thread safety) is
-    // irrelevant here due to the implementation being trivial.
-    unsafe {
-        fn clone(_: *const ()) -> task::RawWaker {
-            task::RawWaker::new(ptr::null(), &VTABLE)
-        }
-        fn noop(_: *const ()) {}
-        static VTABLE: task::RawWakerVTable = task::RawWakerVTable::new(clone, noop, noop, noop);
-        task::Waker::from_raw(task::RawWaker::new(ptr::null(), &VTABLE))
-    }
-}

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -408,7 +408,7 @@ impl Prepare {
 
     /// See [`super::Prepare::read_memory`].
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {
@@ -804,7 +804,7 @@ impl Jit {
 
     /// See [`super::VirtualMachine::read_memory`].
     pub fn read_memory(
-        &'_ self,
+        &self,
         offset: u32,
         size: u32,
     ) -> Result<impl AsRef<[u8]>, OutOfBoundsError> {

--- a/lib/src/executor/vm/jit.rs
+++ b/lib/src/executor/vm/jit.rs
@@ -295,7 +295,7 @@ impl JitPrototype {
         // If the `start` function doesn't call any import, then it will go undetected and no
         // error will be returned.
         // TODO: detect `start` anyway, for consistency with other backends
-        let instance = match future::Future::poll(
+        let instance = match Future::poll(
             pin::pin!(wasmtime::Instance::new_async(
                 &mut store,
                 &base_components.module,
@@ -620,7 +620,7 @@ enum JitInner {
     Done(wasmtime::Store<()>),
 }
 
-type BoxFuture<T> = pin::Pin<Box<dyn future::Future<Output = T> + Send>>;
+type BoxFuture<T> = pin::Pin<Box<dyn Future<Output = T> + Send>>;
 type ExecOutcomeValue = Result<Option<WasmValue>, wasmtime::Error>;
 
 impl Jit {
@@ -733,7 +733,7 @@ impl Jit {
         // Resume the coroutine execution.
         // The `Future` is polled with a no-op waker. We are in total control of when the
         // execution might be able to progress, hence the lack of need for a waker.
-        match future::Future::poll(
+        match Future::poll(
             function_call.as_mut(),
             &mut task::Context::from_waker(&noop_waker()),
         ) {
@@ -926,7 +926,7 @@ impl Jit {
                 // `MemoryGrowRequired`, perform the grow, and switch back to `WithinFunctionCall`.
                 // The `Future` is polled with a no-op waker. We are in total control of when the
                 // execution might be able to progress, hence the lack of need for a waker.
-                match future::Future::poll(
+                match Future::poll(
                     function_call.as_mut(),
                     &mut task::Context::from_waker(&noop_waker()),
                 ) {

--- a/lib/src/executor/vm/tests.rs
+++ b/lib/src/executor/vm/tests.rs
@@ -85,12 +85,14 @@ fn out_of_memory_access() {
             0x06, 0x01, 0x00, 0x41, 0x03, 0x0b, 0x00,
         ];
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes[..],
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0)
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes[..],
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0)
+            })
+            .is_err()
+        );
     }
 }
 
@@ -102,12 +104,14 @@ fn has_start_function() {
             0x02, 0x09, 0x01, 0x01, 0x71, 0x03, 0x69, 0x6d, 0x70, 0x00, 0x00, 0x08, 0x01, 0x00,
         ];
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes[..],
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0)
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes[..],
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0)
+            })
+            .is_err()
+        );
     }
 }
 
@@ -120,12 +124,14 @@ fn unsupported_type() {
             0x00, 0x00,
         ];
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes[..],
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0)
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes[..],
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0)
+            })
+            .is_err()
+        );
     }
 }
 
@@ -997,12 +1003,14 @@ fn feature_disabled_signext() {
             continue;
         }
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1028,12 +1036,14 @@ fn feature_disabled_saturated_float_to_int() {
             continue;
         }
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1053,12 +1063,14 @@ fn feature_disabled_threads() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1075,12 +1087,14 @@ fn feature_disabled_reference_type() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1100,12 +1114,14 @@ fn feature_disabled_bulk_memory() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1124,12 +1140,14 @@ fn feature_disabled_multi_value() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1145,12 +1163,14 @@ fn feature_disabled_memory64() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1173,12 +1193,14 @@ fn feature_disabled_mutable_globals() {
             continue;
         }
 
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1208,12 +1230,14 @@ fn feature_disabled_tail_call() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 
@@ -1267,12 +1291,14 @@ fn feature_disabled_simd128() {
     .unwrap();
 
     for exec_hint in super::ExecHint::available_engines() {
-        assert!(super::VirtualMachinePrototype::new(super::Config {
-            module_bytes: &module_bytes,
-            exec_hint,
-            symbols: &mut |_, _, _| Ok(0),
-        })
-        .is_err());
+        assert!(
+            super::VirtualMachinePrototype::new(super::Config {
+                module_bytes: &module_bytes,
+                exec_hint,
+                symbols: &mut |_, _, _| Ok(0),
+            })
+            .is_err()
+        );
     }
 }
 

--- a/lib/src/finality/decode.rs
+++ b/lib/src/finality/decode.rs
@@ -181,7 +181,7 @@ enum PrecommitsRefInner<'a> {
 }
 
 impl<'a> PrecommitsRef<'a> {
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = PrecommitRef<'a>> + 'a {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = PrecommitRef<'a>> + use<'a> {
         match self.inner {
             PrecommitsRefInner::Undecoded {
                 data,

--- a/lib/src/finality/decode.rs
+++ b/lib/src/finality/decode.rs
@@ -165,7 +165,7 @@ pub struct PrecommitsRef<'a> {
     inner: PrecommitsRefInner<'a>,
 }
 
-impl<'a> fmt::Debug for PrecommitsRef<'a> {
+impl fmt::Debug for PrecommitsRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -250,7 +250,7 @@ impl<'a> Iterator for PrecommitsRefIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for PrecommitsRefIter<'a> {}
+impl ExactSizeIterator for PrecommitsRefIter<'_> {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrecommitRef<'a> {
@@ -268,7 +268,7 @@ pub struct PrecommitRef<'a> {
     pub authority_public_key: &'a [u8; 32],
 }
 
-impl<'a> PrecommitRef<'a> {
+impl PrecommitRef<'_> {
     /// Decodes a SCALE-encoded precommit.
     ///
     /// Returns the rest of the data alongside with the decoded struct.
@@ -357,7 +357,7 @@ impl<'a> Iterator for VotesAncestriesIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for VotesAncestriesIter<'a> {}
+impl ExactSizeIterator for VotesAncestriesIter<'_> {}
 
 /// Potential error when decoding a Grandpa justification.
 #[derive(Debug, derive_more::Display, derive_more::Error)]
@@ -368,7 +368,7 @@ pub struct JustificationDecodeError(#[error(not(source))] nom::error::ErrorKind)
 /// `Nom` combinator that parses a justification.
 fn grandpa_justification<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], GrandpaJustificationRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], GrandpaJustificationRef<'a>> {
     nom::error::context(
         "grandpa_justification",
         nom::combinator::map(
@@ -395,7 +395,7 @@ fn grandpa_justification<'a>(
 /// `Nom` combinator that parses a list of precommits.
 fn precommits<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrecommitsRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], PrecommitsRef<'a>> {
     nom::combinator::map(
         nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
             nom::combinator::recognize(nom::multi::fold_many_m_n(
@@ -418,7 +418,7 @@ fn precommits<'a>(
 /// `Nom` combinator that parses a single precommit.
 fn precommit<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrecommitRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], PrecommitRef<'a>> {
     nom::error::context(
         "precommit",
         nom::combinator::map(
@@ -441,7 +441,7 @@ fn precommit<'a>(
 /// `Nom` combinator that parses a list of headers.
 fn votes_ancestries<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], VotesAncestriesIter> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], VotesAncestriesIter<'a>> {
     nom::error::context(
         "votes ancestries",
         nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
@@ -474,7 +474,7 @@ fn votes_ancestries<'a>(
 
 fn commit_message<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], CommitMessageRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], CommitMessageRef<'a>> {
     nom::error::context(
         "commit_message",
         nom::combinator::map(
@@ -525,7 +525,7 @@ fn commit_message<'a>(
 
 fn unsigned_precommit<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], UnsignedPrecommitRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], UnsignedPrecommitRef<'a>> {
     nom::error::context(
         "unsigned_precommit",
         nom::combinator::map(

--- a/lib/src/finality/verify.rs
+++ b/lib/src/finality/verify.rs
@@ -20,8 +20,8 @@ use crate::finality::decode;
 use alloc::vec::Vec;
 use core::{cmp, iter, mem};
 use rand_chacha::{
-    rand_core::{RngCore as _, SeedableRng as _},
     ChaCha20Rng,
+    rand_core::{RngCore as _, SeedableRng as _},
 };
 
 /// Configuration for a commit verification process.
@@ -452,7 +452,7 @@ pub fn verify_justification<'a>(
             hashbrown::hash_map::Entry::Vacant(_) => {
                 return Err(JustificationVerifyError::NotAuthority {
                     authority_key: *precommit.authority_public_key,
-                })
+                });
             }
         }
 

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -346,7 +346,7 @@ impl Header {
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of the header.
     pub fn scale_encoding(
-        &'_ self,
+        &self,
         block_number_bytes: usize,
     ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         HeaderRef::from(self).scale_encoding(block_number_bytes)

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -252,7 +252,7 @@ impl<'a> HeaderRef<'a> {
     pub fn scale_encoding(
         &self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         self.scale_encoding_before_digest().map(either::Left).chain(
             self.digest
                 .scale_encoding(block_number_bytes)
@@ -269,7 +269,7 @@ impl<'a> HeaderRef<'a> {
         &self,
         block_number_bytes: usize,
         extra_item: DigestItemRef<'a>,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         self.scale_encoding_before_digest().map(either::Left).chain(
             self.digest
                 .scale_encoding_with_extra_item(block_number_bytes, extra_item)
@@ -279,7 +279,7 @@ impl<'a> HeaderRef<'a> {
 
     fn scale_encoding_before_digest(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         iter::once(either::Left(&self.parent_hash[..]))
             .chain(iter::once(either::Right(util::encode_scale_compact_u64(
                 self.number,
@@ -626,7 +626,7 @@ impl<'a> DigestRef<'a> {
     pub fn scale_encoding(
         &self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let encoded_len = util::encode_scale_compact_usize(self.logs().len());
         iter::once(either::Left(encoded_len)).chain(
             self.logs()
@@ -639,7 +639,7 @@ impl<'a> DigestRef<'a> {
         &self,
         block_number_bytes: usize,
         extra_item: DigestItemRef<'a>,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         // Given that `self.logs().len()` counts a number of items present in memory, and that
         // these items have a non-zero size, it is not possible for this value to be equal to
         // `usize::MAX`, as that would mean that the entire memory is completely full
@@ -1101,7 +1101,7 @@ impl<'a> DigestItemRef<'a> {
     pub fn scale_encoding(
         &self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let (item1, item2) = match *self {
             DigestItemRef::AuraPreDigest(ref aura_pre_digest) => {
                 let encoded = aura_pre_digest

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -770,14 +770,14 @@ impl<'a> DigestRef<'a> {
                     aura_predigest_index = Some(item_num);
                 }
                 DigestItemRef::AuraPreDigest(_) => {
-                    return Err(Error::MultipleAuraPreRuntimeDigests)
+                    return Err(Error::MultipleAuraPreRuntimeDigests);
                 }
                 DigestItemRef::AuraConsensus(_) => {}
                 DigestItemRef::BabePreDigest(_) if babe_predigest_index.is_none() => {
                     babe_predigest_index = Some(item_num);
                 }
                 DigestItemRef::BabePreDigest(_) => {
-                    return Err(Error::MultipleBabePreRuntimeDigests)
+                    return Err(Error::MultipleBabePreRuntimeDigests);
                 }
                 DigestItemRef::BabeConsensus(BabeConsensusLogRef::NextEpochData(_))
                     if babe_next_epoch_data_index.is_none() =>

--- a/lib/src/header.rs
+++ b/lib/src/header.rs
@@ -348,7 +348,7 @@ impl Header {
     pub fn scale_encoding(
         &'_ self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_ {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         HeaderRef::from(self).scale_encoding(block_number_bytes)
     }
 

--- a/lib/src/header/aura.rs
+++ b/lib/src/header/aura.rs
@@ -52,7 +52,7 @@ impl<'a> AuraConsensusLogRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let index = iter::once(match self {
             AuraConsensusLogRef::AuthoritiesChange(_) => [1],
             AuraConsensusLogRef::OnDisabled(_) => [2],
@@ -205,7 +205,7 @@ impl<'a> AuraAuthorityRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         iter::once(self.public_key)
     }
 }

--- a/lib/src/header/babe.rs
+++ b/lib/src/header/babe.rs
@@ -63,9 +63,7 @@ impl<'a> BabeConsensusLogRef<'a> {
 
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
-    pub fn scale_encoding(
-        &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    pub fn scale_encoding(&self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         let index = iter::once(match self {
             BabeConsensusLogRef::NextEpochData(_) => [1],
             BabeConsensusLogRef::OnDisabled(_) => [2],
@@ -163,7 +161,7 @@ impl<'a> BabeNextEpochRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let header = util::encode_scale_compact_usize(self.authorities.len());
         iter::once(either::Left(header))
             .chain(
@@ -289,7 +287,7 @@ impl<'a> BabeAuthorityRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         iter::once(either::Right(self.public_key))
             .chain(iter::once(either::Left(self.weight.to_le_bytes())))
     }
@@ -438,9 +436,7 @@ impl<'a> BabePreDigestRef<'a> {
 
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
-    pub fn scale_encoding(
-        &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    pub fn scale_encoding(&self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         let index = iter::once(match self {
             BabePreDigestRef::Primary(_) => [1],
             BabePreDigestRef::SecondaryPlain(_) => [2],
@@ -532,7 +528,7 @@ impl<'a> BabePrimaryPreDigestRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let header = iter::once(either::Left(self.authority_index.to_le_bytes()))
             .chain(iter::once(either::Right(self.slot_number.to_le_bytes())))
             .map(either::Left);
@@ -660,7 +656,7 @@ impl<'a> BabeSecondaryVRFPreDigestRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let header = iter::once(either::Left(self.authority_index.to_le_bytes()))
             .chain(iter::once(either::Right(self.slot_number.to_le_bytes())))
             .map(either::Left);

--- a/lib/src/header/grandpa.rs
+++ b/lib/src/header/grandpa.rs
@@ -406,9 +406,7 @@ pub struct GrandpaAuthority {
 impl GrandpaAuthority {
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
-    pub fn scale_encoding(
-        &'_ self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_ {
+    pub fn scale_encoding(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         GrandpaAuthorityRef::from(self).scale_encoding()
     }
 }

--- a/lib/src/header/grandpa.rs
+++ b/lib/src/header/grandpa.rs
@@ -86,7 +86,7 @@ impl<'a> GrandpaConsensusLogRef<'a> {
     pub fn scale_encoding(
         &self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let index = iter::once(match self {
             GrandpaConsensusLogRef::ScheduledChange(_) => [1],
             GrandpaConsensusLogRef::ForcedChange { .. } => [2],
@@ -245,7 +245,7 @@ impl<'a> GrandpaScheduledChangeRef<'a> {
     pub fn scale_encoding(
         &self,
         block_number_bytes: usize,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         let header = util::encode_scale_compact_usize(self.next_authorities.len());
 
         let mut delay = Vec::with_capacity(block_number_bytes);
@@ -377,7 +377,7 @@ impl<'a> GrandpaAuthorityRef<'a> {
     /// encoding of that object.
     pub fn scale_encoding(
         &self,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + use<'a>> + Clone + use<'a> {
         iter::once(either::Right(self.public_key))
             .chain(iter::once(either::Left(self.weight.get().to_le_bytes())))
     }

--- a/lib/src/header/grandpa.rs
+++ b/lib/src/header/grandpa.rs
@@ -406,7 +406,7 @@ pub struct GrandpaAuthority {
 impl GrandpaAuthority {
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
-    pub fn scale_encoding(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
+    pub fn scale_encoding(&self) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
         GrandpaAuthorityRef::from(self).scale_encoding()
     }
 }

--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -428,7 +428,7 @@ impl Keystore {
         public_key: &'a [u8; 32],
         label: &'static [u8],
         transcript_items: impl Iterator<Item = (&'static [u8], either::Either<&'a [u8], u64>)> + 'a,
-    ) -> impl core::future::Future<Output = Result<VrfSignature, SignVrfError>> + 'a {
+    ) -> impl Future<Output = Result<VrfSignature, SignVrfError>> {
         async move {
             let mut guarded = self.guarded.lock().await;
             let key = guarded

--- a/lib/src/identity/keystore.rs
+++ b/lib/src/identity/keystore.rs
@@ -692,10 +692,12 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(ed25519_zebra::VerificationKey::try_from(public_key)
-                .unwrap()
-                .verify(&ed25519_zebra::Signature::from(signature), b"hello world")
-                .is_ok());
+            assert!(
+                ed25519_zebra::VerificationKey::try_from(public_key)
+                    .unwrap()
+                    .verify(&ed25519_zebra::Signature::from(signature), b"hello world")
+                    .is_ok()
+            );
         });
     }
 
@@ -726,14 +728,16 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(schnorrkel::PublicKey::from_bytes(&public_key)
-                .unwrap()
-                .verify_simple(
-                    b"substrate",
-                    b"hello world",
-                    &schnorrkel::Signature::from_bytes(&signature).unwrap()
-                )
-                .is_ok());
+            assert!(
+                schnorrkel::PublicKey::from_bytes(&public_key)
+                    .unwrap()
+                    .verify_simple(
+                        b"substrate",
+                        b"hello world",
+                        &schnorrkel::Signature::from_bytes(&signature).unwrap()
+                    )
+                    .is_ok()
+            );
         });
     }
 }

--- a/lib/src/identity/ss58.rs
+++ b/lib/src/identity/ss58.rs
@@ -44,7 +44,7 @@ pub struct Decoded<P> {
 pub struct ChainPrefix(u16);
 
 impl fmt::Debug for ChainPrefix {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }

--- a/lib/src/identity/ss58.rs
+++ b/lib/src/identity/ss58.rs
@@ -101,7 +101,7 @@ pub fn encode(decoded: Decoded<impl AsRef<[u8]>>) -> String {
 }
 
 /// Decodes an SS58 address from a string.
-pub fn decode(encoded: &'_ str) -> Result<Decoded<impl AsRef<[u8]>>, DecodeError> {
+pub fn decode(encoded: &str) -> Result<Decoded<impl AsRef<[u8]>>, DecodeError> {
     let mut bytes = bs58::decode(encoded)
         .into_vec()
         .map_err(|err| DecodeError::InvalidBs58(Bs58DecodeError(err)))?;

--- a/lib/src/informant.rs
+++ b/lib/src/informant.rs
@@ -89,7 +89,7 @@ pub struct RelayChain<'a> {
 }
 
 impl<'a> fmt::Display for InformantLine<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: lots of allocations in here
         // TODO: this bar is actually harder to implement than expected; clean up code
 
@@ -193,7 +193,7 @@ impl<'a> fmt::Display for InformantLine<'a> {
 pub struct HashDisplay<'a>(pub &'a [u8]);
 
 impl<'a> fmt::Display for HashDisplay<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "0x")?;
         if self.0.len() >= 2 {
             let val = u16::from_be_bytes(<[u8; 2]>::try_from(&self.0[..2]).unwrap());
@@ -215,7 +215,7 @@ impl<'a> fmt::Display for HashDisplay<'a> {
 pub struct BytesDisplay(pub u64);
 
 impl fmt::Display for BytesDisplay {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut value = self.0 as f64;
 
         if value < 1000.0 {
@@ -265,7 +265,7 @@ impl fmt::Display for BytesDisplay {
 struct BlockNumberDisplay(u64);
 
 impl fmt::Display for BlockNumberDisplay {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "#{}", self.0)?;
         Ok(())
     }

--- a/lib/src/json_rpc/methods.rs
+++ b/lib/src/json_rpc/methods.rs
@@ -47,7 +47,7 @@ pub fn parse_jsonrpc_client_to_server(
         None => {
             return Err(ParseClientToServerError::UnknownNotification {
                 notification_name: call_def.method,
-            })
+            });
         }
     };
 
@@ -137,9 +137,7 @@ pub enum MethodError<'a> {
         actual: usize,
     },
     /// One of the parameters of the function call is invalid.
-    #[display(
-        "Parameter of index {parameter_index} is invalid when calling {rpc_method}: {error}"
-    )]
+    #[display("Parameter of index {parameter_index} is invalid when calling {rpc_method}: {error}")]
     InvalidParameter {
         /// Name of the JSON-RPC method that was attempted to be called.
         rpc_method: &'static str,

--- a/lib/src/json_rpc/parse.rs
+++ b/lib/src/json_rpc/parse.rs
@@ -621,10 +621,12 @@ mod tests {
 
     #[test]
     fn parse_response_missing_id() {
-        assert!(super::parse_response(
-            r#"{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"} }"#
-        )
-        .is_err());
+        assert!(
+            super::parse_response(
+                r#"{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"} }"#
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -675,6 +677,9 @@ mod tests {
     #[test]
     fn build_parse_error() {
         let response = super::build_parse_error_response();
-        assert_eq!(response, "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}");
+        assert_eq!(
+            response,
+            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}"
+        );
     }
 }

--- a/lib/src/json_rpc/payment_info.rs
+++ b/lib/src/json_rpc/payment_info.rs
@@ -18,9 +18,7 @@
 use super::methods;
 
 /// Produces the input to pass to the `TransactionPaymentApi_query_info` runtime call.
-pub fn payment_info_parameters(
-    extrinsic: &'_ [u8],
-) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
+pub fn payment_info_parameters(extrinsic: &[u8]) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
     [
         either::Left(extrinsic),
         either::Right(u32::try_from(extrinsic.len()).unwrap().to_le_bytes()),
@@ -36,7 +34,7 @@ pub const PAYMENT_FEES_FUNCTION_NAME: &str = "TransactionPaymentApi_query_info";
 /// Must be passed the version of the `TransactionPaymentApi` API, according to the runtime
 /// specification.
 pub fn decode_payment_info(
-    scale_encoded: &'_ [u8],
+    scale_encoded: &[u8],
     api_version: u32,
 ) -> Result<methods::RuntimeDispatchInfo, DecodeError> {
     let is_api_v2 = match api_version {
@@ -45,7 +43,7 @@ pub fn decode_payment_info(
         _ => return Err(DecodeError::UnknownRuntimeVersion),
     };
 
-    match nom::combinator::all_consuming(nom_decode_payment_info::<nom::error::Error<&'_ [u8]>>(
+    match nom::combinator::all_consuming(nom_decode_payment_info::<nom::error::Error<&[u8]>>(
         is_api_v2,
     ))(scale_encoded)
     {

--- a/lib/src/json_rpc/payment_info.rs
+++ b/lib/src/json_rpc/payment_info.rs
@@ -20,7 +20,7 @@ use super::methods;
 /// Produces the input to pass to the `TransactionPaymentApi_query_info` runtime call.
 pub fn payment_info_parameters(
     extrinsic: &'_ [u8],
-) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + Clone + '_ {
+) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
     [
         either::Left(extrinsic),
         either::Right(u32::try_from(extrinsic.len()).unwrap().to_le_bytes()),

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -500,10 +500,12 @@ impl ClientMainTask {
 
                     // Allocate the new subscription ID.
                     let subscription_id = self.allocate_subscription_id();
-                    debug_assert!(!self
-                        .inner
-                        .active_subscriptions
-                        .contains_key(&subscription_id));
+                    debug_assert!(
+                        !self
+                            .inner
+                            .active_subscriptions
+                            .contains_key(&subscription_id)
+                    );
 
                     // Insert an "kill channel" in the local state. This kill channel is shared
                     // with the subscription object and is used to notify when a subscription

--- a/lib/src/json_rpc/service/client_main_task.rs
+++ b/lib/src/json_rpc/service/client_main_task.rs
@@ -695,7 +695,7 @@ impl ClientMainTask {
 }
 
 impl fmt::Debug for ClientMainTask {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("ClientMainTask").finish()
     }
 }
@@ -921,7 +921,7 @@ impl SerializedRequestsIo {
 }
 
 impl fmt::Debug for SerializedRequestsIo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("SerializedRequestsIo").finish()
     }
 }
@@ -1006,7 +1006,7 @@ impl RequestProcess {
     /// Indicate the response to the request to the [`ClientMainTask`].
     ///
     /// Has no effect if the [`ClientMainTask`] has been destroyed.
-    pub fn respond(mut self, response: methods::Response<'_>) {
+    pub fn respond(mut self, response: methods::Response) {
         let request_id = methods::parse_jsonrpc_client_to_server(&self.request)
             .unwrap()
             .0;
@@ -1077,7 +1077,7 @@ impl RequestProcess {
 }
 
 impl fmt::Debug for RequestProcess {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.request, f)
     }
 }
@@ -1219,7 +1219,7 @@ impl SubscriptionStartProcess {
 }
 
 impl fmt::Debug for SubscriptionStartProcess {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.request, f)
     }
 }
@@ -1359,7 +1359,7 @@ impl Subscription {
 }
 
 impl fmt::Debug for Subscription {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Subscription")
             .field(&self.subscription_id)
             .finish()

--- a/lib/src/libp2p/collection.rs
+++ b/lib/src/libp2p/collection.rs
@@ -63,8 +63,8 @@ use core::{
     time::Duration,
 };
 use rand_chacha::{
-    rand_core::{RngCore as _, SeedableRng as _},
     ChaCha20Rng,
+    rand_core::{RngCore as _, SeedableRng as _},
 };
 
 pub use super::peer_id::PeerId;

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -691,7 +691,7 @@ where
     pub fn add_substream(&mut self, id: TSubId, outbound: bool) {
         match &mut self.connection {
             MultiStreamConnectionTaskInner::Handshake {
-                opened_substream: ref mut opened_substream @ None,
+                opened_substream: opened_substream @ None,
                 ..
             } if outbound => {
                 *opened_substream = Some((id, webrtc_framing::WebRtcFraming::new()));

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -701,9 +701,11 @@ where
                 extra_open_substreams,
                 ..
             } => {
-                assert!(opened_substream
-                    .as_ref()
-                    .map_or(true, |(open, _)| *open != id));
+                assert!(
+                    opened_substream
+                        .as_ref()
+                        .map_or(true, |(open, _)| *open != id)
+                );
                 // TODO: add a limit to the number allowed?
                 let _was_in = extra_open_substreams.insert(id, outbound);
                 assert!(_was_in.is_none());

--- a/lib/src/libp2p/collection/multi_stream.rs
+++ b/lib/src/libp2p/collection/multi_stream.rs
@@ -843,7 +843,7 @@ where
     pub fn substream_read_write(
         &mut self,
         substream_id: &TSubId,
-        read_write: &'_ mut ReadWrite<TNow>,
+        read_write: &mut ReadWrite<TNow>,
     ) -> SubstreamFate {
         // In WebRTC, the reading and writing sides are never closed.
         // Note that the `established::MultiStream` state machine also performs this check, but

--- a/lib/src/libp2p/collection/single_stream.rs
+++ b/lib/src/libp2p/collection/single_stream.rs
@@ -573,7 +573,7 @@ where
     ///
     /// Panics if [`SingleStreamConnectionTask::reset`] has been called in the past.
     ///
-    pub fn read_write(&mut self, read_write: &'_ mut ReadWrite<TNow>) {
+    pub fn read_write(&mut self, read_write: &mut ReadWrite<TNow>) {
         // There is already at least one pending message. We back-pressure the connection by not
         // performing any reading or writing, as this might generate more messages and open the
         // door for a DoS attack by the remote. As documented, the API user is supposed to pull

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -279,7 +279,7 @@ where
     pub fn substream_read_write(
         &mut self,
         substream_id: &TSubId,
-        read_write: &'_ mut ReadWrite<TNow>,
+        read_write: &mut ReadWrite<TNow>,
     ) -> SubstreamFate {
         let substream = self.in_substreams.get_mut(substream_id).unwrap();
 

--- a/lib/src/libp2p/connection/established/multi_stream.rs
+++ b/lib/src/libp2p/connection/established/multi_stream.rs
@@ -18,7 +18,7 @@
 // TODO: needs docs
 
 use super::{
-    super::super::read_write::ReadWrite, substream, Config, Event, SubstreamId, SubstreamIdInner,
+    super::super::read_write::ReadWrite, Config, Event, SubstreamId, SubstreamIdInner, substream,
 };
 use crate::{libp2p::connection::webrtc_framing, util};
 

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -127,7 +127,7 @@ where
     // TODO: consider exposing an API more similar to the one of substream::Substream::read_write?
     pub fn read_write(
         mut self,
-        read_write: &'_ mut ReadWrite<TNow>,
+        read_write: &mut ReadWrite<TNow>,
     ) -> Result<(SingleStream<TNow, TSubUd>, Option<Event<TSubUd>>), Error> {
         // Start any outgoing ping if necessary.
         if read_write.now >= self.inner.next_ping {

--- a/lib/src/libp2p/connection/established/single_stream.rs
+++ b/lib/src/libp2p/connection/established/single_stream.rs
@@ -52,8 +52,8 @@
 
 use super::{
     super::{super::read_write::ReadWrite, noise, yamux},
-    substream::{self, RespondInRequestError},
     Config, Event, SubstreamId, SubstreamIdInner,
+    substream::{self, RespondInRequestError},
 };
 
 use alloc::{boxed::Box, string::String, vec::Vec};

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -329,7 +329,7 @@ where
     /// substream must be reset if it is not closed.
     pub fn read_write(
         self,
-        read_write: &'_ mut read_write::ReadWrite<TNow>,
+        read_write: &mut read_write::ReadWrite<TNow>,
     ) -> (Option<Self>, Option<Event>) {
         let (me, event) = self.read_write2(read_write);
         (me.map(|inner| Substream { inner }), event)
@@ -337,7 +337,7 @@ where
 
     fn read_write2(
         self,
-        read_write: &'_ mut read_write::ReadWrite<TNow>,
+        read_write: &mut read_write::ReadWrite<TNow>,
     ) -> (Option<SubstreamInner<TNow>>, Option<Event>) {
         match self.inner {
             SubstreamInner::InboundNegotiating(nego, was_rejected_already) => {

--- a/lib/src/libp2p/connection/established/substream.rs
+++ b/lib/src/libp2p/connection/established/substream.rs
@@ -506,7 +506,7 @@ where
                                 Some(Event::NotificationsOutResult {
                                     result: Err(NotificationsOutErr::NegotiationError(err)),
                                 }),
-                            )
+                            );
                         }
                     }
                 }
@@ -689,7 +689,7 @@ where
                                 Some(Event::Response {
                                     response: Err(RequestError::ProtocolNotAvailable),
                                 }),
-                            )
+                            );
                         }
                         Err(err) => {
                             return (
@@ -697,7 +697,7 @@ where
                                 Some(Event::Response {
                                     response: Err(RequestError::NegotiationError(err)),
                                 }),
-                            )
+                            );
                         }
                     }
                 }
@@ -731,7 +731,7 @@ where
                                     Some(Event::Response {
                                         response: Err(RequestError::SubstreamClosed),
                                     }),
-                                )
+                                );
                             }
                         }
                     } else {
@@ -792,7 +792,7 @@ where
                                     error: InboundError::SubstreamClosed,
                                     was_accepted: true,
                                 }),
-                            )
+                            );
                         }
                     }
                 } else {
@@ -806,7 +806,7 @@ where
                                     error: InboundError::RequestInLebError(error),
                                     was_accepted: true,
                                 }),
-                            )
+                            );
                         }
                     }
                 }
@@ -856,7 +856,7 @@ where
                                     error: InboundError::SubstreamClosed,
                                     was_accepted: true,
                                 }),
-                            )
+                            );
                         }
                     }
                 } else {
@@ -870,7 +870,7 @@ where
                                     error: InboundError::NotificationsInError { error },
                                     was_accepted: true,
                                 }),
-                            )
+                            );
                         }
                     }
                 }

--- a/lib/src/libp2p/connection/established/tests.rs
+++ b/lib/src/libp2p/connection/established/tests.rs
@@ -46,7 +46,7 @@ fn perform_handshake(
     alice_config: Config<Duration>,
     bob_config: Config<Duration>,
 ) -> TwoEstablished {
-    use super::super::{single_stream_handshake, NoiseKey};
+    use super::super::{NoiseKey, single_stream_handshake};
 
     assert_ne!(alice_to_bob_buffer_size, 0);
     assert_ne!(bob_to_alice_buffer_size, 0);

--- a/lib/src/libp2p/connection/multistream_select.rs
+++ b/lib/src/libp2p/connection/multistream_select.rs
@@ -418,7 +418,7 @@ mod tests {
     use alloc::collections::VecDeque;
     use core::{cmp, mem};
 
-    use super::{super::super::read_write::ReadWrite, write_message, Config, Message, Negotiation};
+    use super::{super::super::read_write::ReadWrite, Config, Message, Negotiation, write_message};
 
     #[test]
     fn encode() {

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -163,7 +163,7 @@ impl UnsignedNoiseKey {
     }
 
     /// Returns the data that has to be signed.
-    pub fn payload_to_sign(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+    pub fn payload_to_sign(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]>> {
         [
             &b"noise-libp2p-static-key:"[..],
             &self.public_key.as_bytes()[..],

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -163,7 +163,7 @@ impl UnsignedNoiseKey {
     }
 
     /// Returns the data that has to be signed.
-    pub fn payload_to_sign(&'_ self) -> impl Iterator<Item = impl AsRef<[u8]>> {
+    pub fn payload_to_sign(&self) -> impl Iterator<Item = impl AsRef<[u8]>> {
         [
             &b"noise-libp2p-static-key:"[..],
             &self.public_key.as_bytes()[..],
@@ -1201,7 +1201,7 @@ impl CipherState {
     ///
     /// Does *not* include the libp2p-specific message length prefix.
     fn write_chachapoly_message(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         decrypted_buffers: impl Iterator<Item = Vec<u8>>,
     ) -> Result<impl Iterator<Item = Vec<u8>>, EncryptError> {
@@ -1346,7 +1346,7 @@ impl CipherState {
     ///
     /// Does *not* include the libp2p-specific message length prefix.
     fn write_chachapoly_message_to_vec(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         data: &[u8],
     ) -> Result<Vec<u8>, EncryptError> {
@@ -1364,7 +1364,7 @@ impl CipherState {
 
     /// Highly-specific function when the message to decode is 32 bytes.
     fn read_chachapoly_message_to_array(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         message_data: &[u8; 48],
     ) -> Result<[u8; 32], CipherError> {
@@ -1374,7 +1374,7 @@ impl CipherState {
     }
 
     fn read_chachapoly_message_to_vec(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         message_data: &[u8],
     ) -> Result<Vec<u8>, CipherError> {
@@ -1384,7 +1384,7 @@ impl CipherState {
     }
 
     fn read_chachapoly_message_to_vec_append(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         message_data: &[u8],
         out: &mut Vec<u8>,
@@ -1403,7 +1403,7 @@ impl CipherState {
     }
 
     fn read_chachapoly_message_to_slice(
-        &'_ mut self,
+        &mut self,
         associated_data: &[u8],
         message_data: &[u8],
         destination: &mut [u8],

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -837,7 +837,7 @@ impl HandshakeInProgress {
                             return Ok(NoiseHandshake::InProgress(self));
                         }
                         Err(read_write::IncomingBytesTakeError::ReadClosed) => {
-                            return Err(HandshakeError::ReadClosed)
+                            return Err(HandshakeError::ReadClosed);
                         }
                     }
                 };
@@ -854,7 +854,7 @@ impl HandshakeInProgress {
                         return Ok(NoiseHandshake::InProgress(self));
                     }
                     Err(read_write::IncomingBytesTakeError::ReadClosed) => {
-                        return Err(HandshakeError::ReadClosed)
+                        return Err(HandshakeError::ReadClosed);
                     }
                 };
 
@@ -880,7 +880,7 @@ impl HandshakeInProgress {
                         match parser(&available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
-                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError))
+                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
                             }
                         }
                     });
@@ -922,7 +922,7 @@ impl HandshakeInProgress {
                         match parser(&available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
-                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError))
+                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
                             }
                         }
                     };
@@ -1001,7 +1001,7 @@ impl HandshakeInProgress {
                             match parser(&libp2p_handshake_decrypted) {
                                 Ok((_, out)) => (out.key, out.sig),
                                 Err(_) => {
-                                    return Err(HandshakeError::PayloadDecode(PayloadDecodeError))
+                                    return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
                                 }
                             }
                         };
@@ -1046,7 +1046,7 @@ impl HandshakeInProgress {
                         match parser(&available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
-                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError))
+                                return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
                             }
                         }
                     };
@@ -1103,7 +1103,7 @@ impl HandshakeInProgress {
                             match parser(&libp2p_handshake_decrypted) {
                                 Ok((_, out)) => (out.key, out.sig),
                                 Err(_) => {
-                                    return Err(HandshakeError::PayloadDecode(PayloadDecodeError))
+                                    return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
                                 }
                             }
                         };

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -48,8 +48,8 @@ use alloc::{
 use core::{cmp, fmt, mem, num::NonZero, ops};
 use rand::seq::IteratorRandom as _;
 use rand_chacha::{
-    rand_core::{RngCore as _, SeedableRng as _},
     ChaCha20Rng,
+    rand_core::{RngCore as _, SeedableRng as _},
 };
 
 pub use header::GoAwayErrorCode;
@@ -1605,11 +1605,13 @@ where
             panic!()
         }
 
-        debug_assert!(!self
-            .inner
-            .substreams_wake_up
-            .iter()
-            .any(|(_, s)| s == &id.0));
+        debug_assert!(
+            !self
+                .inner
+                .substreams_wake_up
+                .iter()
+                .any(|(_, s)| s == &id.0)
+        );
         debug_assert!(!self.inner.window_frames_to_send.contains_key(&id.0));
         debug_assert!(!self.inner.substreams_write_ready.contains(&id.0));
 
@@ -2095,22 +2097,28 @@ where
         {
             let _was_inserted = self.yamux.inner.dead_substreams.insert(self.substream_id);
             debug_assert!(_was_inserted);
-            debug_assert!(!self
-                .yamux
-                .inner
-                .substreams_wake_up
-                .iter()
-                .any(|(_, s)| *s == self.substream_id));
-            debug_assert!(!self
-                .yamux
-                .inner
-                .substreams_write_ready
-                .contains(&self.substream_id));
-            debug_assert!(!self
-                .yamux
-                .inner
-                .window_frames_to_send
-                .contains_key(&self.substream_id));
+            debug_assert!(
+                !self
+                    .yamux
+                    .inner
+                    .substreams_wake_up
+                    .iter()
+                    .any(|(_, s)| *s == self.substream_id)
+            );
+            debug_assert!(
+                !self
+                    .yamux
+                    .inner
+                    .substreams_write_ready
+                    .contains(&self.substream_id)
+            );
+            debug_assert!(
+                !self
+                    .yamux
+                    .inner
+                    .window_frames_to_send
+                    .contains_key(&self.substream_id)
+            );
         }
 
         self.yamux
@@ -2179,9 +2187,7 @@ pub enum Error {
     /// Failed to decode an incoming Yamux header.
     HeaderDecode(header::YamuxHeaderDecodeError),
     /// Received a SYN flag with a substream ID that is of the same side as the local side.
-    #[display(
-        "Received a SYN flag with a substream ID that is of the same side as the local side"
-    )]
+    #[display("Received a SYN flag with a substream ID that is of the same side as the local side")]
     InvalidInboundStreamId { stream_id: NonZero<u32> },
     /// Received a SYN flag with a known substream ID.
     #[display("Received a SYN flag with a known substream ID")]

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1562,9 +1562,7 @@ where
     /// This function does not remove dead substreams from the state machine. In other words, if
     /// this function is called multiple times in a row, it will always return the same
     /// substreams. Use [`Yamux::remove_dead_substream`] to remove substreams.
-    pub fn dead_substreams(
-        &'_ self,
-    ) -> impl Iterator<Item = (SubstreamId, DeadSubstreamTy, &'_ TSub)> {
+    pub fn dead_substreams(&self) -> impl Iterator<Item = (SubstreamId, DeadSubstreamTy, &TSub)> {
         self.inner.dead_substreams.iter().map(|id| {
             let substream = self.inner.substreams.get(id).unwrap();
             match &substream.state {

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1742,13 +1742,13 @@ impl<TNow, TSub> fmt::Debug for Yamux<TNow, TSub>
 where
     TSub: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         struct List<'a, TNow, TSub>(&'a Yamux<TNow, TSub>);
         impl<'a, TNow, TSub> fmt::Debug for List<'a, TNow, TSub>
         where
             TSub: fmt::Debug,
         {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.debug_list()
                     .entries(self.0.inner.substreams.values().map(|v| &v.user_data))
                     .finish()
@@ -2139,7 +2139,7 @@ impl<'a, TNow, TSub> fmt::Debug for SubstreamReadWrite<'a, TNow, TSub>
 where
     TNow: Clone + cmp::Ord,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("SubstreamReadWrite")
             .field("substream_id", &self.substream_id)
             .finish()

--- a/lib/src/libp2p/connection/yamux.rs
+++ b/lib/src/libp2p/connection/yamux.rs
@@ -1564,7 +1564,7 @@ where
     /// substreams. Use [`Yamux::remove_dead_substream`] to remove substreams.
     pub fn dead_substreams(
         &'_ self,
-    ) -> impl Iterator<Item = (SubstreamId, DeadSubstreamTy, &'_ TSub)> + '_ {
+    ) -> impl Iterator<Item = (SubstreamId, DeadSubstreamTy, &'_ TSub)> {
         self.inner.dead_substreams.iter().map(|id| {
             let substream = self.inner.substreams.get(id).unwrap();
             match &substream.state {

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -178,7 +178,7 @@ pub struct YamuxHeaderDecodeError {
     offset: usize,
 }
 
-fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
+fn decode(bytes: &[u8]) -> nom::IResult<&[u8], DecodedYamuxHeader> {
     nom::sequence::preceded(
         nom::bytes::streaming::tag(&[0]),
         nom::branch::alt((
@@ -258,7 +258,7 @@ fn decode(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], DecodedYamuxHeader> {
     )(bytes)
 }
 
-fn flags(bytes: &'_ [u8]) -> nom::IResult<&'_ [u8], (bool, bool, bool, bool)> {
+fn flags(bytes: &[u8]) -> nom::IResult<&[u8], (bool, bool, bool, bool)> {
     nom::combinator::map_opt(nom::number::streaming::be_u16, |flags| {
         let syn = (flags & 0x1) != 0;
         let ack = (flags & 0x2) != 0;

--- a/lib/src/libp2p/multiaddr.rs
+++ b/lib/src/libp2p/multiaddr.rs
@@ -59,7 +59,7 @@ impl Multiaddr<Vec<u8>> {
         let remain = {
             let mut iter = nom::combinator::iterator(
                 &self.bytes[..],
-                nom::combinator::recognize(protocol::<&'_ [u8], nom::error::Error<&'_ [u8]>>),
+                nom::combinator::recognize(protocol::<&[u8], nom::error::Error<&[u8]>>),
             );
 
             let bytes_prefix = iter.last().unwrap().len();
@@ -96,11 +96,9 @@ impl<T: AsRef<[u8]>> Multiaddr<T> {
     }
 
     /// Returns the list of components of the multiaddress.
-    pub fn iter(&'_ self) -> impl Iterator<Item = Protocol<&'_ [u8]>> {
-        let mut iter = nom::combinator::iterator(
-            self.bytes.as_ref(),
-            protocol::<_, nom::error::Error<&'_ [u8]>>,
-        );
+    pub fn iter(&self) -> impl Iterator<Item = Protocol<&[u8]>> {
+        let mut iter =
+            nom::combinator::iterator(self.bytes.as_ref(), protocol::<_, nom::error::Error<&[u8]>>);
         iter::from_fn(move || (&mut iter).next())
     }
 }

--- a/lib/src/libp2p/multiaddr.rs
+++ b/lib/src/libp2p/multiaddr.rs
@@ -96,7 +96,7 @@ impl<T: AsRef<[u8]>> Multiaddr<T> {
     }
 
     /// Returns the list of components of the multiaddress.
-    pub fn iter(&'_ self) -> impl Iterator<Item = Protocol<&'_ [u8]>> + '_ {
+    pub fn iter(&'_ self) -> impl Iterator<Item = Protocol<&'_ [u8]>> {
         let mut iter = nom::combinator::iterator(
             self.bytes.as_ref(),
             protocol::<_, nom::error::Error<&'_ [u8]>>,

--- a/lib/src/libp2p/multihash.rs
+++ b/lib/src/libp2p/multihash.rs
@@ -106,13 +106,13 @@ pub enum FromBytesError {
 }
 
 impl<T: AsRef<[u8]>> fmt::Debug for Multihash<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl<T: AsRef<[u8]>> fmt::Display for Multihash<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let base58 = bs58::encode(self.0.as_ref()).into_string();
         write!(f, "{base58}")
     }

--- a/lib/src/libp2p/peer_id.rs
+++ b/lib/src/libp2p/peer_id.rs
@@ -244,13 +244,13 @@ impl From<PublicKey> for PeerId {
 }
 
 impl fmt::Debug for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Display for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_base58().fmt(f)
     }
 }

--- a/lib/src/libp2p/websocket.rs
+++ b/lib/src/libp2p/websocket.rs
@@ -20,7 +20,7 @@
 
 #![cfg(feature = "std")]
 
-use futures_util::{future, AsyncRead, AsyncWrite, Future as _};
+use futures_util::{AsyncRead, AsyncWrite, Future as _, future};
 
 use core::{
     cmp, mem,
@@ -63,7 +63,7 @@ pub async fn websocket_client_handshake<T: AsyncRead + AsyncWrite + Send + Unpin
             return Err(io::Error::new(
                 io::ErrorKind::ConnectionRefused,
                 format!("Status code {status_code}"),
-            ))
+            ));
         }
         Err(err) => return Err(io::Error::new(io::ErrorKind::Other, err)),
     };

--- a/lib/src/libp2p/websocket.rs
+++ b/lib/src/libp2p/websocket.rs
@@ -117,7 +117,7 @@ enum Write<T> {
 impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncRead for Connection<T> {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
+        cx: &mut Context,
         out_buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         assert_ne!(out_buf.len(), 0);
@@ -164,7 +164,7 @@ impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncRead for Connectio
 impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncWrite for Connection<T> {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
+        cx: &mut Context,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         loop {
@@ -233,7 +233,7 @@ impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncWrite for Connecti
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         loop {
             match mem::replace(&mut self.sender, Write::Poisoned) {
                 Write::Idle(mut socket) => {
@@ -290,7 +290,7 @@ impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> AsyncWrite for Connecti
         }
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
         loop {
             match mem::replace(&mut self.sender, Write::Poisoned) {
                 Write::Idle(mut socket) => {

--- a/lib/src/libp2p/with_buffers.rs
+++ b/lib/src/libp2p/with_buffers.rs
@@ -113,10 +113,11 @@ where
     ) -> Result<ReadWriteAccess<TNow>, &io::Error> {
         let this = self.project();
 
-        debug_assert!(this
-            .read_write_now
-            .as_ref()
-            .map_or(true, |old_now| *old_now <= now));
+        debug_assert!(
+            this.read_write_now
+                .as_ref()
+                .map_or(true, |old_now| *old_now <= now)
+        );
         *this.read_write_wake_up_after = None;
         *this.read_write_now = Some(now.clone());
 

--- a/lib/src/libp2p/with_buffers.rs
+++ b/lib/src/libp2p/with_buffers.rs
@@ -166,7 +166,7 @@ where
 impl<TSocketFut, TSocket, TNow> WithBuffers<TSocketFut, TSocket, TNow>
 where
     TSocket: AsyncRead + AsyncWrite,
-    TSocketFut: future::Future<Output = Result<TSocket, io::Error>>,
+    TSocketFut: Future<Output = Result<TSocket, io::Error>>,
     TNow: Clone + Ord,
 {
     /// Waits until [`WithBuffers::read_write_access`] should be called again.
@@ -179,7 +179,7 @@ where
         self: Pin<&mut Self>,
         timer_builder: impl FnOnce(TNow) -> F,
     ) where
-        F: future::Future<Output = ()>,
+        F: Future<Output = ()>,
     {
         let mut this = self.project();
 
@@ -218,7 +218,7 @@ where
             // If still `true` at the end of the function, `Poll::Pending` is returned.
             let mut pending = true;
 
-            match future::Future::poll(Pin::new(&mut timer), cx) {
+            match Future::poll(Pin::new(&mut timer), cx) {
                 Poll::Pending => {}
                 Poll::Ready(()) => {
                     pending = false;
@@ -226,7 +226,7 @@ where
             }
 
             match this.socket.as_mut().project() {
-                SocketProj::Pending(future) => match future::Future::poll(future, cx) {
+                SocketProj::Pending(future) => match Future::poll(future, cx) {
                     Poll::Pending => {}
                     Poll::Ready(Ok(socket)) => {
                         this.socket.set(Socket::Resolved(socket));

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -50,14 +50,14 @@
 use crate::util;
 use alloc::{
     borrow::ToOwned as _,
-    collections::{btree_map, BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, btree_map},
     vec::Vec,
 };
 use core::{hash::Hash, iter, ops};
 use rand::seq::IteratorRandom as _;
 use rand_chacha::{
-    rand_core::{RngCore as _, SeedableRng as _},
     ChaCha20Rng,
+    rand_core::{RngCore as _, SeedableRng as _},
 };
 
 pub use crate::libp2p::PeerId;
@@ -1018,7 +1018,7 @@ mod tests {
         BasicPeeringStrategy, Config, InsertAddressConnectionsResult, InsertAddressResult,
         InsertChainPeerResult,
     };
-    use crate::network::service::{peer_id::PublicKey, PeerId};
+    use crate::network::service::{PeerId, peer_id::PublicKey};
     use core::time::Duration;
 
     #[test]

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -311,7 +311,7 @@ where
     /// words peers added through [`BasicPeeringStrategy::insert_chain_peer`].
     ///
     /// The order of the yielded elements is unspecified.
-    pub fn chain_peers_unordered(&'_ self, chain: &TChainId) -> impl Iterator<Item = &'_ PeerId> {
+    pub fn chain_peers_unordered(&self, chain: &TChainId) -> impl Iterator<Item = &PeerId> {
         let Some(&chain_index) = self.chains_indices.get(chain) else {
             // If the `TChainId` is unknown, it means that it doesn't have any peer.
             return either::Right(iter::empty());
@@ -432,7 +432,7 @@ where
     }
 
     /// Returns the list of all addresses that have been inserted for the given peer.
-    pub fn peer_addresses(&'_ self, peer_id: &PeerId) -> impl Iterator<Item = &'_ [u8]> {
+    pub fn peer_addresses(&self, peer_id: &PeerId) -> impl Iterator<Item = &[u8]> {
         let Some(&peer_id_index) = self.peer_ids_indices.get(peer_id) else {
             // If the `PeerId` is unknown, it means it doesn't have any address.
             return either::Right(iter::empty());
@@ -458,7 +458,7 @@ where
     /// often not desirable, it is preferable to keep the API simple and straight-forward rather
     /// than try to be smart about function behaviours.
     pub fn pick_assignable_peer(
-        &'_ mut self,
+        &mut self,
         chain: &TChainId,
         now: &TInstant,
     ) -> AssignablePeer<'_, TInstant> {
@@ -514,7 +514,7 @@ where
     ///
     /// A slot is assigned even if the peer is banned. API users that call this function are
     /// expected to be aware of that.
-    pub fn assign_slot(&'_ mut self, chain: &TChainId, peer_id: &PeerId) {
+    pub fn assign_slot(&mut self, chain: &TChainId, peer_id: &PeerId) {
         let peer_id_index = self.get_or_insert_peer_index(peer_id);
         let chain_index = self.get_or_insert_chain_index(chain);
 

--- a/lib/src/network/basic_peering_strategy.rs
+++ b/lib/src/network/basic_peering_strategy.rs
@@ -311,10 +311,7 @@ where
     /// words peers added through [`BasicPeeringStrategy::insert_chain_peer`].
     ///
     /// The order of the yielded elements is unspecified.
-    pub fn chain_peers_unordered(
-        &'_ self,
-        chain: &TChainId,
-    ) -> impl Iterator<Item = &'_ PeerId> + '_ {
+    pub fn chain_peers_unordered(&'_ self, chain: &TChainId) -> impl Iterator<Item = &'_ PeerId> {
         let Some(&chain_index) = self.chains_indices.get(chain) else {
             // If the `TChainId` is unknown, it means that it doesn't have any peer.
             return either::Right(iter::empty());
@@ -435,7 +432,7 @@ where
     }
 
     /// Returns the list of all addresses that have been inserted for the given peer.
-    pub fn peer_addresses(&'_ self, peer_id: &PeerId) -> impl Iterator<Item = &'_ [u8]> + '_ {
+    pub fn peer_addresses(&'_ self, peer_id: &PeerId) -> impl Iterator<Item = &'_ [u8]> {
         let Some(&peer_id_index) = self.peer_ids_indices.get(peer_id) else {
             // If the `PeerId` is unknown, it means it doesn't have any address.
             return either::Right(iter::empty());

--- a/lib/src/network/codec.rs
+++ b/lib/src/network/codec.rs
@@ -83,13 +83,13 @@ pub enum ProtocolName<'a> {
 }
 
 impl<'a> fmt::Debug for ProtocolName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
 impl<'a> fmt::Display for ProtocolName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for chunk in encode_protocol_name(*self) {
             f.write_str(chunk.as_ref())?;
         }
@@ -99,7 +99,7 @@ impl<'a> fmt::Display for ProtocolName<'a> {
 
 /// Turns a [`ProtocolName`] into its string version. Returns a list of objects that, when
 /// concatenated together, forms the string version of the [`ProtocolName`].
-pub fn encode_protocol_name(protocol: ProtocolName<'_>) -> impl Iterator<Item = impl AsRef<str>> {
+pub fn encode_protocol_name(protocol: ProtocolName) -> impl Iterator<Item = impl AsRef<str>> {
     let (genesis_hash, fork_id, base_protocol_name) = match protocol {
         ProtocolName::Identify => return either::Left(iter::once(Cow::Borrowed("/ipfs/id/1.0.0"))),
         ProtocolName::Ping => return either::Left(iter::once(Cow::Borrowed("/ipfs/ping/1.0.0"))),
@@ -165,7 +165,7 @@ pub fn encode_protocol_name(protocol: ProtocolName<'_>) -> impl Iterator<Item = 
 }
 
 /// Turns a [`ProtocolName`] into a string.
-pub fn encode_protocol_name_string(protocol: ProtocolName<'_>) -> String {
+pub fn encode_protocol_name_string(protocol: ProtocolName) -> String {
     encode_protocol_name(protocol).fold(String::with_capacity(128), |mut a, b| {
         a.push_str(b.as_ref());
         a

--- a/lib/src/network/codec.rs
+++ b/lib/src/network/codec.rs
@@ -99,9 +99,7 @@ impl<'a> fmt::Display for ProtocolName<'a> {
 
 /// Turns a [`ProtocolName`] into its string version. Returns a list of objects that, when
 /// concatenated together, forms the string version of the [`ProtocolName`].
-pub fn encode_protocol_name(
-    protocol: ProtocolName<'_>,
-) -> impl Iterator<Item = impl AsRef<str> + '_> + '_ {
+pub fn encode_protocol_name(protocol: ProtocolName<'_>) -> impl Iterator<Item = impl AsRef<str>> {
     let (genesis_hash, fork_id, base_protocol_name) = match protocol {
         ProtocolName::Identify => return either::Left(iter::once(Cow::Borrowed("/ipfs/id/1.0.0"))),
         ProtocolName::Ping => return either::Left(iter::once(Cow::Borrowed("/ipfs/ping/1.0.0"))),

--- a/lib/src/network/codec/block_announces.rs
+++ b/lib/src/network/codec/block_announces.rs
@@ -90,9 +90,7 @@ pub struct BlockAnnounceRef<'a> {
 ///
 /// This function returns an iterator of buffers. The encoded message consists in the
 /// concatenation of the buffers.
-pub fn encode_block_announce(
-    announce: BlockAnnounceRef,
-) -> impl Iterator<Item = impl AsRef<[u8]>> {
+pub fn encode_block_announce(announce: BlockAnnounceRef) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let is_best = if announce.is_best { [1u8] } else { [0u8] };
 
     [

--- a/lib/src/network/codec/block_announces.rs
+++ b/lib/src/network/codec/block_announces.rs
@@ -91,7 +91,7 @@ pub struct BlockAnnounceRef<'a> {
 /// This function returns an iterator of buffers. The encoded message consists in the
 /// concatenation of the buffers.
 pub fn encode_block_announce(
-    announce: BlockAnnounceRef<'_>,
+    announce: BlockAnnounceRef,
 ) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let is_best = if announce.is_best { [1u8] } else { [0u8] };
 
@@ -150,7 +150,7 @@ pub struct DecodeBlockAnnounceError(#[error(not(source))] nom::error::ErrorKind)
 /// This function returns an iterator of buffers. The encoded message consists in the
 /// concatenation of the buffers.
 pub fn encode_block_announces_handshake(
-    handshake: BlockAnnouncesHandshakeRef<'_>,
+    handshake: BlockAnnouncesHandshakeRef,
     block_number_bytes: usize,
 ) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let mut header = vec![0; 1 + block_number_bytes];

--- a/lib/src/network/codec/block_announces.rs
+++ b/lib/src/network/codec/block_announces.rs
@@ -92,7 +92,7 @@ pub struct BlockAnnounceRef<'a> {
 /// concatenation of the buffers.
 pub fn encode_block_announce(
     announce: BlockAnnounceRef<'_>,
-) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let is_best = if announce.is_best { [1u8] } else { [0u8] };
 
     [
@@ -152,7 +152,7 @@ pub struct DecodeBlockAnnounceError(#[error(not(source))] nom::error::ErrorKind)
 pub fn encode_block_announces_handshake(
     handshake: BlockAnnouncesHandshakeRef<'_>,
     block_number_bytes: usize,
-) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let mut header = vec![0; 1 + block_number_bytes];
     header[0] = handshake.role.scale_encoding()[0];
     // TODO: what to do if the best number doesn't fit in the given size? right now we just wrap around

--- a/lib/src/network/codec/block_request.rs
+++ b/lib/src/network/codec/block_request.rs
@@ -309,7 +309,7 @@ pub fn decode_block_response(
                 match result {
                     Ok((_, out)) => Some(out),
                     Err(nom::Err::Error(_) | nom::Err::Failure(_)) => {
-                        return Err(DecodeBlockResponseError::InvalidJustifications)
+                        return Err(DecodeBlockResponseError::InvalidJustifications);
                     }
                     Err(_) => unreachable!(),
                 }

--- a/lib/src/network/codec/grandpa.rs
+++ b/lib/src/network/codec/grandpa.rs
@@ -34,7 +34,7 @@ pub enum GrandpaNotificationRef<'a> {
     CatchUp(CatchUpRef<'a>),
 }
 
-impl<'a> GrandpaNotificationRef<'a> {
+impl GrandpaNotificationRef<'_> {
     /// Returns an iterator to list of buffers which, when concatenated, produces the SCALE
     /// encoding of that object.
     pub fn scale_encoding(
@@ -171,7 +171,7 @@ pub struct DecodeGrandpaNotificationError(#[error(not(source))] nom::error::Erro
 
 fn grandpa_notification<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], GrandpaNotificationRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], GrandpaNotificationRef<'a>> {
     nom::error::context(
         "grandpa_notification",
         nom::branch::alt((
@@ -219,7 +219,7 @@ fn grandpa_notification<'a>(
 
 fn vote_message<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], VoteMessageRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], VoteMessageRef<'a>> {
     nom::error::context(
         "vote_message",
         nom::combinator::map(
@@ -243,7 +243,7 @@ fn vote_message<'a>(
 
 fn message<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], MessageRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], MessageRef<'a>> {
     nom::error::context(
         "message",
         nom::branch::alt((
@@ -274,7 +274,7 @@ fn message<'a>(
 
 fn unsigned_prevote<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], UnsignedPrevoteRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], UnsignedPrevoteRef<'a>> {
     nom::error::context(
         "unsigned_prevote",
         nom::combinator::map(
@@ -292,7 +292,7 @@ fn unsigned_prevote<'a>(
 
 fn unsigned_precommit<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], UnsignedPrecommitRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], UnsignedPrecommitRef<'a>> {
     nom::error::context(
         "unsigned_precommit",
         nom::combinator::map(
@@ -310,7 +310,7 @@ fn unsigned_precommit<'a>(
 
 fn primary_propose<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrimaryProposeRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], PrimaryProposeRef<'a>> {
     nom::error::context(
         "primary_propose",
         nom::combinator::map(
@@ -328,7 +328,7 @@ fn primary_propose<'a>(
 
 fn neighbor_packet<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], NeighborPacket> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], NeighborPacket> {
     nom::error::context(
         "neighbor_packet",
         nom::combinator::map(
@@ -367,7 +367,7 @@ fn catch_up_request(bytes: &[u8]) -> nom::IResult<&[u8], CatchUpRequest> {
 
 fn catch_up<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], CatchUpRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], CatchUpRef<'a>> {
     nom::error::context(
         "catch_up",
         nom::combinator::map(
@@ -406,7 +406,7 @@ fn catch_up<'a>(
 
 fn prevote<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PrevoteRef> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], PrevoteRef<'a>> {
     nom::error::context(
         "prevote",
         nom::combinator::map(

--- a/lib/src/network/codec/grandpa.rs
+++ b/lib/src/network/codec/grandpa.rs
@@ -97,10 +97,12 @@ impl NeighborPacket {
         ));
         commit_finalized_height.extend(self.commit_finalized_height.to_le_bytes());
         // TODO: unclear what to do if the block number doesn't fit in `block_number_bytes`
-        debug_assert!(!commit_finalized_height
-            .iter()
-            .skip(block_number_bytes)
-            .any(|b| *b != 0));
+        debug_assert!(
+            !commit_finalized_height
+                .iter()
+                .skip(block_number_bytes)
+                .any(|b| *b != 0)
+        );
         commit_finalized_height.resize(block_number_bytes, 0);
 
         [

--- a/lib/src/network/codec/grandpa_warp_sync.rs
+++ b/lib/src/network/codec/grandpa_warp_sync.rs
@@ -95,7 +95,7 @@ pub fn decode_grandpa_warp_sync_response(
 
 fn decode_fragments<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], Vec<GrandpaWarpSyncResponseFragment>> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], Vec<GrandpaWarpSyncResponseFragment<'a>>> {
     nom::combinator::flat_map(crate::util::nom_scale_compact_usize, move |num_elems| {
         nom::multi::many_m_n(num_elems, num_elems, decode_fragment(block_number_bytes))
     })
@@ -103,7 +103,7 @@ fn decode_fragments<'a>(
 
 fn decode_fragment<'a>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], GrandpaWarpSyncResponseFragment> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], GrandpaWarpSyncResponseFragment<'a>> {
     nom::combinator::map(
         nom::sequence::tuple((
             nom::combinator::recognize(move |s| {

--- a/lib/src/network/codec/identify.rs
+++ b/lib/src/network/codec/identify.rs
@@ -121,9 +121,9 @@ pub fn build_identify_response<'a>(
 
 /// Decodes a response to an identify request.
 pub fn decode_identify_response(
-    response_bytes: &'_ [u8],
+    response_bytes: &[u8],
 ) -> Result<
-    IdentifyResponse<'_, vec::IntoIter<&'_ [u8]>, vec::IntoIter<&'_ str>>,
+    IdentifyResponse<'_, vec::IntoIter<&[u8]>, vec::IntoIter<&str>>,
     DecodeIdentifyResponseError,
 > {
     let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(

--- a/lib/src/network/codec/identify.rs
+++ b/lib/src/network/codec/identify.rs
@@ -77,7 +77,7 @@ pub fn build_identify_response<'a>(
         impl Iterator<Item = &'a [u8]> + 'a,
         impl Iterator<Item = &'a str> + 'a,
     >,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     protobuf::string_tag_encode(5, config.protocol_version)
         .map(either::Left)
         .map(either::Left)

--- a/lib/src/network/codec/kademlia.rs
+++ b/lib/src/network/codec/kademlia.rs
@@ -57,7 +57,7 @@ pub fn decode_find_node_response(
         Err(_) => {
             return Err(DecodeFindNodeResponseError::ProtobufDecode(
                 ProtobufDecodeError,
-            ))
+            ));
         }
     };
 

--- a/lib/src/network/codec/state_request.rs
+++ b/lib/src/network/codec/state_request.rs
@@ -81,9 +81,7 @@ pub enum StateRequestStart<'a> {
 // for protocol definition.
 
 /// Builds the bytes corresponding to a state request.
-pub fn build_state_request(
-    config: StateRequest<'_>,
-) -> impl Iterator<Item = impl AsRef<[u8]> + '_> + '_ {
+pub fn build_state_request(config: StateRequest<'_>) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let start = match config.start_key {
         StateRequestStart::MainTrie(key) => {
             either::Left(protobuf::bytes_tag_encode(2, key).map(either::Left))

--- a/lib/src/network/codec/state_request.rs
+++ b/lib/src/network/codec/state_request.rs
@@ -81,7 +81,7 @@ pub enum StateRequestStart<'a> {
 // for protocol definition.
 
 /// Builds the bytes corresponding to a state request.
-pub fn build_state_request(config: StateRequest<'_>) -> impl Iterator<Item = impl AsRef<[u8]>> {
+pub fn build_state_request(config: StateRequest) -> impl Iterator<Item = impl AsRef<[u8]>> {
     let start = match config.start_key {
         StateRequestStart::MainTrie(key) => {
             either::Left(protobuf::bytes_tag_encode(2, key).map(either::Left))

--- a/lib/src/network/codec/storage_call_proof.rs
+++ b/lib/src/network/codec/storage_call_proof.rs
@@ -34,7 +34,7 @@ pub struct StorageProofRequestConfig<TKeysIter> {
 /// Builds the bytes corresponding to a storage proof request.
 pub fn build_storage_proof_request<'a>(
     config: StorageProofRequestConfig<impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + 'a>,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     protobuf::message_tag_encode(
         2,
         protobuf::bytes_tag_encode(2, config.block_hash)
@@ -66,7 +66,7 @@ pub struct CallProofRequestConfig<'a, I> {
 /// Builds the bytes corresponding to a call proof request.
 pub fn build_call_proof_request<'a>(
     config: CallProofRequestConfig<'a, impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a>,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     // TODO: don't allocate here
     let parameter = config
         .parameter_vectored

--- a/lib/src/network/kademlia/kbuckets.rs
+++ b/lib/src/network/kademlia/kbuckets.rs
@@ -556,11 +556,13 @@ mod tests {
         // Iterator that generates random keys that are in the maximum size bucket.
         let mut max_bucket_keys = {
             let local_key_hash = Sha256::digest(&local_key);
-            (0..).map(move |_| loop {
-                let other_key: [u8; 32] = rand::random();
-                let other_key_hashed = Sha256::digest(other_key);
-                if ((local_key_hash[0] ^ other_key_hashed[0]) & 0x80) != 0 {
-                    break other_key.to_vec();
+            (0..).map(move |_| {
+                loop {
+                    let other_key: [u8; 32] = rand::random();
+                    let other_key_hashed = Sha256::digest(other_key);
+                    if ((local_key_hash[0] ^ other_key_hashed[0]) & 0x80) != 0 {
+                        break other_key.to_vec();
+                    }
                 }
             })
         };
@@ -582,9 +584,10 @@ mod tests {
         // Inserting another node in that bucket. Since it's full, the insertion must fail.
         match buckets.entry(&max_bucket_keys.next().unwrap()) {
             super::Entry::Vacant(e) => {
-                assert!(e
-                    .insert((), &Duration::new(0, 0), super::PeerState::Disconnected)
-                    .is_err());
+                assert!(
+                    e.insert((), &Duration::new(0, 0), super::PeerState::Disconnected)
+                        .is_err()
+                );
             }
             _ => panic!(),
         }
@@ -593,9 +596,10 @@ mod tests {
         // the insertion must succeed.
         match buckets.entry(&max_bucket_keys.next().unwrap()) {
             super::Entry::Vacant(e) => {
-                assert!(e
-                    .insert((), &Duration::new(2, 0), super::PeerState::Disconnected)
-                    .is_ok());
+                assert!(
+                    e.insert((), &Duration::new(2, 0), super::PeerState::Disconnected)
+                        .is_ok()
+                );
             }
             _ => panic!(),
         }

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -650,7 +650,7 @@ where
     }
 
     /// Returns the list of all the chains that have been added.
-    pub fn chains(&'_ self) -> impl ExactSizeIterator<Item = ChainId> + '_ {
+    pub fn chains(&'_ self) -> impl ExactSizeIterator<Item = ChainId> {
         self.chains.iter().map(|(idx, _)| ChainId(idx))
     }
 
@@ -899,7 +899,7 @@ where
         &self,
         chain_id: ChainId,
         kind: GossipKind,
-    ) -> impl Iterator<Item = &'_ PeerId> + '_ {
+    ) -> impl Iterator<Item = &'_ PeerId> {
         self.gossip_desired_peers_by_chain
             .range(
                 (chain_id.0, kind, PeerIndex(usize::MIN))
@@ -923,7 +923,7 @@ where
     ///
     /// > **Note**: Connections that are currently in the process of shutting down are also
     /// >           ignored for the purpose of this function.
-    pub fn unconnected_desired(&'_ self) -> impl ExactSizeIterator<Item = &'_ PeerId> + Clone + '_ {
+    pub fn unconnected_desired(&'_ self) -> impl ExactSizeIterator<Item = &'_ PeerId> + Clone {
         self.unconnected_desired
             .iter()
             .map(|peer_index| &self.peers[peer_index.0])
@@ -933,7 +933,7 @@ where
     /// connection exists, but for which no substream connection attempt exists.
     pub fn connected_unopened_gossip_desired(
         &'_ self,
-    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone + '_ {
+    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone {
         self.connected_unopened_gossip_desired.iter().map(
             move |(peer_index, chain_id, gossip_kind)| {
                 (&self.peers[peer_index.0], *chain_id, *gossip_kind)
@@ -945,7 +945,7 @@ where
     /// exists but that are not marked as desired.
     pub fn opened_gossip_undesired(
         &'_ self,
-    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone + '_ {
+    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone {
         self.opened_gossip_undesired
             .iter()
             .map(move |(chain_id, peer_index, gossip_kind)| {
@@ -963,7 +963,7 @@ where
     pub fn opened_gossip_undesired_by_chain(
         &'_ self,
         chain_id: ChainId,
-    ) -> impl Iterator<Item = (&'_ PeerId, GossipKind)> + Clone + '_ {
+    ) -> impl Iterator<Item = (&'_ PeerId, GossipKind)> + Clone {
         // TODO: optimize and add an ExactSizeIterator bound to the return value, and update the users to use len() instead of count()
         self.opened_gossip_undesired
             .iter()
@@ -3287,7 +3287,7 @@ where
         &'_ self,
         chain_id: ChainId,
         kind: GossipKind,
-    ) -> impl Iterator<Item = &'_ PeerId> + '_ {
+    ) -> impl Iterator<Item = &'_ PeerId> {
         assert!(self.chains.contains(chain_id.0));
         let GossipKind::ConsensusTransactions = kind;
 

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -419,7 +419,7 @@ where
             hashbrown::hash_map::Entry::Occupied(entry) => {
                 return Err(AddChainError::Duplicate {
                     existing_identical: ChainId(*entry.get()),
-                })
+                });
             }
         }
 
@@ -1653,7 +1653,7 @@ where
                                         chain_id: ChainId(chain_index),
                                         config,
                                         substream_id,
-                                    })
+                                    });
                                 }
                                 Err(error) => {
                                     let _ = self.substreams.remove(&substream_id);
@@ -2051,26 +2051,29 @@ where
                             // This can only happen if we have a block announces substream with
                             // that peer, otherwise the substream opening attempt should have
                             // been cancelled.
-                            debug_assert!(self
-                                .notification_substreams_by_peer_id
-                                .range(
-                                    (
-                                        NotificationsProtocol::BlockAnnounces { chain_index },
-                                        peer_index,
-                                        SubstreamDirection::Out,
-                                        NotificationsSubstreamState::OPEN_MIN_VALUE,
-                                        SubstreamId::MIN
-                                    )
-                                        ..=(
+                            debug_assert!(
+                                self.notification_substreams_by_peer_id
+                                    .range(
+                                        (
                                             NotificationsProtocol::BlockAnnounces { chain_index },
                                             peer_index,
                                             SubstreamDirection::Out,
-                                            NotificationsSubstreamState::OPEN_MAX_VALUE,
-                                            SubstreamId::MAX
+                                            NotificationsSubstreamState::OPEN_MIN_VALUE,
+                                            SubstreamId::MIN
                                         )
-                                )
-                                .next()
-                                .is_some());
+                                            ..=(
+                                                NotificationsProtocol::BlockAnnounces {
+                                                    chain_index
+                                                },
+                                                peer_index,
+                                                SubstreamDirection::Out,
+                                                NotificationsSubstreamState::OPEN_MAX_VALUE,
+                                                SubstreamId::MAX
+                                            )
+                                    )
+                                    .next()
+                                    .is_some()
+                            );
 
                             // If the substream failed to open, we simply try again.
                             // Trying again means that we might be hammering the remote with
@@ -2245,28 +2248,31 @@ where
                                     state.established && !state.shutting_down
                                 })
                             {
-                                debug_assert!(self
-                                    .notification_substreams_by_peer_id
-                                    .range(
-                                        (
-                                            NotificationsProtocol::BlockAnnounces { chain_index },
-                                            peer_index,
-                                            SubstreamDirection::Out,
-                                            NotificationsSubstreamState::MIN,
-                                            SubstreamId::MIN,
-                                        )
-                                            ..=(
+                                debug_assert!(
+                                    self.notification_substreams_by_peer_id
+                                        .range(
+                                            (
                                                 NotificationsProtocol::BlockAnnounces {
                                                     chain_index
                                                 },
                                                 peer_index,
                                                 SubstreamDirection::Out,
-                                                NotificationsSubstreamState::MAX,
-                                                SubstreamId::MAX,
-                                            ),
-                                    )
-                                    .next()
-                                    .is_none());
+                                                NotificationsSubstreamState::MIN,
+                                                SubstreamId::MIN,
+                                            )
+                                                ..=(
+                                                    NotificationsProtocol::BlockAnnounces {
+                                                        chain_index
+                                                    },
+                                                    peer_index,
+                                                    SubstreamDirection::Out,
+                                                    NotificationsSubstreamState::MAX,
+                                                    SubstreamId::MAX,
+                                                ),
+                                        )
+                                        .next()
+                                        .is_none()
+                                );
 
                                 let _was_inserted =
                                     self.connected_unopened_gossip_desired.insert((
@@ -2706,7 +2712,7 @@ where
                                     return Some(Event::ProtocolError {
                                         error: ProtocolError::BadGrandpaNotification(err),
                                         peer_id: self.peers[peer_index.0].clone(),
-                                    })
+                                    });
                                 }
                             };
 
@@ -2720,7 +2726,7 @@ where
                                             block_number_bytes: self.chains[chain_index]
                                                 .block_number_bytes,
                                         },
-                                    })
+                                    });
                                 }
                                 codec::GrandpaNotificationRef::Neighbor(n) => {
                                     return Some(Event::GrandpaNeighborPacket {
@@ -2731,7 +2737,7 @@ where
                                             set_id: n.set_id,
                                             commit_finalized_height: n.commit_finalized_height,
                                         },
-                                    })
+                                    });
                                 }
                                 _ => {
                                     // Any other type of message is currently ignored. Support

--- a/lib/src/network/service.rs
+++ b/lib/src/network/service.rs
@@ -650,7 +650,7 @@ where
     }
 
     /// Returns the list of all the chains that have been added.
-    pub fn chains(&'_ self) -> impl ExactSizeIterator<Item = ChainId> {
+    pub fn chains(&self) -> impl ExactSizeIterator<Item = ChainId> {
         self.chains.iter().map(|(idx, _)| ChainId(idx))
     }
 
@@ -899,7 +899,7 @@ where
         &self,
         chain_id: ChainId,
         kind: GossipKind,
-    ) -> impl Iterator<Item = &'_ PeerId> {
+    ) -> impl Iterator<Item = &PeerId> {
         self.gossip_desired_peers_by_chain
             .range(
                 (chain_id.0, kind, PeerIndex(usize::MIN))
@@ -923,7 +923,7 @@ where
     ///
     /// > **Note**: Connections that are currently in the process of shutting down are also
     /// >           ignored for the purpose of this function.
-    pub fn unconnected_desired(&'_ self) -> impl ExactSizeIterator<Item = &'_ PeerId> + Clone {
+    pub fn unconnected_desired(&self) -> impl ExactSizeIterator<Item = &PeerId> + Clone {
         self.unconnected_desired
             .iter()
             .map(|peer_index| &self.peers[peer_index.0])
@@ -932,8 +932,8 @@ where
     /// Returns the list of [`PeerId`]s that are marked as desired, and for which a healthy
     /// connection exists, but for which no substream connection attempt exists.
     pub fn connected_unopened_gossip_desired(
-        &'_ self,
-    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone {
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&PeerId, ChainId, GossipKind)> + Clone {
         self.connected_unopened_gossip_desired.iter().map(
             move |(peer_index, chain_id, gossip_kind)| {
                 (&self.peers[peer_index.0], *chain_id, *gossip_kind)
@@ -944,8 +944,8 @@ where
     /// Returns the list of [`PeerId`]s for which a substream connection or connection attempt
     /// exists but that are not marked as desired.
     pub fn opened_gossip_undesired(
-        &'_ self,
-    ) -> impl ExactSizeIterator<Item = (&'_ PeerId, ChainId, GossipKind)> + Clone {
+        &self,
+    ) -> impl ExactSizeIterator<Item = (&PeerId, ChainId, GossipKind)> + Clone {
         self.opened_gossip_undesired
             .iter()
             .map(move |(chain_id, peer_index, gossip_kind)| {
@@ -961,9 +961,9 @@ where
     /// Panics if the [`ChainId`] is invalid.
     ///
     pub fn opened_gossip_undesired_by_chain(
-        &'_ self,
+        &self,
         chain_id: ChainId,
-    ) -> impl Iterator<Item = (&'_ PeerId, GossipKind)> + Clone {
+    ) -> impl Iterator<Item = (&PeerId, GossipKind)> + Clone {
         // TODO: optimize and add an ExactSizeIterator bound to the return value, and update the users to use len() instead of count()
         self.opened_gossip_undesired
             .iter()
@@ -3284,10 +3284,10 @@ where
     /// Panics if the [`ChainId`] is invalid.
     ///
     pub fn gossip_connected_peers(
-        &'_ self,
+        &self,
         chain_id: ChainId,
         kind: GossipKind,
-    ) -> impl Iterator<Item = &'_ PeerId> {
+    ) -> impl Iterator<Item = &PeerId> {
         assert!(self.chains.contains(chain_id.0));
         let GossipKind::ConsensusTransactions = kind;
 
@@ -3328,7 +3328,7 @@ where
     /// Panics if the [`ChainId`] is invalid.
     ///
     pub fn gossip_is_connected(
-        &'_ self,
+        &self,
         chain_id: ChainId,
         target: &PeerId,
         kind: GossipKind,

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -1045,7 +1045,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     warp_sync: self.warp_sync,
                     ready_to_transition: self.ready_to_transition,
                     shared: self.shared,
-                })
+                });
             }
             all_forks::ProcessOne::FinalityProofVerify(inner) => {
                 return ProcessOne::VerifyFinalityProof(FinalityProofVerify {
@@ -1053,7 +1053,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
                     warp_sync: self.warp_sync,
                     ready_to_transition: self.ready_to_transition,
                     shared: self.shared,
-                })
+                });
             }
         }
 

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -482,7 +482,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> {
+    pub fn sources(&self) -> impl Iterator<Item = SourceId> {
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
         };
@@ -577,7 +577,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// potentially-finalized block prevents potentially confusing or erroneous situations.
     ///
     pub fn knows_non_finalized_block(
-        &'_ self,
+        &self,
         height: u64,
         hash: &[u8; 32],
     ) -> impl Iterator<Item = SourceId> {
@@ -628,9 +628,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     /// This method doesn't modify the state machine in any way. [`AllSync::add_request`] must be
     /// called in order for the request to actually be marked as started.
-    pub fn desired_requests(
-        &'_ self,
-    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> {
+    pub fn desired_requests(&self) -> impl Iterator<Item = (SourceId, &TSrc, DesiredRequest)> {
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
         };
@@ -873,7 +871,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> {
+    pub fn obsolete_requests(&self) -> impl Iterator<Item = RequestId> {
         // TODO: not implemented properly
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
@@ -2014,7 +2012,7 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
     ///
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
-        &'_ self,
+        &self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         self.inner.scale_encoded_extrinsics()
     }
@@ -2122,7 +2120,7 @@ impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
     ///
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
-        &'_ self,
+        &self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         self.inner.scale_encoded_extrinsics()
     }

--- a/lib/src/sync/all.rs
+++ b/lib/src/sync/all.rs
@@ -482,7 +482,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> + '_ {
+    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> {
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
         };
@@ -580,7 +580,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
         &'_ self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = SourceId> + '_ {
+    ) -> impl Iterator<Item = SourceId> {
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
         };
@@ -630,7 +630,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     /// called in order for the request to actually be marked as started.
     pub fn desired_requests(
         &'_ self,
-    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> + '_ {
+    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> {
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
         };
@@ -873,7 +873,7 @@ impl<TRq, TSrc, TBl> AllSync<TRq, TSrc, TBl> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> + '_ {
+    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = RequestId> {
         // TODO: not implemented properly
         let Some(all_forks) = &self.all_forks else {
             unreachable!()
@@ -2015,7 +2015,7 @@ impl<TRq, TSrc, TBl> BlockVerify<TRq, TSrc, TBl> {
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
         &'_ self,
-    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
+    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         self.inner.scale_encoded_extrinsics()
     }
 
@@ -2123,7 +2123,7 @@ impl<TRq, TSrc, TBl> HeaderVerifySuccess<TRq, TSrc, TBl> {
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
         &'_ self,
-    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
+    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         self.inner.scale_encoded_extrinsics()
     }
 

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -486,9 +486,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn non_finalized_blocks_unordered(
-        &'_ self,
-    ) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+    pub fn non_finalized_blocks_unordered(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.chain.iter_unordered()
     }
 
@@ -498,7 +496,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// their children.
     pub fn non_finalized_blocks_ancestry_order(
         &'_ self,
-    ) -> impl Iterator<Item = header::HeaderRef<'_>> + '_ {
+    ) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.chain.iter_ancestry_order()
     }
 
@@ -571,7 +569,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> + '_ {
+    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
         self.inner.blocks.sources()
     }
 
@@ -664,9 +662,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// This method doesn't modify the state machine in any way. [`AllForksSync::add_request`]
     /// must be called in order for the request to actually be marked as started.
-    pub fn desired_requests(
-        &'_ self,
-    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, RequestParams)> + '_ {
+    pub fn desired_requests(&'_ self) -> impl Iterator<Item = (SourceId, &'_ TSrc, RequestParams)> {
         // Query justifications of blocks that are necessary in order for finality to progress
         // against sources that have reported these blocks as finalized.
         // TODO: make it clear in the API docs that justifications should be requested as part of a request
@@ -743,7 +739,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> + '_ {
+    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> {
         // TODO: requests meant to query justifications only are considered obsolete by the underlying state machine, which right now is okay because the underlying state machine is pretty loose in its definition of obsolete
         self.inner.blocks.obsolete_requests()
     }
@@ -1904,7 +1900,7 @@ impl<TBl, TRq, TSrc> BlockVerify<TBl, TRq, TSrc> {
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
         &'_ self,
-    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
+    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         if self.parent.inner.blocks.downloading_bodies() {
             Some(
                 self.parent
@@ -2058,7 +2054,7 @@ impl<TBl, TRq, TSrc> HeaderVerifySuccess<TBl, TRq, TSrc> {
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
         &'_ self,
-    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + '_> + Clone + '_> {
+    ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         if self.parent.inner.blocks.downloading_bodies() {
             Some(
                 self.parent

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -486,7 +486,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn non_finalized_blocks_unordered(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn non_finalized_blocks_unordered(&self) -> impl Iterator<Item = header::HeaderRef> {
         self.chain.iter_unordered()
     }
 
@@ -494,9 +494,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
-    pub fn non_finalized_blocks_ancestry_order(
-        &self,
-    ) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn non_finalized_blocks_ancestry_order(&self) -> impl Iterator<Item = header::HeaderRef> {
         self.chain.iter_ancestry_order()
     }
 

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -613,7 +613,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
         &'a self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = SourceId> + 'a {
+    ) -> impl Iterator<Item = SourceId> + use<'a, TBl, TRq, TSrc> {
         self.inner.blocks.knows_non_finalized_block(height, hash)
     }
 

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -2216,7 +2216,7 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
                         return (
                             self.parent,
                             FinalityProofVerifyOutcome::GrandpaCommitError(err),
-                        )
+                        );
                     }
                 }
             }
@@ -2242,7 +2242,7 @@ impl<TBl, TRq, TSrc> FinalityProofVerify<TBl, TRq, TSrc> {
                         return (
                             self.parent,
                             FinalityProofVerifyOutcome::JustificationError(err),
-                        )
+                        );
                     }
                 }
             }

--- a/lib/src/sync/all_forks.rs
+++ b/lib/src/sync/all_forks.rs
@@ -486,7 +486,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
 
     /// Returns the header of all known non-finalized blocks in the chain without any specific
     /// order.
-    pub fn non_finalized_blocks_unordered(&'_ self) -> impl Iterator<Item = header::HeaderRef<'_>> {
+    pub fn non_finalized_blocks_unordered(&self) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.chain.iter_unordered()
     }
 
@@ -495,7 +495,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     /// The returned items are guaranteed to be in an order in which the parents are found before
     /// their children.
     pub fn non_finalized_blocks_ancestry_order(
-        &'_ self,
+        &self,
     ) -> impl Iterator<Item = header::HeaderRef<'_>> {
         self.chain.iter_ancestry_order()
     }
@@ -569,7 +569,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
+    pub fn sources(&self) -> impl ExactSizeIterator<Item = SourceId> {
         self.inner.blocks.sources()
     }
 
@@ -662,7 +662,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// This method doesn't modify the state machine in any way. [`AllForksSync::add_request`]
     /// must be called in order for the request to actually be marked as started.
-    pub fn desired_requests(&'_ self) -> impl Iterator<Item = (SourceId, &'_ TSrc, RequestParams)> {
+    pub fn desired_requests(&self) -> impl Iterator<Item = (SourceId, &TSrc, RequestParams)> {
         // Query justifications of blocks that are necessary in order for finality to progress
         // against sources that have reported these blocks as finalized.
         // TODO: make it clear in the API docs that justifications should be requested as part of a request
@@ -739,7 +739,7 @@ impl<TBl, TRq, TSrc> AllForksSync<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> {
+    pub fn obsolete_requests(&self) -> impl Iterator<Item = (RequestId, &TRq)> {
         // TODO: requests meant to query justifications only are considered obsolete by the underlying state machine, which right now is okay because the underlying state machine is pretty loose in its definition of obsolete
         self.inner.blocks.obsolete_requests()
     }
@@ -1899,7 +1899,7 @@ impl<TBl, TRq, TSrc> BlockVerify<TBl, TRq, TSrc> {
     ///
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
-        &'_ self,
+        &self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         if self.parent.inner.blocks.downloading_bodies() {
             Some(
@@ -2053,7 +2053,7 @@ impl<TBl, TRq, TSrc> HeaderVerifySuccess<TBl, TRq, TSrc> {
     ///
     /// This is `Some` if and only if [`Config::download_bodies`] is `true`
     pub fn scale_encoded_extrinsics(
-        &'_ self,
+        &self,
     ) -> Option<impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone> {
         if self.parent.inner.blocks.downloading_bodies() {
             Some(

--- a/lib/src/sync/all_forks/disjoint.rs
+++ b/lib/src/sync/all_forks/disjoint.rs
@@ -83,7 +83,7 @@ impl<TBl> DisjointBlocks<TBl> {
     }
 
     /// Returns the list of blocks in the collection.
-    pub fn iter(&'_ self) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> {
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &[u8; 32], &TBl)> {
         self.blocks
             .iter()
             .map(|((he, ha), bl)| (*he, ha, &bl.user_data))
@@ -194,10 +194,10 @@ impl<TBl> DisjointBlocks<TBl> {
     /// Returns the list of blocks whose height is `height + 1` and whose parent hash is the
     /// given block.
     pub fn children(
-        &'_ self,
+        &self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> {
+    ) -> impl Iterator<Item = (u64, &[u8; 32], &TBl)> {
         let hash = *hash;
         self.blocks
             .range((height + 1, [0; 32])..=(height + 1, [0xff; 32]))
@@ -290,7 +290,7 @@ impl<TBl> DisjointBlocks<TBl> {
 
     /// Returns the list of blocks whose parent hash is known but the parent itself is absent from
     /// the list of disjoint blocks. These blocks can potentially be verified.
-    pub fn good_tree_roots(&'_ self) -> impl Iterator<Item = TreeRoot> {
+    pub fn good_tree_roots(&self) -> impl Iterator<Item = TreeRoot> {
         self.blocks
             .iter()
             .filter(|(_, block)| !block.bad)
@@ -325,7 +325,7 @@ impl<TBl> DisjointBlocks<TBl> {
     /// >           this method.
     ///
     /// The blocks yielded by the iterator are always ordered by ascending height.
-    pub fn unknown_blocks(&'_ self) -> impl Iterator<Item = (u64, &'_ [u8; 32])> {
+    pub fn unknown_blocks(&self) -> impl Iterator<Item = (u64, &[u8; 32])> {
         // Blocks whose parent hash isn't known.
         let mut iter1 = self
             .blocks

--- a/lib/src/sync/all_forks/disjoint.rs
+++ b/lib/src/sync/all_forks/disjoint.rs
@@ -83,7 +83,7 @@ impl<TBl> DisjointBlocks<TBl> {
     }
 
     /// Returns the list of blocks in the collection.
-    pub fn iter(&'_ self) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> + '_ {
+    pub fn iter(&'_ self) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> {
         self.blocks
             .iter()
             .map(|((he, ha), bl)| (*he, ha, &bl.user_data))
@@ -197,7 +197,7 @@ impl<TBl> DisjointBlocks<TBl> {
         &'_ self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> + '_ {
+    ) -> impl Iterator<Item = (u64, &[u8; 32], &'_ TBl)> {
         let hash = *hash;
         self.blocks
             .range((height + 1, [0; 32])..=(height + 1, [0xff; 32]))
@@ -290,7 +290,7 @@ impl<TBl> DisjointBlocks<TBl> {
 
     /// Returns the list of blocks whose parent hash is known but the parent itself is absent from
     /// the list of disjoint blocks. These blocks can potentially be verified.
-    pub fn good_tree_roots(&'_ self) -> impl Iterator<Item = TreeRoot> + '_ {
+    pub fn good_tree_roots(&'_ self) -> impl Iterator<Item = TreeRoot> {
         self.blocks
             .iter()
             .filter(|(_, block)| !block.bad)
@@ -325,7 +325,7 @@ impl<TBl> DisjointBlocks<TBl> {
     /// >           this method.
     ///
     /// The blocks yielded by the iterator are always ordered by ascending height.
-    pub fn unknown_blocks(&'_ self) -> impl Iterator<Item = (u64, &'_ [u8; 32])> + '_ {
+    pub fn unknown_blocks(&'_ self) -> impl Iterator<Item = (u64, &'_ [u8; 32])> {
         // Blocks whose parent hash isn't known.
         let mut iter1 = self
             .blocks

--- a/lib/src/sync/all_forks/disjoint.rs
+++ b/lib/src/sync/all_forks/disjoint.rs
@@ -158,7 +158,7 @@ impl<TBl> DisjointBlocks<TBl> {
     pub fn remove_below_height(
         &mut self,
         threshold: u64,
-    ) -> impl ExactSizeIterator<Item = (u64, [u8; 32], TBl)> {
+    ) -> impl ExactSizeIterator<Item = (u64, [u8; 32], TBl)> + use<TBl> {
         let above_threshold = self.blocks.split_off(&(threshold, [0; 32]));
         let below_threshold = mem::replace(&mut self.blocks, above_threshold);
         below_threshold

--- a/lib/src/sync/all_forks/disjoint.rs
+++ b/lib/src/sync/all_forks/disjoint.rs
@@ -43,7 +43,7 @@
 
 #![allow(dead_code)] // TODO: remove this after `all.rs` implements full node; right now many methods here are useless because expected to be used only for full node code
 
-use alloc::collections::{btree_map::Entry, BTreeMap};
+use alloc::collections::{BTreeMap, btree_map::Entry};
 use core::{fmt, iter, mem};
 
 /// Collection of pending blocks.

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -321,14 +321,12 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> + '_ {
+    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
         self.sources.keys()
     }
 
     /// Returns the list of all user datas of all sources.
-    pub fn sources_user_data_iter_mut(
-        &'_ mut self,
-    ) -> impl ExactSizeIterator<Item = &'_ mut TSrc> + '_ {
+    pub fn sources_user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> {
         self.sources.user_data_iter_mut().map(|s| &mut s.user_data)
     }
 
@@ -677,7 +675,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// > **Note**: The naming of this function assumes that all blocks that are referenced by
     /// >           this data structure but absent from this data structure are known by the
     /// >           API user.
-    pub fn unverified_leaves(&'_ self) -> impl Iterator<Item = TreeRoot> + '_ {
+    pub fn unverified_leaves(&'_ self) -> impl Iterator<Item = TreeRoot> {
         self.blocks.good_tree_roots().filter(move |pending| {
             match self
                 .blocks
@@ -713,9 +711,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// >           data structure from reaching unreasonable sizes. Please keep in mind, however,
     /// >           that removing blocks will lead to redownloading these blocks later. In other
     /// >           words, it is better to keep these blocks.
-    pub fn unnecessary_unverified_blocks(
-        &'_ self,
-    ) -> impl Iterator<Item = (u64, &'_ [u8; 32])> + '_ {
+    pub fn unnecessary_unverified_blocks(&'_ self) -> impl Iterator<Item = (u64, &'_ [u8; 32])> {
         // TODO: this entire function is O(n) everywhere
 
         // List of blocks that have a bad parent.
@@ -872,7 +868,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> + '_ {
+    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> {
         // TODO: more than that?
         self.requests
             .iter()
@@ -909,7 +905,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// >           requests per source, as this is out of scope of this module. However, there is
     /// >           limit to the number of simultaneous requests per block. See
     /// >           [`Config::max_requests_per_block`].
-    pub fn desired_requests(&'_ self) -> impl Iterator<Item = DesiredRequest> + '_ {
+    pub fn desired_requests(&'_ self) -> impl Iterator<Item = DesiredRequest> {
         self.desired_requests_inner(None)
     }
 
@@ -926,7 +922,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     pub fn source_desired_requests(
         &'_ self,
         source_id: SourceId,
-    ) -> impl Iterator<Item = RequestParams> + '_ {
+    ) -> impl Iterator<Item = RequestParams> {
         self.desired_requests_inner(Some(source_id)).map(move |rq| {
             debug_assert_eq!(rq.source_id, source_id);
             rq.request_params
@@ -945,7 +941,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     fn desired_requests_inner(
         &'_ self,
         force_source: Option<SourceId>,
-    ) -> impl Iterator<Item = DesiredRequest> + '_ {
+    ) -> impl Iterator<Item = DesiredRequest> {
         // TODO: could provide more optimized requests by avoiding potentially overlapping requests (e.g. if blocks #4 and #5 are unknown, ask for block #5 with num_blocks=2), but this is complicated because peers aren't obligated to respond with the given number of blocks
 
         // List of blocks whose header is known but not its body.

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -321,12 +321,12 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     }
 
     /// Returns the list of sources in this state machine.
-    pub fn sources(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
+    pub fn sources(&self) -> impl ExactSizeIterator<Item = SourceId> {
         self.sources.keys()
     }
 
     /// Returns the list of all user datas of all sources.
-    pub fn sources_user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> {
+    pub fn sources_user_data_iter_mut(&mut self) -> impl ExactSizeIterator<Item = &mut TSrc> {
         self.sources.user_data_iter_mut().map(|s| &mut s.user_data)
     }
 
@@ -675,7 +675,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// > **Note**: The naming of this function assumes that all blocks that are referenced by
     /// >           this data structure but absent from this data structure are known by the
     /// >           API user.
-    pub fn unverified_leaves(&'_ self) -> impl Iterator<Item = TreeRoot> {
+    pub fn unverified_leaves(&self) -> impl Iterator<Item = TreeRoot> {
         self.blocks.good_tree_roots().filter(move |pending| {
             match self
                 .blocks
@@ -711,7 +711,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// >           data structure from reaching unreasonable sizes. Please keep in mind, however,
     /// >           that removing blocks will lead to redownloading these blocks later. In other
     /// >           words, it is better to keep these blocks.
-    pub fn unnecessary_unverified_blocks(&'_ self) -> impl Iterator<Item = (u64, &'_ [u8; 32])> {
+    pub fn unnecessary_unverified_blocks(&self) -> impl Iterator<Item = (u64, &[u8; 32])> {
         // TODO: this entire function is O(n) everywhere
 
         // List of blocks that have a bad parent.
@@ -868,7 +868,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     ///
     /// > **Note**: It is in no way mandatory to actually call this function and cancel the
     /// >           requests that are returned.
-    pub fn obsolete_requests(&'_ self) -> impl Iterator<Item = (RequestId, &'_ TRq)> {
+    pub fn obsolete_requests(&self) -> impl Iterator<Item = (RequestId, &TRq)> {
         // TODO: more than that?
         self.requests
             .iter()
@@ -905,7 +905,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// >           requests per source, as this is out of scope of this module. However, there is
     /// >           limit to the number of simultaneous requests per block. See
     /// >           [`Config::max_requests_per_block`].
-    pub fn desired_requests(&'_ self) -> impl Iterator<Item = DesiredRequest> {
+    pub fn desired_requests(&self) -> impl Iterator<Item = DesiredRequest> {
         self.desired_requests_inner(None)
     }
 
@@ -920,7 +920,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// Panics if the [`SourceId`] is out of range.
     ///
     pub fn source_desired_requests(
-        &'_ self,
+        &self,
         source_id: SourceId,
     ) -> impl Iterator<Item = RequestParams> {
         self.desired_requests_inner(Some(source_id)).map(move |rq| {
@@ -939,7 +939,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     /// Panics if the [`SourceId`] is out of range.
     ///
     fn desired_requests_inner(
-        &'_ self,
+        &self,
         force_source: Option<SourceId>,
     ) -> impl Iterator<Item = DesiredRequest> {
         // TODO: could provide more optimized requests by avoiding potentially overlapping requests (e.g. if blocks #4 and #5 are unknown, ask for block #5 with num_blocks=2), but this is complicated because peers aren't obligated to respond with the given number of blocks

--- a/lib/src/sync/all_forks/pending_blocks.rs
+++ b/lib/src/sync/all_forks/pending_blocks.rs
@@ -426,7 +426,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
         &'a self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = SourceId> + 'a {
+    ) -> impl Iterator<Item = SourceId> + use<'a, TBl, TRq, TSrc> {
         self.sources.knows_non_finalized_block(height, hash)
     }
 
@@ -465,7 +465,7 @@ impl<TBl, TRq, TSrc> PendingBlocks<TBl, TRq, TSrc> {
     pub fn set_finalized_block_height(
         &mut self,
         height: u64,
-    ) -> impl ExactSizeIterator<Item = TBl> {
+    ) -> impl ExactSizeIterator<Item = TBl> + use<TBl, TRq, TSrc> {
         self.sources.set_finalized_block_height(height);
         self.blocks
             .remove_below_height(height + 1)

--- a/lib/src/sync/all_forks/sources.rs
+++ b/lib/src/sync/all_forks/sources.rs
@@ -83,7 +83,7 @@ impl<TSrc> AllForksSources<TSrc> {
     }
 
     /// Returns the list of all [`SourceId`]s.
-    pub fn keys(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
+    pub fn keys(&self) -> impl ExactSizeIterator<Item = SourceId> {
         self.sources.keys().copied()
     }
 
@@ -105,7 +105,7 @@ impl<TSrc> AllForksSources<TSrc> {
     }
 
     /// Returns the list of all user datas of all sources.
-    pub fn user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> {
+    pub fn user_data_iter_mut(&mut self) -> impl ExactSizeIterator<Item = &mut TSrc> {
         self.sources.values_mut().map(|s| &mut s.user_data)
     }
 

--- a/lib/src/sync/all_forks/sources.rs
+++ b/lib/src/sync/all_forks/sources.rs
@@ -332,7 +332,7 @@ impl<TSrc> AllForksSources<TSrc> {
         &'a self,
         height: u64,
         hash: &[u8; 32],
-    ) -> impl Iterator<Item = SourceId> + 'a {
+    ) -> impl Iterator<Item = SourceId> + use<'a, TSrc> {
         assert!(height > self.finalized_block_height);
         self.known_blocks2
             .range((height, *hash, SourceId(u64::MIN))..=(height, *hash, SourceId(u64::MAX)))

--- a/lib/src/sync/all_forks/sources.rs
+++ b/lib/src/sync/all_forks/sources.rs
@@ -83,7 +83,7 @@ impl<TSrc> AllForksSources<TSrc> {
     }
 
     /// Returns the list of all [`SourceId`]s.
-    pub fn keys(&'_ self) -> impl ExactSizeIterator<Item = SourceId> + '_ {
+    pub fn keys(&'_ self) -> impl ExactSizeIterator<Item = SourceId> {
         self.sources.keys().copied()
     }
 
@@ -105,7 +105,7 @@ impl<TSrc> AllForksSources<TSrc> {
     }
 
     /// Returns the list of all user datas of all sources.
-    pub fn user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> + '_ {
+    pub fn user_data_iter_mut(&'_ mut self) -> impl ExactSizeIterator<Item = &'_ mut TSrc> {
         self.sources.values_mut().map(|s| &mut s.user_data)
     }
 

--- a/lib/src/sync/para.rs
+++ b/lib/src/sync/para.rs
@@ -62,7 +62,7 @@ pub enum OccupiedCoreAssumption {
 
 impl OccupiedCoreAssumption {
     /// Returns the SCALE encoding of this type.
-    pub fn scale_encoded(&self) -> impl AsRef<[u8]> + Clone {
+    pub fn scale_encoded(&self) -> impl AsRef<[u8]> + Clone + use<> {
         match self {
             OccupiedCoreAssumption::Included => [0],
             OccupiedCoreAssumption::TimedOut => [1],

--- a/lib/src/sync/para.rs
+++ b/lib/src/sync/para.rs
@@ -112,7 +112,7 @@ pub struct PersistedValidationDataRef<'a> {
 /// `Nom` combinator that parses a [`PersistedValidationDataRef`].
 fn persisted_validation_data<'a, E: nom::error::ParseError<&'a [u8]>>(
     block_number_bytes: usize,
-) -> impl FnMut(&'a [u8]) -> nom::IResult<&[u8], PersistedValidationDataRef, E> {
+) -> impl FnMut(&'a [u8]) -> nom::IResult<&'a [u8], PersistedValidationDataRef<'a>, E> {
     nom::combinator::map(
         nom::sequence::tuple((
             crate::util::nom_bytes_decode,

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -621,7 +621,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     }
 
     /// Returns a list of all known sources stored in the state machine.
-    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> + '_ {
+    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> {
         self.sources.iter().map(|(id, _)| SourceId(id))
     }
 
@@ -666,7 +666,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     pub fn remove_source(
         &'_ mut self,
         to_remove: SourceId,
-    ) -> (TSrc, impl Iterator<Item = (RequestId, TRq)> + '_) {
+    ) -> (TSrc, impl Iterator<Item = (RequestId, TRq)>) {
         debug_assert!(self.sources.contains(to_remove.0));
         let removed = self.sources.remove(to_remove.0);
         let _was_in = self
@@ -800,7 +800,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     /// [`WarpSync::add_request`], it is no longer returned by this function.
     pub fn desired_requests(
         &'_ self,
-    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> + '_ {
+    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> {
         // If we are in the fragments download phase, return a fragments download request.
         let mut desired_warp_sync_request = if self.warp_sync_fragments_download.is_none() {
             if self.verify_queue.iter().fold(0, |sum, entry| {

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -621,7 +621,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     }
 
     /// Returns a list of all known sources stored in the state machine.
-    pub fn sources(&'_ self) -> impl Iterator<Item = SourceId> {
+    pub fn sources(&self) -> impl Iterator<Item = SourceId> {
         self.sources.iter().map(|(id, _)| SourceId(id))
     }
 
@@ -664,7 +664,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     /// Panics if the [`SourceId`] is invalid.
     ///
     pub fn remove_source(
-        &'_ mut self,
+        &mut self,
         to_remove: SourceId,
     ) -> (TSrc, impl Iterator<Item = (RequestId, TRq)>) {
         debug_assert!(self.sources.contains(to_remove.0));
@@ -798,9 +798,7 @@ impl<TSrc, TRq> WarpSync<TSrc, TRq> {
     ///
     /// Once a request that matches a desired request is added through
     /// [`WarpSync::add_request`], it is no longer returned by this function.
-    pub fn desired_requests(
-        &'_ self,
-    ) -> impl Iterator<Item = (SourceId, &'_ TSrc, DesiredRequest)> {
+    pub fn desired_requests(&self) -> impl Iterator<Item = (SourceId, &TSrc, DesiredRequest)> {
         // If we are in the fragments download phase, return a fragments download request.
         let mut desired_warp_sync_request = if self.warp_sync_fragments_download.is_none() {
             if self.verify_queue.iter().fold(0, |sum, entry| {

--- a/lib/src/sync/warp_sync.rs
+++ b/lib/src/sync/warp_sync.rs
@@ -199,7 +199,7 @@ pub fn start_warp_sync<TSrc, TRq>(
             return Err((
                 config.start_chain_information,
                 WarpSyncInitError::NotGrandpa,
-            ))
+            ));
         }
     }
 
@@ -209,7 +209,7 @@ pub fn start_warp_sync<TSrc, TRq>(
             return Err((
                 config.start_chain_information,
                 WarpSyncInitError::UnknownConsensus,
-            ))
+            ));
         }
     }
 
@@ -2166,9 +2166,11 @@ impl<TSrc, TRq> BuildChainInformation<TSrc, TRq> {
 
         let runtime_calls = mem::take(&mut self.inner.runtime_calls);
 
-        debug_assert!(runtime_calls
-            .values()
-            .all(|c| matches!(c, CallProof::Downloaded { .. })));
+        debug_assert!(
+            runtime_calls
+                .values()
+                .all(|c| matches!(c, CallProof::Downloaded { .. }))
+        );
 
         // Decode all the Merkle proofs that have been received.
         let calls = {

--- a/lib/src/transactions/light_pool.rs
+++ b/lib/src/transactions/light_pool.rs
@@ -246,7 +246,7 @@ where
     /// Returns a list of transactions whose state is "not validated", and their user data.
     ///
     /// These transactions should always be validated against the current best block.
-    pub fn unvalidated_transactions(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
+    pub fn unvalidated_transactions(&self) -> impl Iterator<Item = (TransactionId, &TTx)> {
         let best_block_relative_height = match self.best_block_index {
             Some(idx) => self.blocks_tree.get(idx).unwrap().relative_block_height,
             None => self.blocks_tree_root_relative_height,
@@ -268,16 +268,14 @@ where
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn transactions_iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
+    pub fn transactions_iter(&self) -> impl Iterator<Item = (TransactionId, &TTx)> {
         self.transactions
             .iter()
             .map(|(id, tx)| (TransactionId(id), &tx.user_data))
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn transactions_iter_mut(
-        &'_ mut self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> {
+    pub fn transactions_iter_mut(&mut self) -> impl Iterator<Item = (TransactionId, &mut TTx)> {
         self.transactions
             .iter_mut()
             .map(|(id, tx)| (TransactionId(id), &mut tx.user_data))
@@ -305,7 +303,7 @@ where
     }
 
     /// Tries to find the transactions in the pool whose bytes are `scale_encoded`.
-    pub fn find_transaction(&'_ self, scale_encoded: &[u8]) -> impl Iterator<Item = TransactionId> {
+    pub fn find_transaction(&self, scale_encoded: &[u8]) -> impl Iterator<Item = TransactionId> {
         let hash = blake2_hash(scale_encoded);
         self.by_hash
             .range((hash, TransactionId(usize::MIN))..=(hash, TransactionId(usize::MAX)))
@@ -372,8 +370,8 @@ where
     /// >           possible for the transaction to become valid again in the future if a reorg
     /// >           happens and removes the block the transaction was validated against.
     pub fn invalid_transactions_best_block(
-        &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> {
+        &self,
+    ) -> impl Iterator<Item = (TransactionId, &TTx, &TErr)> {
         // Note that this iterates over all transactions every time, which seems unoptimal, but
         // is also way easier to implement and probably doesn't cost too much in practice.
         self.transactions
@@ -393,8 +391,8 @@ where
     /// >           block it was verified against. In other words, it can assumed that transactions
     /// >           returned here will never be valid.
     pub fn invalid_transactions_finalized_block(
-        &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> {
+        &self,
+    ) -> impl Iterator<Item = (TransactionId, &TTx, &TErr)> {
         // Note that this iterates over all transactions every time, which seems unoptimal, but
         // is also way easier to implement and probably doesn't cost too much in practice.
         self.transactions.iter().filter_map(move |(tx_id, tx)| {
@@ -680,7 +678,7 @@ where
     // TODO: return something more precise in case the block in which a transaction is included is updated?
     #[must_use = "`set_block_body` returns the list of transactions that are now included in the chain"]
     pub fn set_block_body(
-        &'_ mut self,
+        &mut self,
         block_hash: &[u8; 32],
         body: impl Iterator<Item = impl AsRef<[u8]>>,
     ) -> impl Iterator<Item = (TransactionId, usize)> {
@@ -780,7 +778,7 @@ where
     /// Blocks that were inserted when there wasn't any transaction in the pool are never
     /// returned.
     // TODO: return whether in best chain
-    pub fn missing_block_bodies(&'_ self) -> impl Iterator<Item = (&'_ [u8; 32], &'_ TBl)> {
+    pub fn missing_block_bodies(&self) -> impl Iterator<Item = (&[u8; 32], &TBl)> {
         self.blocks_tree
             .iter_unordered()
             .filter_map(move |(_, block)| {

--- a/lib/src/transactions/light_pool.rs
+++ b/lib/src/transactions/light_pool.rs
@@ -824,9 +824,10 @@ where
         } else {
             let index = *self.blocks_by_id.get(new_finalized_block_hash).unwrap();
             // TODO: check ancestry of previously finalized too
-            assert!(self
-                .blocks_tree
-                .is_ancestor(index, self.best_block_index.unwrap()));
+            assert!(
+                self.blocks_tree
+                    .is_ancestor(index, self.best_block_index.unwrap())
+            );
             index
         };
 

--- a/lib/src/transactions/light_pool.rs
+++ b/lib/src/transactions/light_pool.rs
@@ -246,9 +246,7 @@ where
     /// Returns a list of transactions whose state is "not validated", and their user data.
     ///
     /// These transactions should always be validated against the current best block.
-    pub fn unvalidated_transactions(
-        &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx)> + '_ {
+    pub fn unvalidated_transactions(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
         let best_block_relative_height = match self.best_block_index {
             Some(idx) => self.blocks_tree.get(idx).unwrap().relative_block_height,
             None => self.blocks_tree_root_relative_height,
@@ -270,7 +268,7 @@ where
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn transactions_iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> + '_ {
+    pub fn transactions_iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
         self.transactions
             .iter()
             .map(|(id, tx)| (TransactionId(id), &tx.user_data))
@@ -279,7 +277,7 @@ where
     /// Returns the list of all transactions within the pool.
     pub fn transactions_iter_mut(
         &'_ mut self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> {
         self.transactions
             .iter_mut()
             .map(|(id, tx)| (TransactionId(id), &mut tx.user_data))
@@ -307,10 +305,7 @@ where
     }
 
     /// Tries to find the transactions in the pool whose bytes are `scale_encoded`.
-    pub fn find_transaction(
-        &'_ self,
-        scale_encoded: &[u8],
-    ) -> impl Iterator<Item = TransactionId> + '_ {
+    pub fn find_transaction(&'_ self, scale_encoded: &[u8]) -> impl Iterator<Item = TransactionId> {
         let hash = blake2_hash(scale_encoded);
         self.by_hash
             .range((hash, TransactionId(usize::MIN))..=(hash, TransactionId(usize::MAX)))
@@ -378,7 +373,7 @@ where
     /// >           happens and removes the block the transaction was validated against.
     pub fn invalid_transactions_best_block(
         &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> {
         // Note that this iterates over all transactions every time, which seems unoptimal, but
         // is also way easier to implement and probably doesn't cost too much in practice.
         self.transactions
@@ -399,7 +394,7 @@ where
     /// >           returned here will never be valid.
     pub fn invalid_transactions_finalized_block(
         &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, &'_ TTx, &'_ TErr)> {
         // Note that this iterates over all transactions every time, which seems unoptimal, but
         // is also way easier to implement and probably doesn't cost too much in practice.
         self.transactions.iter().filter_map(move |(tx_id, tx)| {
@@ -688,7 +683,7 @@ where
         &'_ mut self,
         block_hash: &[u8; 32],
         body: impl Iterator<Item = impl AsRef<[u8]>>,
-    ) -> impl Iterator<Item = (TransactionId, usize)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, usize)> {
         let block_index = *self.blocks_by_id.get(block_hash).unwrap();
 
         // TODO: what if body was already known? this will trigger the `debug_assert!(_was_included)` below
@@ -785,7 +780,7 @@ where
     /// Blocks that were inserted when there wasn't any transaction in the pool are never
     /// returned.
     // TODO: return whether in best chain
-    pub fn missing_block_bodies(&'_ self) -> impl Iterator<Item = (&'_ [u8; 32], &'_ TBl)> + '_ {
+    pub fn missing_block_bodies(&'_ self) -> impl Iterator<Item = (&'_ [u8; 32], &'_ TBl)> {
         self.blocks_tree
             .iter_unordered()
             .filter_map(move |(_, block)| {

--- a/lib/src/transactions/light_pool.rs
+++ b/lib/src/transactions/light_pool.rs
@@ -817,7 +817,7 @@ where
     pub fn set_finalized_block(
         &mut self,
         new_finalized_block_hash: &[u8; 32],
-    ) -> impl Iterator<Item = ([u8; 32], TBl)> {
+    ) -> impl Iterator<Item = ([u8; 32], TBl)> + use<TTx, TBl, TErr> {
         let new_finalized_block_index = if *new_finalized_block_hash == self.blocks_tree_root_hash {
             assert!(self.finalized_block_index.is_none());
             return Vec::new().into_iter();
@@ -940,8 +940,8 @@ where
     ///
     /// Also removes the transactions from the pool that were included in these blocks.
     pub fn prune_finalized_with_body(
-        &'_ mut self,
-    ) -> impl Iterator<Item = PruneBodyFinalized<TTx, TBl>> + '_ {
+        &mut self,
+    ) -> impl Iterator<Item = PruneBodyFinalized<TTx, TBl>> + use<TTx, TBl, TErr> {
         // TODO: optimize?
 
         let finalized_block_index = match self.finalized_block_index {

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -295,7 +295,7 @@ impl<TTx> Pool<TTx> {
     pub fn remove_included(
         &'_ mut self,
         block_inferior_of_equal: u64,
-    ) -> impl Iterator<Item = (TransactionId, TTx)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, TTx)> {
         // First, unvalidate all the transactions that we are going to remove.
         // This is done separately ahead of time in order to guarantee that there is no state
         // mismatch when `unvalidate_transaction` is entered.
@@ -379,7 +379,7 @@ impl<TTx> Pool<TTx> {
     /// the iterator for convenience, to avoid writing error-prone code.
     pub fn unvalidated_transactions(
         &'_ self,
-    ) -> impl ExactSizeIterator<Item = (TransactionId, &TTx, u64)> + '_ {
+    ) -> impl ExactSizeIterator<Item = (TransactionId, &TTx, u64)> {
         self.not_validated.iter().copied().map(move |tx_id| {
             let tx = self.transactions.get(tx_id.0).unwrap();
             let height = tx
@@ -391,14 +391,14 @@ impl<TTx> Pool<TTx> {
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> + '_ {
+    pub fn iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
         self.transactions
             .iter()
             .map(|(id, tx)| (TransactionId(id), &tx.user_data))
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn iter_mut(&'_ mut self) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> + '_ {
+    pub fn iter_mut(&'_ mut self) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> {
         self.transactions
             .iter_mut()
             .map(|(id, tx)| (TransactionId(id), &mut tx.user_data))
@@ -430,7 +430,7 @@ impl<TTx> Pool<TTx> {
     pub fn transactions_by_scale_encoding(
         &'_ self,
         scale_encoded: &[u8],
-    ) -> impl Iterator<Item = TransactionId> + '_ {
+    ) -> impl Iterator<Item = TransactionId> {
         let hash = blake2_hash(scale_encoded);
         self.by_hash
             .range((hash, TransactionId(usize::MIN))..=(hash, TransactionId(usize::MAX)))
@@ -522,7 +522,7 @@ impl<TTx> Pool<TTx> {
     /// altogether if desired.
     pub fn best_block_includable_transactions(
         &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx)> + '_ {
+    ) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
         self.includable
             .iter()
             .rev()

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -293,7 +293,7 @@ impl<TTx> Pool<TTx> {
     /// The returned iterator is guaranteed to remove all transactions even if it is dropped
     /// eagerly.
     pub fn remove_included(
-        &'_ mut self,
+        &mut self,
         block_inferior_of_equal: u64,
     ) -> impl Iterator<Item = (TransactionId, TTx)> {
         // First, unvalidate all the transactions that we are going to remove.
@@ -378,7 +378,7 @@ impl<TTx> Pool<TTx> {
     /// block at which it has been included minus one, or the current best block. It is yielded by
     /// the iterator for convenience, to avoid writing error-prone code.
     pub fn unvalidated_transactions(
-        &'_ self,
+        &self,
     ) -> impl ExactSizeIterator<Item = (TransactionId, &TTx, u64)> {
         self.not_validated.iter().copied().map(move |tx_id| {
             let tx = self.transactions.get(tx_id.0).unwrap();
@@ -391,14 +391,14 @@ impl<TTx> Pool<TTx> {
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn iter(&'_ self) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
+    pub fn iter(&self) -> impl Iterator<Item = (TransactionId, &TTx)> {
         self.transactions
             .iter()
             .map(|(id, tx)| (TransactionId(id), &tx.user_data))
     }
 
     /// Returns the list of all transactions within the pool.
-    pub fn iter_mut(&'_ mut self) -> impl Iterator<Item = (TransactionId, &'_ mut TTx)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (TransactionId, &mut TTx)> {
         self.transactions
             .iter_mut()
             .map(|(id, tx)| (TransactionId(id), &mut tx.user_data))
@@ -428,7 +428,7 @@ impl<TTx> Pool<TTx> {
     /// This operation has a complexity of `O(log n)` where `n` is the number of entries in the
     /// pool.
     pub fn transactions_by_scale_encoding(
-        &'_ self,
+        &self,
         scale_encoded: &[u8],
     ) -> impl Iterator<Item = TransactionId> {
         let hash = blake2_hash(scale_encoded);
@@ -521,8 +521,8 @@ impl<TTx> Pool<TTx> {
     /// lead to the runtime returning errors. It is safe, however, to skip some transactions
     /// altogether if desired.
     pub fn best_block_includable_transactions(
-        &'_ self,
-    ) -> impl Iterator<Item = (TransactionId, &'_ TTx)> {
+        &self,
+    ) -> impl Iterator<Item = (TransactionId, &TTx)> {
         self.includable
             .iter()
             .rev()

--- a/lib/src/transactions/pool.rs
+++ b/lib/src/transactions/pool.rs
@@ -85,7 +85,7 @@
 //!
 
 use alloc::{
-    collections::{btree_set, BTreeSet},
+    collections::{BTreeSet, btree_set},
     vec::Vec,
 };
 use core::{fmt, iter, mem, ops};
@@ -481,11 +481,12 @@ impl<TTx> Pool<TTx> {
         num_to_retract: u64,
     ) -> impl Iterator<Item = (TransactionId, u64)> {
         // Checks that there's no transaction included above `self.best_block_height`.
-        debug_assert!(self
-            .by_height
-            .range((self.best_block_height + 1, TransactionId(usize::MIN),)..,)
-            .next()
-            .is_none());
+        debug_assert!(
+            self.by_height
+                .range((self.best_block_height + 1, TransactionId(usize::MIN),)..,)
+                .next()
+                .is_none()
+        );
 
         // Update `best_block_height` as first step, in order to panic sooner in case of underflow.
         self.best_block_height = self.best_block_height.checked_sub(num_to_retract).unwrap();

--- a/lib/src/transactions/validate.rs
+++ b/lib/src/transactions/validate.rs
@@ -175,7 +175,7 @@ pub enum TransactionValidityError {
 pub fn validate_transaction_runtime_parameters_v2<'a>(
     scale_encoded_transaction: impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a,
     source: TransactionSource,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
     validate_transaction_runtime_parameters_inner(scale_encoded_transaction, source, &[])
 }
 
@@ -184,7 +184,7 @@ pub fn validate_transaction_runtime_parameters_v3<'a>(
     scale_encoded_transaction: impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a,
     source: TransactionSource,
     block_hash: &'a [u8; 32],
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
     validate_transaction_runtime_parameters_inner(scale_encoded_transaction, source, block_hash)
 }
 
@@ -192,7 +192,7 @@ fn validate_transaction_runtime_parameters_inner<'a>(
     scale_encoded_transaction: impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a,
     source: TransactionSource,
     block_hash: &'a [u8],
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + Clone + 'a {
+) -> impl Iterator<Item = impl AsRef<[u8]>> + Clone {
     // The `TaggedTransactionQueue_validate_transaction` function expects a SCALE-encoded
     // `(source, tx, block_hash)`. The encoding is performed manually in order to avoid
     // performing redundant data copies.

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -118,8 +118,8 @@ pub mod trie_structure;
 use alloc::collections::BTreeSet;
 
 pub use nibble::{
-    all_nibbles, bytes_to_nibbles, nibbles_to_bytes_prefix_extend, nibbles_to_bytes_suffix_extend,
-    nibbles_to_bytes_truncate, BytesToNibbles, Nibble, NibbleFromU8Error,
+    BytesToNibbles, Nibble, NibbleFromU8Error, all_nibbles, bytes_to_nibbles,
+    nibbles_to_bytes_prefix_extend, nibbles_to_bytes_suffix_extend, nibbles_to_bytes_truncate,
 };
 
 /// The format of the nodes of trie has two different versions.
@@ -289,7 +289,7 @@ pub fn ordered_root(
 
 #[cfg(test)]
 mod tests {
-    use super::{trie_node, HashFunction};
+    use super::{HashFunction, trie_node};
     use core::iter;
 
     #[test]

--- a/lib/src/trie/branch_search.rs
+++ b/lib/src/trie/branch_search.rs
@@ -124,7 +124,7 @@ enum NextKeyInner {
 impl NextKey {
     /// The API user must provide the trie node with a storage value whose key is the first one
     /// that is strictly superior or superior or equal to the key returned by this function.
-    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> + '_ {
+    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> {
         trie::nibbles_to_bytes_suffix_extend(match &self.inner {
             NextKeyInner::FirstFound { .. } => either::Left(self.key_before.iter().copied()),
             NextKeyInner::FurtherRound {
@@ -170,7 +170,7 @@ impl NextKey {
 
     /// The API user must indicate a key that starts with the bytes returned by this function.
     /// If the first key doesn't start with these bytes, then the API user must indicate `None`.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> {
         trie::nibbles_to_bytes_truncate(self.prefix.iter().copied())
     }
 

--- a/lib/src/trie/branch_search.rs
+++ b/lib/src/trie/branch_search.rs
@@ -124,7 +124,7 @@ enum NextKeyInner {
 impl NextKey {
     /// The API user must provide the trie node with a storage value whose key is the first one
     /// that is strictly superior or superior or equal to the key returned by this function.
-    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> {
+    pub fn key_before(&self) -> impl Iterator<Item = u8> {
         trie::nibbles_to_bytes_suffix_extend(match &self.inner {
             NextKeyInner::FirstFound { .. } => either::Left(self.key_before.iter().copied()),
             NextKeyInner::FurtherRound {
@@ -170,7 +170,7 @@ impl NextKey {
 
     /// The API user must indicate a key that starts with the bytes returned by this function.
     /// If the first key doesn't start with these bytes, then the API user must indicate `None`.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> {
+    pub fn prefix(&self) -> impl Iterator<Item = u8> {
         trie::nibbles_to_bytes_truncate(self.prefix.iter().copied())
     }
 

--- a/lib/src/trie/branch_search/tests.rs
+++ b/lib/src/trie/branch_search/tests.rs
@@ -17,7 +17,7 @@
 
 #![cfg(test)]
 
-use super::{start_branch_search, BranchSearch, Config};
+use super::{BranchSearch, Config, start_branch_search};
 use crate::trie;
 
 use rand::distributions::{Distribution as _, Uniform};

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -135,7 +135,7 @@ struct Node {
 
 impl CalcInner {
     /// Returns the full key of the node currently being iterated.
-    fn current_iter_node_full_key(&'_ self) -> impl Iterator<Item = Nibble> {
+    fn current_iter_node_full_key(&self) -> impl Iterator<Item = Nibble> {
         self.stack.iter().flat_map(|node| {
             let child_nibble = if node.children.len() == 16 {
                 None
@@ -219,7 +219,7 @@ pub struct NextKey {
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> {
+    pub fn key_before(&self) -> impl Iterator<Item = u8> {
         self.branch_search.key_before()
     }
 
@@ -231,7 +231,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> {
+    pub fn prefix(&self) -> impl Iterator<Item = u8> {
         self.branch_search.prefix()
     }
 
@@ -291,7 +291,7 @@ pub struct StorageValue {
 
 impl StorageValue {
     /// Returns the key whose value is being requested.
-    pub fn key(&'_ self) -> impl Iterator<Item = u8> {
+    pub fn key(&self) -> impl Iterator<Item = u8> {
         // This function can never be reached if the number of nibbles is uneven.
         debug_assert_eq!(self.calculation.current_iter_node_full_key().count() % 2, 0);
         nibbles_to_bytes_suffix_extend(self.calculation.current_iter_node_full_key())

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -79,10 +79,10 @@
 //!
 
 use super::{
-    branch_search,
-    nibble::{nibbles_to_bytes_suffix_extend, Nibble},
-    trie_node, HashFunction, TrieEntryVersion, EMPTY_BLAKE2_TRIE_MERKLE_VALUE,
-    EMPTY_KECCAK256_TRIE_MERKLE_VALUE,
+    EMPTY_BLAKE2_TRIE_MERKLE_VALUE, EMPTY_KECCAK256_TRIE_MERKLE_VALUE, HashFunction,
+    TrieEntryVersion, branch_search,
+    nibble::{Nibble, nibbles_to_bytes_suffix_extend},
+    trie_node,
 };
 
 use alloc::vec::Vec;

--- a/lib/src/trie/calculate_root.rs
+++ b/lib/src/trie/calculate_root.rs
@@ -135,7 +135,7 @@ struct Node {
 
 impl CalcInner {
     /// Returns the full key of the node currently being iterated.
-    fn current_iter_node_full_key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    fn current_iter_node_full_key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.stack.iter().flat_map(|node| {
             let child_nibble = if node.children.len() == 16 {
                 None
@@ -219,7 +219,7 @@ pub struct NextKey {
 
 impl NextKey {
     /// Returns the key whose next key must be passed back.
-    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> + '_ {
+    pub fn key_before(&'_ self) -> impl Iterator<Item = u8> {
         self.branch_search.key_before()
     }
 
@@ -231,7 +231,7 @@ impl NextKey {
 
     /// Returns the prefix the next key must start with. If the next key doesn't start with the
     /// given prefix, then `None` should be provided.
-    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> + '_ {
+    pub fn prefix(&'_ self) -> impl Iterator<Item = u8> {
         self.branch_search.prefix()
     }
 
@@ -291,7 +291,7 @@ pub struct StorageValue {
 
 impl StorageValue {
     /// Returns the key whose value is being requested.
-    pub fn key(&'_ self) -> impl Iterator<Item = u8> + '_ {
+    pub fn key(&'_ self) -> impl Iterator<Item = u8> {
         // This function can never be reached if the number of nibbles is uneven.
         debug_assert_eq!(self.calculation.current_iter_node_full_key().count() % 2, 0);
         nibbles_to_bytes_suffix_extend(self.calculation.current_iter_node_full_key())

--- a/lib/src/trie/nibble.rs
+++ b/lib/src/trie/nibble.rs
@@ -83,19 +83,19 @@ impl From<Nibble> for usize {
 }
 
 impl fmt::LowerHex for Nibble {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
 impl fmt::UpperHex for Nibble {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::UpperHex::fmt(&self.0, f)
     }
 }
 
 impl fmt::Debug for Nibble {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:x}", self.0)
     }
 }

--- a/lib/src/trie/nibble.rs
+++ b/lib/src/trie/nibble.rs
@@ -326,7 +326,7 @@ impl<I: ExactSizeIterator<Item = u8>> ExactSizeIterator for BytesToNibbles<I> {}
 
 #[cfg(test)]
 mod tests {
-    use super::{bytes_to_nibbles, Nibble, NibbleFromU8Error};
+    use super::{Nibble, NibbleFromU8Error, bytes_to_nibbles};
 
     #[test]
     fn nibble_try_from() {

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -87,7 +87,7 @@ enum QueryTy {
 
 impl PrefixScan {
     /// Returns the list of keys whose storage proof must be queried.
-    pub fn requested_keys(&'_ self) -> impl Iterator<Item = impl Iterator<Item = nibble::Nibble>> {
+    pub fn requested_keys(&self) -> impl Iterator<Item = impl Iterator<Item = nibble::Nibble>> {
         self.next_queries.iter().map(|(l, _)| l.iter().copied())
     }
 

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -87,9 +87,7 @@ enum QueryTy {
 
 impl PrefixScan {
     /// Returns the list of keys whose storage proof must be queried.
-    pub fn requested_keys(
-        &'_ self,
-    ) -> impl Iterator<Item = impl Iterator<Item = nibble::Nibble> + '_> + '_ {
+    pub fn requested_keys(&'_ self) -> impl Iterator<Item = impl Iterator<Item = nibble::Nibble>> {
         self.next_queries.iter().map(|(l, _)| l.iter().copied())
     }
 

--- a/lib/src/trie/prefix_proof.rs
+++ b/lib/src/trie/prefix_proof.rs
@@ -51,7 +51,7 @@ pub struct Config<'a> {
 }
 
 /// Start a new scanning process.
-pub fn prefix_scan(config: Config<'_>) -> PrefixScan {
+pub fn prefix_scan(config: Config) -> PrefixScan {
     PrefixScan {
         trie_root_hash: config.trie_root_hash,
         full_storage_values_required: config.full_storage_values_required,

--- a/lib/src/trie/prefix_proof/tests.rs
+++ b/lib/src/trie/prefix_proof/tests.rs
@@ -17,7 +17,7 @@
 
 #![cfg(test)]
 
-use super::{prefix_scan, Config, ResumeOutcome};
+use super::{Config, ResumeOutcome, prefix_scan};
 
 // TODO: more tests
 

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -595,7 +595,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     // TODO: ordering between trie roots unspecified
     // TODO: consider not returning a Vec
     pub fn iter_runtime_context_ordered(
-        &'_ self,
+        &self,
     ) -> impl Iterator<Item = (EntryKey<'_, Vec<u8>>, StorageValue<'_>)> {
         self.iter_ordered().filter_map(
             |(
@@ -628,7 +628,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     /// The iterator includes branch nodes.
     // TODO: ordering between trie roots unspecified
     pub fn iter_ordered(
-        &'_ self,
+        &self,
     ) -> impl Iterator<Item = (EntryKey<'_, EntryKeyIter<'_, T>>, ProofEntry<'_, T>)> {
         let proof = self.proof.as_ref();
 
@@ -815,7 +815,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     /// This function will return `Ok` even if there is no node in the trie for `key`, in which
     /// case the returned [`TrieNodeInfo`] will indicate no storage value and no children.
     pub fn trie_node_info(
-        &'_ self,
+        &self,
         trie_root_merkle_value: &[u8; 32],
         mut key: impl Iterator<Item = nibble::Nibble>,
     ) -> Result<TrieNodeInfo<'_, T>, IncompleteProofError> {
@@ -968,10 +968,10 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     /// >           [`DecodedTrieProof::trie_node_info`].
     // TODO: accept param as iterator rather than slice?
     pub fn storage_value(
-        &'_ self,
+        &self,
         trie_root_merkle_value: &[u8; 32],
         key: &[u8],
-    ) -> Result<Option<(&'_ [u8], TrieEntryVersion)>, IncompleteProofError> {
+    ) -> Result<Option<(&[u8], TrieEntryVersion)>, IncompleteProofError> {
         match self
             .trie_node_info(
                 trie_root_merkle_value,
@@ -1006,7 +1006,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     /// Returns `Ok(None)` if the proof indicates that there is no next key (within the given
     /// prefix).
     pub fn next_key(
-        &'_ self,
+        &self,
         trie_root_merkle_value: &[u8; 32],
         key_before: impl Iterator<Item = nibble::Nibble>,
         mut or_equal: bool,
@@ -1273,10 +1273,10 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     /// value.
     /// Returns `Ok(None)` if the proof indicates that there is no descendant.
     pub fn closest_descendant_merkle_value(
-        &'_ self,
+        &self,
         trie_root_merkle_value: &[u8; 32],
         mut key: impl Iterator<Item = nibble::Nibble>,
-    ) -> Result<Option<&'_ [u8]>, IncompleteProofError> {
+    ) -> Result<Option<&[u8]>, IncompleteProofError> {
         let proof = self.proof.as_ref();
 
         // Find the starting point of the requested trie.
@@ -1680,7 +1680,7 @@ impl<'a, T> Children<'a, T> {
     }
 
     /// Returns an iterator of 16 items, one for each child.
-    pub fn children(&'_ self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Child<'a, T>> {
+    pub fn children(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Child<'a, T>> {
         self.children.iter().cloned()
     }
 }

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -38,7 +38,7 @@
 //! Once decoded, one can examine the content of the proof, in other words the list of storage
 //! items and values.
 
-use super::{nibble, trie_node, TrieEntryVersion};
+use super::{TrieEntryVersion, nibble, trie_node};
 
 use alloc::vec::Vec;
 use core::{fmt, iter, ops};

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -596,7 +596,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     // TODO: consider not returning a Vec
     pub fn iter_runtime_context_ordered(
         &'_ self,
-    ) -> impl Iterator<Item = (EntryKey<'_, Vec<u8>>, StorageValue<'_>)> + '_ {
+    ) -> impl Iterator<Item = (EntryKey<'_, Vec<u8>>, StorageValue<'_>)> {
         self.iter_ordered().filter_map(
             |(
                 EntryKey {
@@ -629,7 +629,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     // TODO: ordering between trie roots unspecified
     pub fn iter_ordered(
         &'_ self,
-    ) -> impl Iterator<Item = (EntryKey<'_, EntryKeyIter<'_, T>>, ProofEntry<'_, T>)> + '_ {
+    ) -> impl Iterator<Item = (EntryKey<'_, EntryKeyIter<'_, T>>, ProofEntry<'_, T>)> {
         let proof = self.proof.as_ref();
 
         self.trie_roots
@@ -1680,9 +1680,7 @@ impl<'a, T> Children<'a, T> {
     }
 
     /// Returns an iterator of 16 items, one for each child.
-    pub fn children(
-        &'_ self,
-    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Child<'a, T>> + '_ {
+    pub fn children(&'_ self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Child<'a, T>> {
         self.children.iter().cloned()
     }
 }

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -483,7 +483,7 @@ struct Entry {
 }
 
 impl<T: AsRef<[u8]>> fmt::Debug for DecodedTrieProof<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
             .entries(self.iter_ordered().map(
                 |(
@@ -495,7 +495,7 @@ impl<T: AsRef<[u8]>> fmt::Debug for DecodedTrieProof<T> {
                 )| {
                     struct DummyHash<'a>(&'a [u8]);
                     impl<'a> fmt::Debug for DummyHash<'a> {
-                        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                             if self.0.is_empty() {
                                 write!(f, "∅")?
                             }
@@ -508,7 +508,7 @@ impl<T: AsRef<[u8]>> fmt::Debug for DecodedTrieProof<T> {
 
                     struct DummyNibbles<'a, T: AsRef<[u8]>>(EntryKeyIter<'a, T>);
                     impl<'a, T: AsRef<[u8]>> fmt::Debug for DummyNibbles<'a, T> {
-                        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                             let mut any_written = false;
                             for nibble in self.0.clone() {
                                 any_written = true;
@@ -596,7 +596,7 @@ impl<T: AsRef<[u8]>> DecodedTrieProof<T> {
     // TODO: consider not returning a Vec
     pub fn iter_runtime_context_ordered(
         &self,
-    ) -> impl Iterator<Item = (EntryKey<'_, Vec<u8>>, StorageValue<'_>)> {
+    ) -> impl Iterator<Item = (EntryKey<'_, Vec<u8>>, StorageValue)> {
         self.iter_ordered().filter_map(
             |(
                 EntryKey {
@@ -1376,7 +1376,7 @@ pub enum StorageValue<'a> {
 }
 
 impl<'a> fmt::Debug for StorageValue<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             StorageValue::Known { value, inline } if value.len() <= 48 => {
                 write!(
@@ -1532,7 +1532,7 @@ impl<'a, T> Clone for EntryKeyIter<'a, T> {
 }
 
 impl<'a, T: AsRef<[u8]>> fmt::Debug for EntryKeyIter<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut any_printed = false;
         for nibble in self.clone() {
             any_printed = true;
@@ -1695,13 +1695,13 @@ impl<'a, T> Clone for Children<'a, T> {
 }
 
 impl<'a, T> fmt::Debug for Children<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Binary::fmt(&self, f)
     }
 }
 
 impl<'a, T> fmt::Binary for Children<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for child in &self.children {
             let chr = match child {
                 Child::InProof { .. } | Child::AbsentFromProof { .. } => '1',

--- a/lib/src/trie/proof_decode/tests.rs
+++ b/lib/src/trie/proof_decode/tests.rs
@@ -247,47 +247,51 @@ fn next_key_works() {
         Err(super::IncompleteProofError())
     ));
 
-    assert!(decoded
-        .next_key(
-            EXAMPLE_PROOF_STATE_ROOT,
-            [
-                9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb, 2,
-                4, 6, 4, 0xe, 3, 3, 3, 9, 7
-            ]
-            .into_iter()
-            .map(|n| Nibble::try_from(n).unwrap()),
-            true,
-            [
-                9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb, 2,
-                4, 6, 4, 0xe, 3, 3, 3, 9, 7, 0
-            ]
-            .into_iter()
-            .map(|n| Nibble::try_from(n).unwrap()),
-            true
-        )
-        .unwrap()
-        .is_none());
+    assert!(
+        decoded
+            .next_key(
+                EXAMPLE_PROOF_STATE_ROOT,
+                [
+                    9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb,
+                    2, 4, 6, 4, 0xe, 3, 3, 3, 9, 7
+                ]
+                .into_iter()
+                .map(|n| Nibble::try_from(n).unwrap()),
+                true,
+                [
+                    9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb,
+                    2, 4, 6, 4, 0xe, 3, 3, 3, 9, 7, 0
+                ]
+                .into_iter()
+                .map(|n| Nibble::try_from(n).unwrap()),
+                true
+            )
+            .unwrap()
+            .is_none()
+    );
 
-    assert!(decoded
-        .next_key(
-            EXAMPLE_PROOF_STATE_ROOT,
-            [
-                9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb, 2,
-                4, 6, 4, 0xe, 3, 3, 3, 9, 7
-            ]
-            .into_iter()
-            .map(|n| Nibble::try_from(n).unwrap()),
-            true,
-            [
-                9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb, 2,
-                4, 6, 4, 0xe, 3, 3, 3, 0xa
-            ]
-            .into_iter()
-            .map(|n| Nibble::try_from(n).unwrap()),
-            true
-        )
-        .unwrap()
-        .is_none());
+    assert!(
+        decoded
+            .next_key(
+                EXAMPLE_PROOF_STATE_ROOT,
+                [
+                    9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb,
+                    2, 4, 6, 4, 0xe, 3, 3, 3, 9, 7
+                ]
+                .into_iter()
+                .map(|n| Nibble::try_from(n).unwrap()),
+                true,
+                [
+                    9, 0xc, 5, 0xd, 7, 9, 5, 0xd, 0, 2, 9, 7, 0xb, 0xe, 5, 6, 0, 2, 7, 0xa, 4, 0xb,
+                    2, 4, 6, 4, 0xe, 3, 3, 3, 0xa
+                ]
+                .into_iter()
+                .map(|n| Nibble::try_from(n).unwrap()),
+                true
+            )
+            .unwrap()
+            .is_none()
+    );
 
     // TODO: more tests
 }
@@ -336,25 +340,29 @@ fn closest_descendant_merkle_value_works() {
         Err(super::IncompleteProofError())
     ));
 
-    assert!(decoded
-        .closest_descendant_merkle_value(
-            EXAMPLE_PROOF_STATE_ROOT,
-            [super::nibble::Nibble::try_from(0xe).unwrap()].into_iter()
-        )
-        .unwrap()
-        .is_none());
+    assert!(
+        decoded
+            .closest_descendant_merkle_value(
+                EXAMPLE_PROOF_STATE_ROOT,
+                [super::nibble::Nibble::try_from(0xe).unwrap()].into_iter()
+            )
+            .unwrap()
+            .is_none()
+    );
 
-    assert!(decoded
-        .closest_descendant_merkle_value(
-            EXAMPLE_PROOF_STATE_ROOT,
-            [
-                super::nibble::Nibble::try_from(0xe).unwrap(),
-                super::nibble::Nibble::try_from(0).unwrap()
-            ]
-            .into_iter()
-        )
-        .unwrap()
-        .is_none());
+    assert!(
+        decoded
+            .closest_descendant_merkle_value(
+                EXAMPLE_PROOF_STATE_ROOT,
+                [
+                    super::nibble::Nibble::try_from(0xe).unwrap(),
+                    super::nibble::Nibble::try_from(0).unwrap()
+                ]
+                .into_iter()
+            )
+            .unwrap()
+            .is_none()
+    );
 
     assert_eq!(
         decoded
@@ -372,23 +380,27 @@ fn closest_descendant_merkle_value_works() {
         ][..]
     );
 
-    assert!(decoded
-        .closest_descendant_merkle_value(
-            EXAMPLE_PROOF_STATE_ROOT,
-            trie::bytes_to_nibbles(
-                [156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 228].into_iter()
+    assert!(
+        decoded
+            .closest_descendant_merkle_value(
+                EXAMPLE_PROOF_STATE_ROOT,
+                trie::bytes_to_nibbles(
+                    [156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 228].into_iter()
+                )
             )
-        )
-        .unwrap()
-        .is_none());
+            .unwrap()
+            .is_none()
+    );
 
     assert_eq!(
         decoded
             .closest_descendant_merkle_value(
                 EXAMPLE_PROOF_STATE_ROOT,
                 trie::bytes_to_nibbles(
-                    [156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 227, 51, 151]
-                        .into_iter()
+                    [
+                        156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 227, 51, 151
+                    ]
+                    .into_iter()
                 )
             )
             .unwrap()
@@ -399,21 +411,23 @@ fn closest_descendant_merkle_value_works() {
         ][..]
     );
 
-    assert!(decoded
-        .closest_descendant_merkle_value(
-            EXAMPLE_PROOF_STATE_ROOT,
-            trie::bytes_to_nibbles(
-                [
-                    156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 227, 51, 151, 99, 230,
-                    211, 193, 251, 21, 128, 94, 223, 208, 36, 23, 46, 164, 129, 125, 112, 129, 84,
-                    37, 150, 173, 176, 93, 97, 64, 193, 112, 172, 71, 158, 223, 124, 253, 90, 163,
-                    83, 87, 89, 10, 207, 229, 209, 26, 128, 77, 148, 78, 0
-                ]
-                .into_iter()
+    assert!(
+        decoded
+            .closest_descendant_merkle_value(
+                EXAMPLE_PROOF_STATE_ROOT,
+                trie::bytes_to_nibbles(
+                    [
+                        156, 93, 121, 93, 2, 151, 190, 86, 2, 122, 75, 36, 100, 227, 51, 151, 99,
+                        230, 211, 193, 251, 21, 128, 94, 223, 208, 36, 23, 46, 164, 129, 125, 112,
+                        129, 84, 37, 150, 173, 176, 93, 97, 64, 193, 112, 172, 71, 158, 223, 124,
+                        253, 90, 163, 83, 87, 89, 10, 207, 229, 209, 26, 128, 77, 148, 78, 0
+                    ]
+                    .into_iter()
+                )
             )
-        )
-        .unwrap()
-        .is_none());
+            .unwrap()
+            .is_none()
+    );
 
     assert_eq!(
         decoded
@@ -516,15 +530,17 @@ fn very_small_root_node_decodes() {
 
     let proof = super::decode_and_verify_proof(super::Config { proof }).unwrap();
 
-    assert!(proof
-        .closest_descendant_merkle_value(
-            &[
-                83, 2, 191, 235, 8, 252, 233, 114, 129, 199, 229, 115, 221, 238, 15, 205, 193, 110,
-                145, 107, 12, 3, 10, 145, 117, 211, 203, 151, 182, 147, 221, 178,
-            ],
-            iter::empty()
-        )
-        .is_ok());
+    assert!(
+        proof
+            .closest_descendant_merkle_value(
+                &[
+                    83, 2, 191, 235, 8, 252, 233, 114, 129, 199, 229, 115, 221, 238, 15, 205, 193,
+                    110, 145, 107, 12, 3, 10, 145, 117, 211, 203, 151, 182, 147, 221, 178,
+                ],
+                iter::empty()
+            )
+            .is_ok()
+    );
 }
 
 #[test]
@@ -537,15 +553,17 @@ fn identical_inline_nodes() {
     })
     .unwrap();
 
-    assert!(proof
-        .closest_descendant_merkle_value(
-            &[
-                15, 224, 134, 90, 11, 145, 174, 197, 185, 253, 233, 197, 95, 101, 197, 10, 78, 28,
-                137, 217, 102, 198, 242, 100, 90, 96, 9, 204, 213, 69, 174, 4,
-            ],
-            iter::empty()
-        )
-        .is_ok());
+    assert!(
+        proof
+            .closest_descendant_merkle_value(
+                &[
+                    15, 224, 134, 90, 11, 145, 174, 197, 185, 253, 233, 197, 95, 101, 197, 10, 78,
+                    28, 137, 217, 102, 198, 242, 100, 90, 96, 9, 204, 213, 69, 174, 4,
+                ],
+                iter::empty()
+            )
+            .is_ok()
+    );
 }
 
 #[test]
@@ -2341,15 +2359,17 @@ fn invalid_nodes_are_ignored() {
 
     let decoded_proof = super::decode_and_verify_proof(super::Config { proof }).unwrap();
 
-    assert!(decoded_proof
-        .closest_descendant_merkle_value(
-            &[
-                250, 90, 64, 163, 99, 146, 173, 5, 126, 222, 6, 39, 161, 170, 189, 182, 82, 178,
-                16, 36, 159, 119, 199, 211, 66, 172, 109, 244, 187, 161, 173, 95,
-            ],
-            core::iter::empty()
-        )
-        .is_ok());
+    assert!(
+        decoded_proof
+            .closest_descendant_merkle_value(
+                &[
+                    250, 90, 64, 163, 99, 146, 173, 5, 126, 222, 6, 39, 161, 170, 189, 182, 82,
+                    178, 16, 36, 159, 119, 199, 211, 66, 172, 109, 244, 187, 161, 173, 95,
+                ],
+                core::iter::empty()
+            )
+            .is_ok()
+    );
 }
 
 #[test]

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -111,7 +111,7 @@ impl ProofBuilder {
         // whether a separate storage node should be included in the proof.
         let storage_value_node = match (&decoded_node_value.storage_value, &unhashed_storage_value)
         {
-            (trie_node::StorageValue::Unhashed(ref in_node_value), Some(ref user_provided)) => {
+            (trie_node::StorageValue::Unhashed(in_node_value), Some(user_provided)) => {
                 assert_eq!(in_node_value, user_provided);
                 None
             }

--- a/lib/src/trie/proof_encode.rs
+++ b/lib/src/trie/proof_encode.rs
@@ -607,9 +607,11 @@ mod tests {
             // Verify the correctness of the proof.
             let proof =
                 proof_decode::decode_and_verify_proof(proof_decode::Config { proof }).unwrap();
-            assert!(proof
-                .closest_descendant_merkle_value(&trie_root_hash, iter::empty())
-                .is_ok());
+            assert!(
+                proof
+                    .closest_descendant_merkle_value(&trie_root_hash, iter::empty())
+                    .is_ok()
+            );
         }
     }
 

--- a/lib/src/trie/trie_node.rs
+++ b/lib/src/trie/trie_node.rs
@@ -314,7 +314,7 @@ impl fmt::Debug for MerkleValueOutput {
 /// Decodes a node value found in a proof into its components.
 ///
 /// This can decode nodes no matter their version or hash algorithm.
-pub fn decode(mut node_value: &'_ [u8]) -> Result<Decoded<DecodedPartialKey<'_>, &'_ [u8]>, Error> {
+pub fn decode(mut node_value: &[u8]) -> Result<Decoded<DecodedPartialKey<'_>, &[u8]>, Error> {
     if node_value.is_empty() {
         return Err(Error::Empty);
     }

--- a/lib/src/trie/trie_node.rs
+++ b/lib/src/trie/trie_node.rs
@@ -314,7 +314,7 @@ impl fmt::Debug for MerkleValueOutput {
 /// Decodes a node value found in a proof into its components.
 ///
 /// This can decode nodes no matter their version or hash algorithm.
-pub fn decode(mut node_value: &[u8]) -> Result<Decoded<DecodedPartialKey<'_>, &[u8]>, Error> {
+pub fn decode(mut node_value: &[u8]) -> Result<Decoded<DecodedPartialKey, &[u8]>, Error> {
     if node_value.is_empty() {
         return Err(Error::Empty);
     }

--- a/lib/src/trie/trie_node.rs
+++ b/lib/src/trie/trie_node.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{nibble, HashFunction};
+use super::{HashFunction, nibble};
 use alloc::vec::Vec;
 use core::{cmp, fmt, iter, slice};
 
@@ -673,12 +673,14 @@ mod tests {
 
     #[test]
     fn no_children_no_storage_value() {
-        assert!(super::encode(super::Decoded {
-            children: [None::<&'static [u8]>; 16],
-            storage_value: super::StorageValue::None,
-            partial_key: core::iter::empty()
-        })
-        .is_ok());
+        assert!(
+            super::encode(super::Decoded {
+                children: [None::<&'static [u8]>; 16],
+                storage_value: super::StorageValue::None,
+                partial_key: core::iter::empty()
+            })
+            .is_ok()
+        );
 
         assert!(matches!(
             super::encode(super::Decoded {

--- a/lib/src/trie/trie_node.rs
+++ b/lib/src/trie/trie_node.rs
@@ -35,7 +35,7 @@ pub fn encode<'a>(
         impl ExactSizeIterator<Item = nibble::Nibble> + Clone,
         impl AsRef<[u8]> + Clone + 'a,
     >,
-) -> Result<impl Iterator<Item = impl AsRef<[u8]> + 'a + Clone> + Clone + 'a, EncodeError> {
+) -> Result<impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone, EncodeError> {
     // The return value is composed of three parts:
     // - Before the storage value.
     // - The storage value (which can be empty).

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -164,12 +164,12 @@ impl<TUd> TrieStructure<TUd> {
     }
 
     /// Returns a list of all nodes in the structure, without any specific order.
-    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = NodeIndex> {
+    pub fn iter_unordered(&self) -> impl Iterator<Item = NodeIndex> {
         self.nodes.iter().map(|(k, _)| NodeIndex(k))
     }
 
     /// Returns a list of all nodes in the structure in lexicographic order of keys.
-    pub fn iter_ordered(&'_ self) -> impl Iterator<Item = NodeIndex> {
+    pub fn iter_ordered(&self) -> impl Iterator<Item = NodeIndex> {
         self.all_node_lexicographic_ordered().map(NodeIndex)
     }
 
@@ -959,7 +959,7 @@ impl<TUd> TrieStructure<TUd> {
     }
 
     /// Iterates over all nodes of the trie in a lexicographic order.
-    fn all_node_lexicographic_ordered(&'_ self) -> impl Iterator<Item = usize> {
+    fn all_node_lexicographic_ordered(&self) -> impl Iterator<Item = usize> {
         fn ancestry_order_next<TUd>(tree: &TrieStructure<TUd>, node_index: usize) -> Option<usize> {
             if let Some(first_child) = tree
                 .nodes
@@ -1050,7 +1050,7 @@ impl<TUd> TrieStructure<TUd> {
     /// This method is a shortcut for [`TrieStructure::node_by_index`] followed with
     /// [`NodeAccess::full_key`].
     pub fn node_full_key_by_index(
-        &'_ self,
+        &self,
         node_index: NodeIndex,
     ) -> Option<impl Iterator<Item = Nibble>> {
         if !self.nodes.contains(node_index.0) {
@@ -1065,7 +1065,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn node_full_key(&'_ self, target: usize) -> impl Iterator<Item = Nibble> {
+    fn node_full_key(&self, target: usize) -> impl Iterator<Item = Nibble> {
         self.node_path(target)
             .chain(iter::once(target))
             .flat_map(move |n| {
@@ -1083,7 +1083,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> {
+    fn node_path(&self, target: usize) -> impl Iterator<Item = usize> {
         debug_assert!(self.nodes.get(usize::MAX).is_none());
         // First element is an invalid key, each successor is the last element of
         // `reverse_node_path(target)` that isn't equal to `current`.
@@ -1105,7 +1105,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn reverse_node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> {
+    fn reverse_node_path(&self, target: usize) -> impl Iterator<Item = usize> {
         // First element is `target`, each successor is `current.parent`.
         // Since `target` must explicitly not be included, we skip the first element.
         iter::successors(Some(target), move |current| {
@@ -1314,7 +1314,7 @@ impl<'a, TUd> NodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn full_key(&self) -> impl Iterator<Item = Nibble> {
         match self {
             NodeAccess::Storage(n) => Either::Left(n.full_key()),
             NodeAccess::Branch(n) => Either::Right(n.full_key()),
@@ -1322,7 +1322,7 @@ impl<'a, TUd> NodeAccess<'a, TUd> {
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
+    pub fn partial_key(&self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         match self {
             NodeAccess::Storage(n) => Either::Left(n.partial_key()),
             NodeAccess::Branch(n) => Either::Right(n.partial_key()),
@@ -1453,12 +1453,12 @@ impl<'a, TUd> StorageNodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn full_key(&self) -> impl Iterator<Item = Nibble> {
         self.trie.node_full_key(self.node_index)
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
+    pub fn partial_key(&self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         self.trie
             .nodes
             .get(self.node_index)
@@ -1828,12 +1828,12 @@ impl<'a, TUd> BranchNodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn full_key(&self) -> impl Iterator<Item = Nibble> {
         self.trie.node_full_key(self.node_index)
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
+    pub fn partial_key(&self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         self.trie
             .nodes
             .get(self.node_index)
@@ -2219,7 +2219,7 @@ pub struct PrepareInsertTwo<'a, TUd> {
 
 impl<'a, TUd> PrepareInsertTwo<'a, TUd> {
     /// Key of the branch node that will be inserted.
-    pub fn branch_node_key(&'_ self) -> impl Iterator<Item = Nibble> {
+    pub fn branch_node_key(&self) -> impl Iterator<Item = Nibble> {
         if let Some((parent_index, child_index)) = self.branch_parent {
             let parent = self.trie.node_full_key(parent_index);
             let iter = parent

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -164,12 +164,12 @@ impl<TUd> TrieStructure<TUd> {
     }
 
     /// Returns a list of all nodes in the structure, without any specific order.
-    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn iter_unordered(&'_ self) -> impl Iterator<Item = NodeIndex> {
         self.nodes.iter().map(|(k, _)| NodeIndex(k))
     }
 
     /// Returns a list of all nodes in the structure in lexicographic order of keys.
-    pub fn iter_ordered(&'_ self) -> impl Iterator<Item = NodeIndex> + '_ {
+    pub fn iter_ordered(&'_ self) -> impl Iterator<Item = NodeIndex> {
         self.all_node_lexicographic_ordered().map(NodeIndex)
     }
 
@@ -959,7 +959,7 @@ impl<TUd> TrieStructure<TUd> {
     }
 
     /// Iterates over all nodes of the trie in a lexicographic order.
-    fn all_node_lexicographic_ordered(&'_ self) -> impl Iterator<Item = usize> + '_ {
+    fn all_node_lexicographic_ordered(&'_ self) -> impl Iterator<Item = usize> {
         fn ancestry_order_next<TUd>(tree: &TrieStructure<TUd>, node_index: usize) -> Option<usize> {
             if let Some(first_child) = tree
                 .nodes
@@ -1052,7 +1052,7 @@ impl<TUd> TrieStructure<TUd> {
     pub fn node_full_key_by_index(
         &'_ self,
         node_index: NodeIndex,
-    ) -> Option<impl Iterator<Item = Nibble> + '_> {
+    ) -> Option<impl Iterator<Item = Nibble>> {
         if !self.nodes.contains(node_index.0) {
             return None;
         }
@@ -1065,7 +1065,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn node_full_key(&'_ self, target: usize) -> impl Iterator<Item = Nibble> + '_ {
+    fn node_full_key(&'_ self, target: usize) -> impl Iterator<Item = Nibble> {
         self.node_path(target)
             .chain(iter::once(target))
             .flat_map(move |n| {
@@ -1083,7 +1083,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> + '_ {
+    fn node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> {
         debug_assert!(self.nodes.get(usize::MAX).is_none());
         // First element is an invalid key, each successor is the last element of
         // `reverse_node_path(target)` that isn't equal to `current`.
@@ -1105,7 +1105,7 @@ impl<TUd> TrieStructure<TUd> {
     /// # Panic
     ///
     /// Panics if `target` is not a valid index.
-    fn reverse_node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> + '_ {
+    fn reverse_node_path(&'_ self, target: usize) -> impl Iterator<Item = usize> {
         // First element is `target`, each successor is `current.parent`.
         // Since `target` must explicitly not be included, we skip the first element.
         iter::successors(Some(target), move |current| {
@@ -1314,7 +1314,7 @@ impl<'a, TUd> NodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
         match self {
             NodeAccess::Storage(n) => Either::Left(n.full_key()),
             NodeAccess::Branch(n) => Either::Right(n.full_key()),
@@ -1322,7 +1322,7 @@ impl<'a, TUd> NodeAccess<'a, TUd> {
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone + '_ {
+    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         match self {
             NodeAccess::Storage(n) => Either::Left(n.partial_key()),
             NodeAccess::Branch(n) => Either::Right(n.partial_key()),
@@ -1453,12 +1453,12 @@ impl<'a, TUd> StorageNodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.trie.node_full_key(self.node_index)
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone + '_ {
+    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         self.trie
             .nodes
             .get(self.node_index)
@@ -1828,12 +1828,12 @@ impl<'a, TUd> BranchNodeAccess<'a, TUd> {
     }
 
     /// Returns the full key of the node.
-    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn full_key(&'_ self) -> impl Iterator<Item = Nibble> {
         self.trie.node_full_key(self.node_index)
     }
 
     /// Returns the partial key of the node.
-    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone + '_ {
+    pub fn partial_key(&'_ self) -> impl ExactSizeIterator<Item = Nibble> + Clone {
         self.trie
             .nodes
             .get(self.node_index)
@@ -2219,7 +2219,7 @@ pub struct PrepareInsertTwo<'a, TUd> {
 
 impl<'a, TUd> PrepareInsertTwo<'a, TUd> {
     /// Key of the branch node that will be inserted.
-    pub fn branch_node_key(&'_ self) -> impl Iterator<Item = Nibble> + '_ {
+    pub fn branch_node_key(&'_ self) -> impl Iterator<Item = Nibble> {
         if let Some((parent_index, child_index)) = self.branch_parent {
             let parent = self.trie.node_full_key(parent_index);
             let iter = parent

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -22,7 +22,7 @@
 
 // TODO: the API of `TrieStructure` is rather wonky and could be simplified
 
-use super::nibble::{bytes_to_nibbles, Nibble};
+use super::nibble::{Nibble, bytes_to_nibbles};
 
 use alloc::{borrow::ToOwned as _, vec, vec::Vec};
 use core::{cmp, fmt, iter, mem, ops};
@@ -347,7 +347,7 @@ impl<TUd> TrieStructure<TUd> {
             None => {
                 return ExistingNodeInnerResult::NotFound {
                     closest_ancestor: None,
-                }
+                };
             }
         };
         debug_assert!(self.nodes.get(current_index).unwrap().parent.is_none());
@@ -376,7 +376,7 @@ impl<TUd> TrieStructure<TUd> {
                     return ExistingNodeInnerResult::Found {
                         node_index: current_index,
                         has_storage_value: current.has_storage_value,
-                    }
+                    };
                 }
             };
 

--- a/lib/src/trie/trie_structure.rs
+++ b/lib/src/trie/trie_structure.rs
@@ -631,7 +631,7 @@ impl<TUd> TrieStructure<TUd> {
         &'a self,
         start_bound: ops::Bound<&'a [u8]>, // TODO: why does this require a `'a` lifetime? I don't get it
         end_bound: ops::Bound<&'a [u8]>,
-    ) -> impl Iterator<Item = NodeIndex> + 'a {
+    ) -> impl Iterator<Item = NodeIndex> + use<'a, TUd> {
         let start_bound = match start_bound {
             ops::Bound::Included(key) => {
                 ops::Bound::Included(bytes_to_nibbles(key.iter().copied()))
@@ -660,7 +660,7 @@ impl<TUd> TrieStructure<TUd> {
         &'a self,
         start_bound: ops::Bound<impl Iterator<Item = Nibble>>,
         end_bound: ops::Bound<impl Iterator<Item = Nibble> + 'a>,
-    ) -> impl Iterator<Item = NodeIndex> + 'a {
+    ) -> impl Iterator<Item = NodeIndex> {
         self.range_inner(start_bound, end_bound).map(NodeIndex)
     }
 
@@ -669,7 +669,7 @@ impl<TUd> TrieStructure<TUd> {
         &'a self,
         start_bound: ops::Bound<impl Iterator<Item = Nibble>>,
         end_bound: ops::Bound<impl Iterator<Item = Nibble> + 'a>,
-    ) -> impl Iterator<Item = usize> + 'a {
+    ) -> impl Iterator<Item = usize> {
         // Start by processing the end bound to obtain an "end key".
         // This end key is always assumed to be excluded. In other words, only keys strictly
         // inferior to the end key are returned. If the user provides `Included`, we modify the key

--- a/lib/src/trie/trie_structure/tests.rs
+++ b/lib/src/trie/trie_structure/tests.rs
@@ -312,19 +312,21 @@ fn insert_branch() {
     .insert_storage_value()
     .insert((), ());
 
-    assert!(!trie
-        .node(
-            [
-                Nibble::try_from(1).unwrap(),
-                Nibble::try_from(2).unwrap(),
-                Nibble::try_from(3).unwrap(),
-            ]
-            .iter()
-            .cloned(),
-        )
-        .into_occupied()
-        .unwrap()
-        .has_storage_value());
+    assert!(
+        !trie
+            .node(
+                [
+                    Nibble::try_from(1).unwrap(),
+                    Nibble::try_from(2).unwrap(),
+                    Nibble::try_from(3).unwrap(),
+                ]
+                .iter()
+                .cloned(),
+            )
+            .into_occupied()
+            .unwrap()
+            .has_storage_value()
+    );
 }
 
 #[test]
@@ -385,11 +387,12 @@ fn remove_prefix_basic() {
     );
 
     assert_eq!(trie.len(), 1);
-    assert!(trie
-        .node([Nibble::try_from(1).unwrap(),].iter().cloned(),)
-        .into_occupied()
-        .unwrap()
-        .has_storage_value());
+    assert!(
+        trie.node([Nibble::try_from(1).unwrap(),].iter().cloned(),)
+            .into_occupied()
+            .unwrap()
+            .has_storage_value()
+    );
 }
 
 #[test]
@@ -512,11 +515,12 @@ fn remove_prefix_exact() {
     );
 
     assert_eq!(trie.len(), 1);
-    assert!(trie
-        .node([Nibble::try_from(1).unwrap(),].iter().cloned(),)
-        .into_occupied()
-        .unwrap()
-        .has_storage_value());
+    assert!(
+        trie.node([Nibble::try_from(1).unwrap(),].iter().cloned(),)
+            .into_occupied()
+            .unwrap()
+            .has_storage_value()
+    );
 }
 
 #[test]
@@ -548,8 +552,8 @@ fn remove_prefix_doesnt_match_anything() {
     );
 
     assert_eq!(trie.len(), 1);
-    assert!(trie
-        .node(
+    assert!(
+        trie.node(
             [
                 Nibble::try_from(1).unwrap(),
                 Nibble::try_from(2).unwrap(),
@@ -560,7 +564,8 @@ fn remove_prefix_doesnt_match_anything() {
         )
         .into_occupied()
         .unwrap()
-        .has_storage_value());
+        .has_storage_value()
+    );
 }
 
 #[test]
@@ -593,8 +598,8 @@ fn remove_prefix_nothing_to_remove() {
     );
 
     assert_eq!(trie.len(), 1);
-    assert!(trie
-        .node(
+    assert!(
+        trie.node(
             [
                 Nibble::try_from(1).unwrap(),
                 Nibble::try_from(2).unwrap(),
@@ -605,7 +610,8 @@ fn remove_prefix_nothing_to_remove() {
         )
         .into_occupied()
         .unwrap()
-        .has_storage_value());
+        .has_storage_value()
+    );
 }
 
 #[test]

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -217,7 +217,7 @@ macro_rules! decode_scale_compact {
                             return Err(nom::Err::Error(nom::error::make_error(
                                 bytes,
                                 nom::error::ErrorKind::Satisfy,
-                            )))
+                            )));
                         }
                     };
                     Ok((&bytes[4..], value))

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -275,7 +275,7 @@ decode_scale_compact!(nom_scale_compact_u64, u64);
 macro_rules! encode_scale_compact {
     ($fn_name:ident, $num_ty:ty) => {
         /// Returns a buffer containing the SCALE-compact encoding of the parameter.
-        pub(crate) fn $fn_name(mut value: $num_ty) -> impl AsRef<[u8]> + Clone {
+        pub(crate) fn $fn_name(mut value: $num_ty) -> impl AsRef<[u8]> + Clone + use<> {
             const MAX_BITS: usize = 1 + (<$num_ty>::BITS as usize) / 8;
             let mut array = arrayvec::ArrayVec::<u8, MAX_BITS>::new();
 

--- a/lib/src/util/leb128.rs
+++ b/lib/src/util/leb128.rs
@@ -132,7 +132,7 @@ pub(crate) fn nom_leb128_u64<'a, E: nom::error::ParseError<&'a [u8]>>(
                 return Err(nom::Err::Error(nom::error::make_error(
                     bytes,
                     nom::error::ErrorKind::LengthValue,
-                )))
+                )));
             }
         };
 

--- a/lib/src/util/protobuf.rs
+++ b/lib/src/util/protobuf.rs
@@ -463,7 +463,9 @@ mod tests {
 
         assert_eq!(
             &encoded,
-            &[210, 30, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
+            &[
+                210, 30, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100
+            ]
         );
 
         let decoded = super::string_tag_decode::<nom::error::Error<&[u8]>>(&encoded)

--- a/lib/src/util/protobuf.rs
+++ b/lib/src/util/protobuf.rs
@@ -45,10 +45,10 @@ pub(crate) fn enum_tag_encode(
     varint_zigzag_tag_encode(field, enum_value).map(|b| [b])
 }
 
-pub(crate) fn message_tag_encode<'a>(
+pub(crate) fn message_tag_encode(
     field: u64,
-    inner_message: impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+    inner_message: impl Iterator<Item = impl AsRef<[u8]>>,
+) -> impl Iterator<Item = impl AsRef<[u8]>> {
     // We have to buffer the inner message into a `Vec` in order to determine its length. The
     // alternative would have been to require a `Clone` bound on the inner message iterator, but
     // that would be overly restrictive.
@@ -66,19 +66,19 @@ pub(crate) fn message_tag_encode<'a>(
         .chain(iter::once(either::Left(inner_message)))
 }
 
-pub(crate) fn bytes_tag_encode<'a>(
+pub(crate) fn bytes_tag_encode(
     field: u64,
-    data: impl AsRef<[u8]> + Clone + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    data: impl AsRef<[u8]> + Clone,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
     // Protobuf only allows 2 GiB of data.
     debug_assert!(data.as_ref().len() <= 2 * 1024 * 1024 * 1024);
     delimited_tag_encode(field, data)
 }
 
-pub(crate) fn string_tag_encode<'a>(
+pub(crate) fn string_tag_encode(
     field: u64,
-    data: impl AsRef<str> + Clone + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    data: impl AsRef<str> + Clone,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
     #[derive(Clone)]
     struct Wrapper<T>(T);
     impl<T: AsRef<str>> AsRef<[u8]> for Wrapper<T> {
@@ -98,10 +98,10 @@ pub(crate) fn varint_zigzag_tag_encode(field: u64, value: u64) -> impl Iterator<
     tag_encode(field, 0).chain(leb128::encode(value))
 }
 
-pub(crate) fn delimited_tag_encode<'a>(
+pub(crate) fn delimited_tag_encode(
     field: u64,
-    data: impl AsRef<[u8]> + Clone + 'a,
-) -> impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a {
+    data: impl AsRef<[u8]> + Clone,
+) -> impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone {
     tag_encode(field, 2)
         .chain(leb128::encode_usize(data.as_ref().len()))
         .map(|v| either::Right([v]))

--- a/lib/src/verify/body_only.rs
+++ b/lib/src/verify/body_only.rs
@@ -37,14 +37,11 @@ pub const EXECUTE_BLOCK_FUNCTION_NAME: &str = "Core_execute_block";
 
 /// Returns a list of buffers that, when concatenated together, forms the parameter to pass to
 /// the `Core_execute_block` function in order to verify the inherents of a block.
-pub fn execute_block_parameter<'a>(
-    block_header: &'a [u8],
+pub fn execute_block_parameter(
+    block_header: &[u8],
     block_number_bytes: usize,
-    block_body: impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a,
-) -> Result<
-    impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a,
-    ExecuteBlockParameterError,
-> {
+    block_body: impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone,
+) -> Result<impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone, ExecuteBlockParameterError> {
     // Consensus engines add a seal at the end of the digest logs. This seal is guaranteed to
     // be the last item. We need to remove it before we can verify the unsealed header.
     let mut unsealed_header = match header::decode(block_header, block_number_bytes) {
@@ -88,15 +85,12 @@ pub const CHECK_INHERENTS_FUNCTION_NAME: &str = "BlockBuilder_check_inherents";
 
 /// Returns a list of buffers that, when concatenated together, forms the parameter to pass to
 /// the `BlockBuilder_check_inherents` function in order to verify the inherents of a block.
-pub fn check_inherents_parameter<'a>(
-    block_header: &'a [u8],
+pub fn check_inherents_parameter(
+    block_header: &[u8],
     block_number_bytes: usize,
-    block_body: impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a,
+    block_body: impl ExactSizeIterator<Item = impl AsRef<[u8]> + Clone> + Clone,
     now_from_unix_epoch: Duration,
-) -> Result<
-    impl Iterator<Item = impl AsRef<[u8]> + Clone + 'a> + Clone + 'a,
-    ExecuteBlockParameterError,
-> {
+) -> Result<impl Iterator<Item = impl AsRef<[u8]> + Clone> + Clone, ExecuteBlockParameterError> {
     // The first parameter of `BlockBuilder_check_inherents` is identical to the one of
     // `Core_execute_block`.
     let execute_block_parameter =

--- a/lib/src/verify/inherents.rs
+++ b/lib/src/verify/inherents.rs
@@ -50,7 +50,7 @@ pub struct InherentData {
 impl InherentData {
     /// Turns this list of inherents into a list that can be passed as parameter to the runtime.
     pub fn as_raw_list(
-        &'_ self,
+        &self,
     ) -> impl ExactSizeIterator<Item = ([u8; 8], impl AsRef<[u8]> + Clone)> + Clone {
         [(*b"timstap0", self.timestamp.to_le_bytes())].into_iter()
     }

--- a/lib/src/verify/inherents.rs
+++ b/lib/src/verify/inherents.rs
@@ -51,7 +51,7 @@ impl InherentData {
     /// Turns this list of inherents into a list that can be passed as parameter to the runtime.
     pub fn as_raw_list(
         &'_ self,
-    ) -> impl ExactSizeIterator<Item = ([u8; 8], impl AsRef<[u8]> + Clone + '_)> + Clone + '_ {
+    ) -> impl ExactSizeIterator<Item = ([u8; 8], impl AsRef<[u8]> + Clone)> + Clone {
         [(*b"timstap0", self.timestamp.to_le_bytes())].into_iter()
     }
 

--- a/light-base/src/database.rs
+++ b/light-base/src/database.rs
@@ -38,7 +38,7 @@ use core::cmp;
 use smoldot::{
     chain,
     database::finalized_serialize,
-    libp2p::{multiaddr, PeerId},
+    libp2p::{PeerId, multiaddr},
 };
 
 use crate::{network_service, platform, runtime_service, sync_service};

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -125,8 +125,7 @@ struct Background<TPlat: PlatformRef> {
     transactions_service: Arc<transactions_service::TransactionsService<TPlat>>,
 
     /// Tasks that are spawned by the service and running in the background.
-    background_tasks:
-        stream::FuturesUnordered<Pin<Box<dyn future::Future<Output = Event<TPlat>> + Send>>>,
+    background_tasks: stream::FuturesUnordered<Pin<Box<dyn Future<Output = Event<TPlat>> + Send>>>,
 
     /// Channel where serialized JSON-RPC requests are pulled from.
     requests_rx: Pin<Box<async_channel::Receiver<String>>>,
@@ -264,7 +263,7 @@ enum RuntimeServiceSubscription<TPlat: PlatformRef> {
 
     /// Waiting for the runtime service to start the subscription. Can potentially take a long
     /// time.
-    Pending(Pin<Box<dyn future::Future<Output = runtime_service::SubscribeAll<TPlat>> + Send>>),
+    Pending(Pin<Box<dyn Future<Output = runtime_service::SubscribeAll<TPlat>> + Send>>),
 
     /// Subscription not requested yet. Should transition to
     /// [`RuntimeServiceSubscription::Pending`] as soon as possible.

--- a/light-base/src/json_rpc_service/background.rs
+++ b/light-base/src/json_rpc_service/background.rs
@@ -36,14 +36,14 @@ use core::{iter, mem, num::NonZero, pin::Pin, time::Duration};
 use futures_lite::{FutureExt as _, StreamExt as _};
 use futures_util::{future, stream};
 use rand_chacha::{
-    rand_core::{RngCore as _, SeedableRng as _},
     ChaCha20Rng,
+    rand_core::{RngCore as _, SeedableRng as _},
 };
 use smoldot::{
     header,
     informant::HashDisplay,
     json_rpc::{self, methods, parse},
-    libp2p::{multiaddr, PeerId},
+    libp2p::{PeerId, multiaddr},
     network::codec,
 };
 
@@ -4787,9 +4787,11 @@ pub(super) async fn run<TPlat: PlatformRef>(
                 *current_finalized_block = finalized_hash;
                 *finalized_heads_subscriptions_stale = true;
 
-                debug_assert!(pruned_blocks
-                    .iter()
-                    .all(|hash| pinned_blocks.contains_key(hash)));
+                debug_assert!(
+                    pruned_blocks
+                        .iter()
+                        .all(|hash| pinned_blocks.contains_key(hash))
+                );
 
                 // Add the pruned and finalized blocks to the LRU cache. The least-recently used
                 // entries in the cache are unpinned and no longer tracked.

--- a/light-base/src/lib.rs
+++ b/light-base/src/lib.rs
@@ -87,7 +87,7 @@ extern crate alloc;
 
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec, vec::Vec};
 use core::{num::NonZero, ops, time::Duration};
-use hashbrown::{hash_map::Entry, HashMap};
+use hashbrown::{HashMap, hash_map::Entry};
 use itertools::Itertools as _;
 use platform::PlatformRef;
 use smoldot::{

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -42,7 +42,7 @@
 
 use crate::{
     log,
-    platform::{self, address_parse, PlatformRef},
+    platform::{self, PlatformRef, address_parse},
 };
 
 use alloc::{
@@ -57,7 +57,7 @@ use alloc::{
 use core::{cmp, mem, num::NonZero, pin::Pin, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
-use futures_util::{future, stream, StreamExt as _};
+use futures_util::{StreamExt as _, future, stream};
 use hashbrown::{HashMap, HashSet};
 use rand::seq::IteratorRandom as _;
 use rand_chacha::rand_core::SeedableRng as _;
@@ -974,7 +974,7 @@ async fn background_task<TPlat: PlatformRef>(mut task: BackgroundTask<TPlat>) {
                                     break 'search WakeUpReason::CanAssignSlot(
                                         peer_id.clone(),
                                         chain_id,
-                                    )
+                                    );
                                 }
                                 basic_peering_strategy::AssignablePeer::AllPeersBanned {
                                     next_unban,

--- a/light-base/src/network_service.rs
+++ b/light-base/src/network_service.rs
@@ -798,7 +798,7 @@ struct BackgroundTask<TPlat: PlatformRef> {
     // TODO: sort by ChainId instead of using a Vec?
     event_senders: either::Either<
         Vec<(ChainId, async_channel::Sender<Event>)>,
-        Pin<Box<dyn future::Future<Output = Vec<(ChainId, async_channel::Sender<Event>)>> + Send>>,
+        Pin<Box<dyn Future<Output = Vec<(ChainId, async_channel::Sender<Event>)>> + Send>>,
     >,
 
     /// Whenever [`NetworkServiceChain::subscribe`] is called, the new sender is added to this list.

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -244,7 +244,7 @@ pub(super) async fn webrtc_multi_stream_connection_task<TPlat: PlatformRef>(
     // Stream that yields an item whenever a substream is ready to be read-written.
     // TODO: we box the future because of the type checker being annoying
     let mut when_substreams_rw_ready = FuturesUnordered::<
-        pin::Pin<Box<dyn future::Future<Output = (pin::Pin<Box<TPlat::Stream>>, usize)> + Send>>,
+        pin::Pin<Box<dyn Future<Output = (pin::Pin<Box<TPlat::Stream>>, usize)> + Send>>,
     >::new();
     // Identifier to assign to the next substream.
     // TODO: weird API

--- a/light-base/src/network_service/tasks.rs
+++ b/light-base/src/network_service/tasks.rs
@@ -23,7 +23,7 @@ use crate::{
 use alloc::{boxed::Box, string::String};
 use core::{pin, time::Duration};
 use futures_lite::FutureExt as _;
-use futures_util::{future, stream::FuturesUnordered, StreamExt as _};
+use futures_util::{StreamExt as _, future, stream::FuturesUnordered};
 use smoldot::{libp2p::collection::SubstreamFate, network::service};
 
 /// Asynchronous task managing a specific single-stream connection.

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -81,7 +81,7 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     /// Object that dereferences to [`read_write::ReadWrite`] and gives access to the stream's
     /// buffers. See the [`read_write`] module for more information.
     /// See also [`PlatformRef::read_write_access`].
-    type ReadWriteAccess<'a>: ops::DerefMut<Target = read_write::ReadWrite<Self::Instant>> + 'a;
+    type ReadWriteAccess<'a>: ops::DerefMut<Target = read_write::ReadWrite<Self::Instant>> + use<'a>;
 
     /// Reference to an error that happened on a stream.
     ///
@@ -97,11 +97,11 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
         + Send
         + 'static;
     /// `Future` returned by [`PlatformRef::wait_read_write_again`].
-    type StreamUpdateFuture<'a>: Future<Output = ()> + Send + 'a;
+    type StreamUpdateFuture<'a>: Future<Output = ()> + Send + use<'a>;
     /// `Future` returned by [`PlatformRef::next_substream`].
     type NextSubstreamFuture<'a>: Future<Output = Option<(Self::Stream, SubstreamDirection)>>
         + Send
-        + 'a;
+        + use<'a>;
 
     /// Returns the time elapsed since [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)
     /// (i.e. 00:00:00 UTC on 1 January 1970), ignoring leap seconds.

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -16,10 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use alloc::borrow::Cow;
-use core::{
-    fmt, future::Future, net::IpAddr, ops, panic::UnwindSafe, pin::Pin, str, time::Duration,
-};
-use futures_util::future;
+use core::{fmt, net::IpAddr, ops, panic::UnwindSafe, pin::Pin, str, time::Duration};
 
 pub use smoldot::libp2p::read_write;
 
@@ -146,11 +143,7 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     /// >           difficult if not impossible to implement this trait on `Future`s. It is for
     /// >           the same reason that the `std::thread::spawn` function of the standard library
     /// >           doesn't require its parameter to implement `UnwindSafe`.
-    fn spawn_task(
-        &self,
-        task_name: Cow<str>,
-        task: impl future::Future<Output = ()> + Send + 'static,
-    );
+    fn spawn_task(&self, task_name: Cow<str>, task: impl Future<Output = ()> + Send + 'static);
 
     /// Emit a log line.
     ///

--- a/light-base/src/platform.rs
+++ b/light-base/src/platform.rs
@@ -81,7 +81,7 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
     /// Object that dereferences to [`read_write::ReadWrite`] and gives access to the stream's
     /// buffers. See the [`read_write`] module for more information.
     /// See also [`PlatformRef::read_write_access`].
-    type ReadWriteAccess<'a>: ops::DerefMut<Target = read_write::ReadWrite<Self::Instant>> + use<'a>;
+    type ReadWriteAccess<'a>: ops::DerefMut<Target = read_write::ReadWrite<Self::Instant>> + 'a;
 
     /// Reference to an error that happened on a stream.
     ///
@@ -97,11 +97,11 @@ pub trait PlatformRef: UnwindSafe + Clone + Send + Sync + 'static {
         + Send
         + 'static;
     /// `Future` returned by [`PlatformRef::wait_read_write_again`].
-    type StreamUpdateFuture<'a>: Future<Output = ()> + Send + use<'a>;
+    type StreamUpdateFuture<'a>: Future<Output = ()> + Send + 'a;
     /// `Future` returned by [`PlatformRef::next_substream`].
     type NextSubstreamFuture<'a>: Future<Output = Option<(Self::Stream, SubstreamDirection)>>
         + Send
-        + use<'a>;
+        + 'a;
 
     /// Returns the time elapsed since [the Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)
     /// (i.e. 00:00:00 UTC on 1 January 1970), ignoring leap seconds.

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -143,11 +143,7 @@ impl PlatformRef for Arc<DefaultPlatform> {
         smol::Timer::at(when).map(|_| ())
     }
 
-    fn spawn_task(
-        &self,
-        _task_name: Cow<str>,
-        task: impl future::Future<Output = ()> + Send + 'static,
-    ) {
+    fn spawn_task(&self, _task_name: Cow<str>, task: impl Future<Output = ()> + Send + 'static) {
         // In order to make sure that the execution threads don't stop if there are still
         // tasks to execute, we hold a copy of the `Arc<DefaultPlatform>` inside of the task until
         // it is finished.

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -36,8 +36,8 @@
 //!
 
 use super::{
-    with_buffers, Address, ConnectionType, IpAddr, LogLevel, MultiStreamAddress,
-    MultiStreamWebRtcConnection, PlatformRef, SubstreamDirection,
+    Address, ConnectionType, IpAddr, LogLevel, MultiStreamAddress, MultiStreamWebRtcConnection,
+    PlatformRef, SubstreamDirection, with_buffers,
 };
 
 use alloc::{borrow::Cow, sync::Arc};
@@ -48,7 +48,7 @@ use core::{
     str,
     time::Duration,
 };
-use futures_util::{future, FutureExt as _};
+use futures_util::{FutureExt as _, future};
 use smoldot::libp2p::websocket;
 use std::{
     io,

--- a/light-base/src/platform/default.rs
+++ b/light-base/src/platform/default.rs
@@ -304,7 +304,7 @@ impl PlatformRef for Arc<DefaultPlatform> {
         match *c {}
     }
 
-    fn next_substream(&self, c: &'_ mut Self::MultiStream) -> Self::NextSubstreamFuture<'_> {
+    fn next_substream(&self, c: &mut Self::MultiStream) -> Self::NextSubstreamFuture<'_> {
         // This function can only be called with so-called "multi-stream" connections. We never
         // open such connection.
         match *c {}

--- a/light-base/src/platform/with_prefix.rs
+++ b/light-base/src/platform/with_prefix.rs
@@ -67,11 +67,7 @@ impl<T: PlatformRef> PlatformRef for WithPrefix<T> {
         self.inner.sleep_until(when)
     }
 
-    fn spawn_task(
-        &self,
-        task_name: Cow<str>,
-        task: impl futures_util::future::Future<Output = ()> + Send + 'static,
-    ) {
+    fn spawn_task(&self, task_name: Cow<str>, task: impl Future<Output = ()> + Send + 'static) {
         self.inner
             .spawn_task(Cow::Owned(format!("{}-{}", self.prefix, task_name)), task)
     }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -70,7 +70,7 @@ use core::{cmp, iter, mem, num::NonZero, ops, pin::Pin, time::Duration};
 use derive_more::derive;
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
-use futures_util::{future, stream, Stream, StreamExt as _};
+use futures_util::{Stream, StreamExt as _, future, stream};
 use itertools::Itertools as _;
 use rand::seq::IteratorRandom as _;
 use rand_chacha::rand_core::SeedableRng as _;
@@ -78,7 +78,7 @@ use smoldot::{
     chain::async_tree,
     executor, header,
     informant::{BytesDisplay, HashDisplay},
-    trie::{self, proof_decode, Nibble},
+    trie::{self, Nibble, proof_decode},
 };
 
 /// Configuration for a runtime service.
@@ -944,7 +944,7 @@ async fn run_background<TPlat: PlatformRef>(
 
                         match async_op {
                             async_tree::NextNecessaryAsyncOp::Ready(dl) => {
-                                break WakeUpReason::StartDownload(dl.id, dl.block_index)
+                                break WakeUpReason::StartDownload(dl.id, dl.block_index);
                             }
                             async_tree::NextNecessaryAsyncOp::NotReady { when } => {
                                 if let Some(when) = when {
@@ -962,7 +962,7 @@ async fn run_background<TPlat: PlatformRef>(
                         Tree::FinalizedBlockRuntimeKnown { tree, .. } => {
                             match tree.try_advance_output() {
                                 Some(update) => {
-                                    break WakeUpReason::TreeAdvanceFinalizedKnown(update)
+                                    break WakeUpReason::TreeAdvanceFinalizedKnown(update);
                                 }
                                 None => wait.await,
                             }
@@ -970,7 +970,7 @@ async fn run_background<TPlat: PlatformRef>(
                         Tree::FinalizedBlockRuntimeUnknown { tree, .. } => {
                             match tree.try_advance_output() {
                                 Some(update) => {
-                                    break WakeUpReason::TreeAdvanceFinalizedUnknown(update)
+                                    break WakeUpReason::TreeAdvanceFinalizedUnknown(update);
                                 }
                                 None => wait.await,
                             }
@@ -3005,7 +3005,7 @@ fn download_runtime<TPlat: PlatformRef>(
                         storage_heap_pages,
                         code_merkle_value,
                         code_closest_ancestor_excluding,
-                    ))
+                    ));
                 }
                 sync_service::StorageQueryProgress::Progress {
                     request_index: 0,
@@ -3039,7 +3039,7 @@ fn download_runtime<TPlat: PlatformRef>(
                 }
                 sync_service::StorageQueryProgress::Progress { .. } => unreachable!(),
                 sync_service::StorageQueryProgress::Error(error) => {
-                    break Err(RuntimeDownloadError::StorageQuery(error))
+                    break Err(RuntimeDownloadError::StorageQuery(error));
                 }
             }
         }
@@ -3194,7 +3194,7 @@ async fn runtime_call_single_attempt<TPlat: PlatformRef>(
                         Err(SingleRuntimeCallAttemptError::Inaccessible(
                             RuntimeCallInaccessibleError::MissingProofEntry,
                         )),
-                    )
+                    );
                 }
                 Ok(None) => None,
                 Ok(Some((value, _))) => match <&[u8; 32]>::try_from(value) {
@@ -3205,7 +3205,7 @@ async fn runtime_call_single_attempt<TPlat: PlatformRef>(
                             Err(SingleRuntimeCallAttemptError::Inaccessible(
                                 RuntimeCallInaccessibleError::MissingProofEntry,
                             )),
-                        )
+                        );
                     }
                 },
             }

--- a/light-base/src/runtime_service.rs
+++ b/light-base/src/runtime_service.rs
@@ -2941,7 +2941,7 @@ fn download_runtime<TPlat: PlatformRef>(
     sync_service: Arc<sync_service::SyncService<TPlat>>,
     block_hash: [u8; 32],
     scale_encoded_header: &[u8],
-) -> impl future::Future<
+) -> impl Future<
     Output = Result<
         (
             Option<Vec<u8>>,
@@ -2951,7 +2951,7 @@ fn download_runtime<TPlat: PlatformRef>(
         ),
         RuntimeDownloadError,
     >,
-> {
+> + use<TPlat> {
     // In order to perform the download, we need to known the state root hash of the
     // block in question, which requires decoding the block. If the decoding fails,
     // we report that the asynchronous operation has failed with the hope that this

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -32,7 +32,7 @@ use alloc::{
     borrow::ToOwned as _, boxed::Box, collections::VecDeque, format, string::String, sync::Arc,
     vec::Vec,
 };
-use core::{cmp, fmt, future::Future, mem, num::NonZero, pin::Pin, time::Duration};
+use core::{cmp, fmt, mem, num::NonZero, pin::Pin, time::Duration};
 use futures_channel::oneshot;
 use rand::seq::IteratorRandom as _;
 use rand_chacha::rand_core::SeedableRng as _;

--- a/light-base/src/sync_service.rs
+++ b/light-base/src/sync_service.rs
@@ -41,7 +41,7 @@ use smoldot::{
     executor::host,
     libp2p::PeerId,
     network::{codec, service},
-    trie::{self, prefix_proof, proof_decode, Nibble},
+    trie::{self, Nibble, prefix_proof, proof_decode},
 };
 
 mod parachain;

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -21,7 +21,7 @@ use crate::{log, network_service, platform::PlatformRef, runtime_service, util};
 use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{mem, num::NonZero, pin::Pin, time::Duration};
 use futures_lite::FutureExt as _;
-use futures_util::{future, stream, StreamExt as _};
+use futures_util::{StreamExt as _, future, stream};
 use hashbrown::HashMap;
 use itertools::Itertools as _;
 use smoldot::{

--- a/light-base/src/sync_service/parachain.rs
+++ b/light-base/src/sync_service/parachain.rs
@@ -190,7 +190,7 @@ struct ParachainBackgroundTaskAfterSubscription<TPlat: PlatformRef> {
     >,
 
     /// Future that is ready when we need to start a new parachain head fetch operation.
-    next_start_parahead_fetch: Pin<Box<dyn future::Future<Output = ()> + Send>>,
+    next_start_parahead_fetch: Pin<Box<dyn Future<Output = ()> + Send>>,
 }
 
 impl<TPlat: PlatformRef> ParachainBackgroundTask<TPlat> {

--- a/light-base/src/sync_service/standalone.rs
+++ b/light-base/src/sync_service/standalone.rs
@@ -31,7 +31,7 @@ use alloc::{
 };
 use core::{cmp, iter, num::NonZero, pin::Pin, time::Duration};
 use futures_lite::FutureExt as _;
-use futures_util::{future, stream, FutureExt as _, StreamExt as _};
+use futures_util::{FutureExt as _, StreamExt as _, future, stream};
 use hashbrown::HashMap;
 use smoldot::{
     chain, header,
@@ -304,7 +304,10 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
                                 &task.platform,
                                 Warn,
                                 &task.log_target,
-                                format!("Failed to build the chain information during warp syncing process: {}", error)
+                                format!(
+                                    "Failed to build the chain information during warp syncing process: {}",
+                                    error
+                                )
                             );
                         }
                     }
@@ -501,7 +504,7 @@ pub(super) async fn start_standalone_chain<TPlat: PlatformRef>(
 
             WakeUpReason::SyncProcess(all::ProcessOne::VerifyFinalityProof(verify)) => {
                 // Finality proof to verify.
-                let sender = verify.sender().1 .0.clone();
+                let sender = verify.sender().1.0.clone();
                 match verify.perform({
                     let mut seed = [0; 32];
                     task.platform.fill_random_bytes(&mut seed);

--- a/light-base/src/transactions_service.rs
+++ b/light-base/src/transactions_service.rs
@@ -81,7 +81,7 @@ use core::{cmp, iter, num::NonZero, pin, time::Duration};
 use futures_channel::oneshot;
 use futures_lite::FutureExt as _;
 use futures_util::stream::FuturesUnordered;
-use futures_util::{future, FutureExt as _, StreamExt as _};
+use futures_util::{FutureExt as _, StreamExt as _, future};
 use itertools::Itertools as _;
 use smoldot::{
     header,
@@ -1469,7 +1469,7 @@ async fn validate_transaction<TPlat: PlatformRef>(
     {
         Ok(r) => r,
         Err(runtime_service::PinPinnedBlockRuntimeError::ObsoleteSubscription) => {
-            return Err(ValidationError::ObsoleteSubscription)
+            return Err(ValidationError::ObsoleteSubscription);
         }
         Err(runtime_service::PinPinnedBlockRuntimeError::BlockNotPinned) => unreachable!(),
     };
@@ -1500,29 +1500,29 @@ async fn validate_transaction<TPlat: PlatformRef>(
         Err(runtime_service::RuntimeCallError::Execution(error)) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Execution(error)),
-            ))
+            ));
         }
         Err(runtime_service::RuntimeCallError::Crash) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Crash),
-            ))
+            ));
         }
         Err(runtime_service::RuntimeCallError::Inaccessible(errors)) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::Inaccessible(errors)),
-            ))
+            ));
         }
         Err(runtime_service::RuntimeCallError::InvalidRuntime(error)) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(ValidateTransactionError::InvalidRuntime(error)),
-            ))
+            ));
         }
         Err(runtime_service::RuntimeCallError::ApiVersionRequirementUnfulfilled) => {
             return Err(ValidationError::InvalidOrError(
                 InvalidOrError::ValidateError(
                     ValidateTransactionError::ApiVersionRequirementUnfulfilled,
                 ),
-            ))
+            ));
         }
     };
 

--- a/light-base/src/util.rs
+++ b/light-base/src/util.rs
@@ -21,9 +21,9 @@ use core::fmt::{self, Write as _};
 /// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
 /// the end.
 pub fn truncated_str<'a>(
-    input: impl Iterator<Item = char> + Clone + 'a,
+    input: impl Iterator<Item = char> + Clone + use<'a>,
     limit: usize,
-) -> impl fmt::Display + 'a {
+) -> impl fmt::Display + use<'a> {
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {

--- a/light-base/src/util.rs
+++ b/light-base/src/util.rs
@@ -24,7 +24,7 @@ pub fn truncated_str(input: impl Iterator<Item = char> + Clone, limit: usize) ->
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             let mut counter = 0;
             for c in self.0.clone() {
                 f.write_char(c)?;

--- a/light-base/src/util.rs
+++ b/light-base/src/util.rs
@@ -20,10 +20,7 @@ use core::fmt::{self, Write as _};
 /// Returns an opaque object implementing the `fmt::Display` trait. Truncates the given `char`
 /// yielding iterator to the given number of elements, and if the limit is reached adds a `…` at
 /// the end.
-pub fn truncated_str<'a>(
-    input: impl Iterator<Item = char> + Clone + use<'a>,
-    limit: usize,
-) -> impl fmt::Display + use<'a> {
+pub fn truncated_str(input: impl Iterator<Item = char> + Clone, limit: usize) -> impl fmt::Display {
     struct Iter<I>(I, usize);
 
     impl<I: Iterator<Item = char> + Clone> fmt::Display for Iter<I> {

--- a/wasm-node/rust/src/allocator.rs
+++ b/wasm-node/rust/src/allocator.rs
@@ -45,40 +45,48 @@ static ALLOCATOR: AllocCounter = AllocCounter {
 
 unsafe impl alloc::GlobalAlloc for AllocCounter {
     unsafe fn alloc(&self, layout: alloc::Layout) -> *mut u8 {
-        let ret = self.inner.alloc(layout);
-        if !ret.is_null() {
-            self.total
-                .fetch_add(layout.size(), atomic::Ordering::Relaxed);
+        unsafe {
+            let ret = self.inner.alloc(layout);
+            if !ret.is_null() {
+                self.total
+                    .fetch_add(layout.size(), atomic::Ordering::Relaxed);
+            }
+            ret
         }
-        ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: alloc::Layout) {
-        self.total
-            .fetch_sub(layout.size(), atomic::Ordering::Relaxed);
-        self.inner.dealloc(ptr, layout);
+        unsafe {
+            self.total
+                .fetch_sub(layout.size(), atomic::Ordering::Relaxed);
+            self.inner.dealloc(ptr, layout);
+        }
     }
 
     unsafe fn alloc_zeroed(&self, layout: alloc::Layout) -> *mut u8 {
-        let ret = self.inner.alloc_zeroed(layout);
-        if !ret.is_null() {
-            self.total
-                .fetch_add(layout.size(), atomic::Ordering::Relaxed);
+        unsafe {
+            let ret = self.inner.alloc_zeroed(layout);
+            if !ret.is_null() {
+                self.total
+                    .fetch_add(layout.size(), atomic::Ordering::Relaxed);
+            }
+            ret
         }
-        ret
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: alloc::Layout, new_size: usize) -> *mut u8 {
-        let ret = self.inner.realloc(ptr, layout, new_size);
-        if !ret.is_null() {
-            if new_size >= layout.size() {
-                self.total
-                    .fetch_add(new_size - layout.size(), atomic::Ordering::Relaxed);
-            } else {
-                self.total
-                    .fetch_sub(layout.size() - new_size, atomic::Ordering::Relaxed);
+        unsafe {
+            let ret = self.inner.realloc(ptr, layout, new_size);
+            if !ret.is_null() {
+                if new_size >= layout.size() {
+                    self.total
+                        .fetch_add(new_size - layout.size(), atomic::Ordering::Relaxed);
+                } else {
+                    self.total
+                        .fetch_sub(layout.size() - new_size, atomic::Ordering::Relaxed);
+                }
             }
+            ret
         }
-        ret
     }
 }

--- a/wasm-node/rust/src/lib.rs
+++ b/wasm-node/rust/src/lib.rs
@@ -32,8 +32,8 @@ use alloc::{
 };
 use async_lock::Mutex;
 use core::{num::NonZero, pin::Pin, str, task};
-use futures_util::{stream, Stream as _, StreamExt as _};
-use smoldot_light::{platform::PlatformRef, HandleRpcError};
+use futures_util::{Stream as _, StreamExt as _, stream};
+use smoldot_light::{HandleRpcError, platform::PlatformRef};
 
 pub mod bindings;
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -76,13 +76,13 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                 > + Send,
         >,
     >;
-    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn future::Future<Output = ()> + Send + use<'a>>>;
+    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn future::Future<Output = ()> + Send + 'a>>;
     type NextSubstreamFuture<'a> = pin::Pin<
         Box<
             dyn future::Future<
                     Output = Option<(Self::Stream, smoldot_light::platform::SubstreamDirection)>,
                 > + Send
-                + use<'a>,
+                + 'a,
         >,
     >;
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -76,13 +76,13 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
                 > + Send,
         >,
     >;
-    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn future::Future<Output = ()> + Send + 'a>>;
+    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn future::Future<Output = ()> + Send + use<'a>>>;
     type NextSubstreamFuture<'a> = pin::Pin<
         Box<
             dyn future::Future<
                     Output = Option<(Self::Stream, smoldot_light::platform::SubstreamDirection)>,
                 > + Send
-                + 'a,
+                + use<'a>,
         >,
     >;
 

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -19,7 +19,7 @@ use crate::{bindings, timers::Delay};
 
 use futures_lite::future::FutureExt as _;
 
-use smoldot_light::platform::{read_write, SubstreamDirection};
+use smoldot_light::platform::{SubstreamDirection, read_write};
 
 use alloc::{
     borrow::{Cow, ToOwned as _},

--- a/wasm-node/rust/src/platform.rs
+++ b/wasm-node/rust/src/platform.rs
@@ -69,19 +69,18 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
     type StreamErrorRef<'a> = StreamError;
     type MultiStreamConnectFuture = pin::Pin<
         Box<
-            dyn future::Future<
+            dyn Future<
                     Output = smoldot_light::platform::MultiStreamWebRtcConnection<
                         Self::MultiStream,
                     >,
                 > + Send,
         >,
     >;
-    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn future::Future<Output = ()> + Send + 'a>>;
+    type StreamUpdateFuture<'a> = pin::Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
     type NextSubstreamFuture<'a> = pin::Pin<
         Box<
-            dyn future::Future<
-                    Output = Option<(Self::Stream, smoldot_light::platform::SubstreamDirection)>,
-                > + Send
+            dyn Future<Output = Option<(Self::Stream, smoldot_light::platform::SubstreamDirection)>>
+                + Send
                 + 'a,
         >,
     >;
@@ -113,11 +112,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
         Delay::new_at_monotonic_clock(when)
     }
 
-    fn spawn_task(
-        &self,
-        task_name: Cow<str>,
-        task: impl future::Future<Output = ()> + Send + 'static,
-    ) {
+    fn spawn_task(&self, task_name: Cow<str>, task: impl Future<Output = ()> + Send + 'static) {
         // The code below processes tasks that have names.
         #[pin_project::pin_project]
         struct FutureAdapter<F> {
@@ -126,7 +121,7 @@ impl smoldot_light::platform::PlatformRef for PlatformRef {
             future: F,
         }
 
-        impl<F: future::Future> future::Future for FutureAdapter<F> {
+        impl<F: Future> Future for FutureAdapter<F> {
             type Output = F::Output;
             fn poll(self: pin::Pin<&mut Self>, cx: &mut task::Context) -> task::Poll<Self::Output> {
                 let this = self.project();

--- a/wasm-node/rust/src/timers.rs
+++ b/wasm-node/rust/src/timers.rs
@@ -28,7 +28,7 @@ use alloc::collections::BTreeSet;
 use async_lock::Mutex;
 use core::{
     cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
-    future, mem,
+    mem,
     pin::Pin,
     task::{Context, Poll, Waker},
     time::Duration,
@@ -93,7 +93,7 @@ impl Delay {
     }
 }
 
-impl future::Future for Delay {
+impl Future for Delay {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {


### PR DESCRIPTION
Can be reviewed commit by commit.

While in absolute I think that the changes to lifetime rules is positive, updating a large existing code base to the new rules is kind of painful due to compilation errors happening in a different place than where the actual mistake is.

CI will fail for now because `cargo-deny` hasn't updated their image yet, so this will need to wait a bit to merge.
