### PR TITLE
Update to nom v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,12 +1638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,12 +1672,11 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -58,7 +58,7 @@ libm = { version = "0.2.8", default-features = false }
 libsecp256k1 = { version = "0.7.1", default-features = false, features = ["static-context", "hmac"] }
 # The log` crate is forbidden, as it is very impolite to emit logs from a library.
 merlin = { version = "3.0", default-features = false }
-nom = { version = "7.1.3", default-features = false, features = ["alloc"] }
+nom = { version = "8.0.0", default-features = false, features = ["alloc"] }
 num-bigint = { version = "0.4.3", default-features = false }
 num-rational = { version = "0.4.1", default-features = false, features = ["num-bigint"] }
 num-traits = { version = "0.2.19", default-features = false }

--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -1107,9 +1107,12 @@ impl ReadyToRun {
                 let max_keys_to_remove = {
                     let input = expect_pointer_size!(1);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
-                        nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::streaming::le_u32,
-                        ))(input.as_ref())
+                        nom::Parser::parse(
+                            &mut nom::combinator::all_consuming(util::nom_option_decode(
+                                nom::number::streaming::le_u32,
+                            )),
+                            input.as_ref(),
+                        )
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
@@ -1309,9 +1312,12 @@ impl ReadyToRun {
                 let max_keys_to_remove = {
                     let input = expect_pointer_size!(1);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
-                        nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::streaming::le_u32,
-                        ))(input.as_ref())
+                        nom::Parser::parse(
+                            &mut nom::combinator::all_consuming(util::nom_option_decode(
+                                nom::number::streaming::le_u32,
+                            )),
+                            input.as_ref(),
+                        )
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
@@ -1356,9 +1362,12 @@ impl ReadyToRun {
                 let max_keys_to_remove = {
                     let input = expect_pointer_size!(2);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
-                        nom::combinator::all_consuming(util::nom_option_decode(
-                            nom::number::streaming::le_u32,
-                        ))(input.as_ref())
+                        nom::Parser::parse(
+                            &mut nom::combinator::all_consuming(util::nom_option_decode(
+                                nom::number::streaming::le_u32,
+                            )),
+                            input.as_ref(),
+                        )
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
@@ -1984,25 +1993,28 @@ impl ReadyToRun {
                 let result = {
                     let input = expect_pointer_size!(0);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
-                        nom::combinator::all_consuming(nom::combinator::flat_map(
-                            crate::util::nom_scale_compact_usize,
-                            |num_elems| {
-                                nom::multi::many_m_n(
-                                    num_elems,
-                                    num_elems,
-                                    nom::sequence::tuple((
-                                        nom::combinator::flat_map(
-                                            crate::util::nom_scale_compact_usize,
-                                            nom::bytes::streaming::take,
+                        nom::Parser::parse(
+                            &mut nom::combinator::all_consuming(nom::combinator::flat_map(
+                                crate::util::nom_scale_compact_usize,
+                                |num_elems| {
+                                    nom::multi::many_m_n(
+                                        num_elems,
+                                        num_elems,
+                                        (
+                                            nom::combinator::flat_map(
+                                                crate::util::nom_scale_compact_usize,
+                                                nom::bytes::streaming::take,
+                                            ),
+                                            nom::combinator::flat_map(
+                                                crate::util::nom_scale_compact_usize,
+                                                nom::bytes::streaming::take,
+                                            ),
                                         ),
-                                        nom::combinator::flat_map(
-                                            crate::util::nom_scale_compact_usize,
-                                            nom::bytes::streaming::take,
-                                        ),
-                                    )),
-                                )
-                            },
-                        ))(input.as_ref())
+                                    )
+                                },
+                            )),
+                            input.as_ref(),
+                        )
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {
@@ -2050,19 +2062,22 @@ impl ReadyToRun {
                 let result = {
                     let input = expect_pointer_size!(0);
                     let parsing_result: Result<_, nom::Err<(&[u8], nom::error::ErrorKind)>> =
-                        nom::combinator::all_consuming(nom::combinator::flat_map(
-                            crate::util::nom_scale_compact_usize,
-                            |num_elems| {
-                                nom::multi::many_m_n(
-                                    num_elems,
-                                    num_elems,
-                                    nom::combinator::flat_map(
-                                        crate::util::nom_scale_compact_usize,
-                                        nom::bytes::streaming::take,
-                                    ),
-                                )
-                            },
-                        ))(input.as_ref())
+                        nom::Parser::parse(
+                            &mut nom::combinator::all_consuming(nom::combinator::flat_map(
+                                crate::util::nom_scale_compact_usize,
+                                |num_elems| {
+                                    nom::multi::many_m_n(
+                                        num_elems,
+                                        num_elems,
+                                        nom::combinator::flat_map(
+                                            crate::util::nom_scale_compact_usize,
+                                            nom::bytes::streaming::take,
+                                        ),
+                                    )
+                                },
+                            )),
+                            input.as_ref(),
+                        )
                         .map(|(_, parse_result)| parse_result);
 
                     match parsing_result {

--- a/lib/src/identity/seed_phrase.rs
+++ b/lib/src/identity/seed_phrase.rs
@@ -92,8 +92,8 @@ pub fn decode_ed25519_private_key(phrase: &str) -> Result<Box<[u8; 32]>, ParsePr
 
 /// Turns a human-readable private key (a.k.a. a seed phrase) into a seed and a derivation path.
 pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateKeyError> {
-    let parse_result: Result<_, nom::Err<nom::error::Error<&str>>> =
-        nom::combinator::all_consuming(nom::sequence::tuple((
+    let parse_result: Result<_, nom::Err<nom::error::Error<&str>>> = nom::Parser::parse(
+        &mut nom::combinator::all_consuming((
             // Either BIP39 words or some hexadecimal
             nom::branch::alt((
                 // Hexadecimal. Wrapped in `either::Left`
@@ -141,7 +141,9 @@ pub fn parse_private_key(phrase: &str) -> Result<ParsedPrivateKey, ParsePrivateK
                 nom::bytes::streaming::tag("///"),
                 |s| Ok(("", s)), // Take the rest of the input after the `///`
             ))),
-        )))(phrase);
+        )),
+        phrase,
+    );
 
     match parse_result {
         Ok((_, (either::Left(seed), path, _password))) => {

--- a/lib/src/libp2p/connection/noise.rs
+++ b/lib/src/libp2p/connection/noise.rs
@@ -868,16 +868,13 @@ impl HandshakeInProgress {
                     self.0.remote_ephemeral_public_key = x25519_dalek::PublicKey::from(*{
                         // Because the remote hasn't authenticated us at this point, sending more
                         // data than what the protocol specifies is forbidden.
-                        let mut parser = nom::combinator::all_consuming::<
-                            _,
-                            _,
-                            (&[u8], nom::error::ErrorKind),
-                            _,
-                        >(nom::combinator::map(
-                            nom::bytes::streaming::take(32u32),
-                            |k| <&[u8; 32]>::try_from(k).unwrap(),
-                        ));
-                        match parser(&available_message) {
+                        let mut parser =
+                            nom::combinator::all_consuming::<_, (&[u8], nom::error::ErrorKind), _>(
+                                nom::combinator::map(nom::bytes::streaming::take(32u32), |k| {
+                                    <&[u8; 32]>::try_from(k).unwrap()
+                                }),
+                            );
+                        match nom::Parser::parse(&mut parser, &available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
                                 return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
@@ -905,21 +902,19 @@ impl HandshakeInProgress {
                     ) = {
                         // Because the remote hasn't fully authenticated us at this point, sending
                         // more data than what the protocol specifies is forbidden.
-                        let mut parser = nom::combinator::all_consuming::<
-                            _,
-                            _,
-                            (&[u8], nom::error::ErrorKind),
-                            _,
-                        >(nom::sequence::tuple((
-                            nom::combinator::map(nom::bytes::streaming::take(32u32), |k| {
-                                <&[u8; 32]>::try_from(k).unwrap()
-                            }),
-                            nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
-                                <&[u8; 48]>::try_from(k).unwrap()
-                            }),
-                            nom::combinator::rest,
-                        )));
-                        match parser(&available_message) {
+                        let mut parser =
+                            nom::combinator::all_consuming::<_, (&[u8], nom::error::ErrorKind), _>(
+                                (
+                                    nom::combinator::map(nom::bytes::streaming::take(32u32), |k| {
+                                        <&[u8; 32]>::try_from(k).unwrap()
+                                    }),
+                                    nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
+                                        <&[u8; 48]>::try_from(k).unwrap()
+                                    }),
+                                    nom::combinator::rest,
+                                ),
+                            );
+                        match nom::Parser::parse(&mut parser, &available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
                                 return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
@@ -991,14 +986,13 @@ impl HandshakeInProgress {
                             let mut parser =
                                 nom::combinator::all_consuming::<
                                     _,
-                                    _,
                                     (&[u8], nom::error::ErrorKind),
                                     _,
                                 >(protobuf::message_decode! {
                                     #[required] key = 1 => protobuf::bytes_tag_decode,
                                     #[required] sig = 2 => protobuf::bytes_tag_decode,
                                 });
-                            match parser(&libp2p_handshake_decrypted) {
+                            match nom::Parser::parse(&mut parser, &libp2p_handshake_decrypted) {
                                 Ok((_, out)) => (out.key, out.sig),
                                 Err(_) => {
                                     return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
@@ -1032,18 +1026,16 @@ impl HandshakeInProgress {
                         // handshake message and a noise transport message as two different things.
                         // While the remote could in theory send post-handshake
                         // application-specific data in this message, in practice it is forbidden.
-                        let mut parser = nom::combinator::all_consuming::<
-                            _,
-                            _,
-                            (&[u8], nom::error::ErrorKind),
-                            _,
-                        >(nom::sequence::tuple((
-                            nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
-                                <&[u8; 48]>::try_from(k).unwrap()
-                            }),
-                            nom::combinator::rest,
-                        )));
-                        match parser(&available_message) {
+                        let mut parser =
+                            nom::combinator::all_consuming::<_, (&[u8], nom::error::ErrorKind), _>(
+                                (
+                                    nom::combinator::map(nom::bytes::streaming::take(48u32), |k| {
+                                        <&[u8; 48]>::try_from(k).unwrap()
+                                    }),
+                                    nom::combinator::rest,
+                                ),
+                            );
+                        match nom::Parser::parse(&mut parser, &available_message) {
                             Ok((_, out)) => out,
                             Err(_) => {
                                 return Err(HandshakeError::PayloadDecode(PayloadDecodeError));
@@ -1093,14 +1085,13 @@ impl HandshakeInProgress {
                             let mut parser =
                                 nom::combinator::all_consuming::<
                                     _,
-                                    _,
                                     (&[u8], nom::error::ErrorKind),
                                     _,
                                 >(protobuf::message_decode! {
                                     #[required] key = 1 => protobuf::bytes_tag_decode,
                                     #[required] sig = 2 => protobuf::bytes_tag_decode,
                                 });
-                            match parser(&libp2p_handshake_decrypted) {
+                            match nom::Parser::parse(&mut parser, &libp2p_handshake_decrypted) {
                                 Ok((_, out)) => (out.key, out.sig),
                                 Err(_) => {
                                     return Err(HandshakeError::PayloadDecode(PayloadDecodeError));

--- a/lib/src/libp2p/connection/yamux/header.rs
+++ b/lib/src/libp2p/connection/yamux/header.rs
@@ -162,7 +162,10 @@ pub fn encode(header: &DecodedYamuxHeader) -> [u8; 12] {
 
 /// Decodes a Yamux header.
 pub fn decode_yamux_header(bytes: &[u8; 12]) -> Result<DecodedYamuxHeader, YamuxHeaderDecodeError> {
-    match nom::combinator::all_consuming(nom::combinator::complete(decode))(bytes) {
+    match nom::Parser::parse(
+        &mut nom::combinator::all_consuming(nom::combinator::complete(decode)),
+        bytes,
+    ) {
         Ok((_, h)) => Ok(h),
         Err(nom::Err::Incomplete(_)) => unreachable!(),
         Err(nom::Err::Failure(err) | nom::Err::Error(err)) => Err(YamuxHeaderDecodeError {
@@ -179,96 +182,108 @@ pub struct YamuxHeaderDecodeError {
 }
 
 fn decode(bytes: &[u8]) -> nom::IResult<&[u8], DecodedYamuxHeader> {
-    nom::sequence::preceded(
-        nom::bytes::streaming::tag(&[0]),
-        nom::branch::alt((
-            nom::combinator::map(
-                nom::sequence::tuple((
-                    nom::bytes::streaming::tag(&[0]),
-                    flags,
-                    nom::combinator::map_opt(nom::number::streaming::be_u32, NonZero::<u32>::new),
-                    nom::number::streaming::be_u32,
-                )),
-                |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Data {
-                    syn,
-                    ack,
-                    fin,
-                    rst,
-                    stream_id,
-                    length,
-                },
-            ),
-            nom::combinator::map(
-                nom::sequence::tuple((
-                    nom::bytes::streaming::tag(&[1]),
-                    flags,
-                    nom::combinator::map_opt(nom::number::streaming::be_u32, NonZero::<u32>::new),
-                    nom::number::streaming::be_u32,
-                )),
-                |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Window {
-                    syn,
-                    ack,
-                    fin,
-                    rst,
-                    stream_id,
-                    length,
-                },
-            ),
-            nom::combinator::map(
-                nom::sequence::tuple((
-                    nom::bytes::streaming::tag(&[2]),
-                    nom::bytes::streaming::tag(&[0x0, 0x1]),
-                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
-                    nom::number::streaming::be_u32,
-                )),
-                |(_, _, _, opaque_value)| DecodedYamuxHeader::PingRequest { opaque_value },
-            ),
-            nom::combinator::map(
-                nom::sequence::tuple((
-                    nom::bytes::streaming::tag(&[2]),
-                    nom::bytes::streaming::tag(&[0x0, 0x2]),
-                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
-                    nom::number::streaming::be_u32,
-                )),
-                |(_, _, _, opaque_value)| DecodedYamuxHeader::PingResponse { opaque_value },
-            ),
-            nom::combinator::map(
-                nom::sequence::tuple((
-                    nom::bytes::streaming::tag(&[3]),
-                    nom::bytes::streaming::tag(&[0, 0]),
-                    nom::bytes::streaming::tag(&[0, 0, 0, 0]),
-                    nom::branch::alt((
-                        nom::combinator::map(
-                            nom::bytes::streaming::tag(0u32.to_be_bytes()),
-                            |_| GoAwayErrorCode::NormalTermination,
+    nom::Parser::parse(
+        &mut nom::sequence::preceded(
+            nom::bytes::streaming::tag(&[0][..]),
+            nom::branch::alt((
+                nom::combinator::map(
+                    (
+                        nom::bytes::streaming::tag(&[0][..]),
+                        flags,
+                        nom::combinator::map_opt(
+                            nom::number::streaming::be_u32,
+                            NonZero::<u32>::new,
                         ),
-                        nom::combinator::map(
-                            nom::bytes::streaming::tag(1u32.to_be_bytes()),
-                            |_| GoAwayErrorCode::ProtocolError,
+                        nom::number::streaming::be_u32,
+                    ),
+                    |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Data {
+                        syn,
+                        ack,
+                        fin,
+                        rst,
+                        stream_id,
+                        length,
+                    },
+                ),
+                nom::combinator::map(
+                    (
+                        nom::bytes::streaming::tag(&[1][..]),
+                        flags,
+                        nom::combinator::map_opt(
+                            nom::number::streaming::be_u32,
+                            NonZero::<u32>::new,
                         ),
-                        nom::combinator::map(
-                            nom::bytes::streaming::tag(2u32.to_be_bytes()),
-                            |_| GoAwayErrorCode::InternalError,
-                        ),
-                    )),
-                )),
-                |(_, _, _, error_code)| DecodedYamuxHeader::GoAway { error_code },
-            ),
-        )),
-    )(bytes)
+                        nom::number::streaming::be_u32,
+                    ),
+                    |(_, (syn, ack, fin, rst), stream_id, length)| DecodedYamuxHeader::Window {
+                        syn,
+                        ack,
+                        fin,
+                        rst,
+                        stream_id,
+                        length,
+                    },
+                ),
+                nom::combinator::map(
+                    (
+                        nom::bytes::streaming::tag(&[2][..]),
+                        nom::bytes::streaming::tag(&[0x0, 0x1][..]),
+                        nom::bytes::streaming::tag(&[0, 0, 0, 0][..]),
+                        nom::number::streaming::be_u32,
+                    ),
+                    |(_, _, _, opaque_value)| DecodedYamuxHeader::PingRequest { opaque_value },
+                ),
+                nom::combinator::map(
+                    (
+                        nom::bytes::streaming::tag(&[2][..]),
+                        nom::bytes::streaming::tag(&[0x0, 0x2][..]),
+                        nom::bytes::streaming::tag(&[0, 0, 0, 0][..]),
+                        nom::number::streaming::be_u32,
+                    ),
+                    |(_, _, _, opaque_value)| DecodedYamuxHeader::PingResponse { opaque_value },
+                ),
+                nom::combinator::map(
+                    (
+                        nom::bytes::streaming::tag(&[3][..]),
+                        nom::bytes::streaming::tag(&[0, 0][..]),
+                        nom::bytes::streaming::tag(&[0, 0, 0, 0][..]),
+                        nom::branch::alt((
+                            nom::combinator::map(
+                                nom::bytes::streaming::tag(&0u32.to_be_bytes()[..]),
+                                |_| GoAwayErrorCode::NormalTermination,
+                            ),
+                            nom::combinator::map(
+                                nom::bytes::streaming::tag(&1u32.to_be_bytes()[..]),
+                                |_| GoAwayErrorCode::ProtocolError,
+                            ),
+                            nom::combinator::map(
+                                nom::bytes::streaming::tag(&2u32.to_be_bytes()[..]),
+                                |_| GoAwayErrorCode::InternalError,
+                            ),
+                        )),
+                    ),
+                    |(_, _, _, error_code)| DecodedYamuxHeader::GoAway { error_code },
+                ),
+            )),
+        ),
+        bytes,
+    )
 }
 
 fn flags(bytes: &[u8]) -> nom::IResult<&[u8], (bool, bool, bool, bool)> {
-    nom::combinator::map_opt(nom::number::streaming::be_u16, |flags| {
-        let syn = (flags & 0x1) != 0;
-        let ack = (flags & 0x2) != 0;
-        let fin = (flags & 0x4) != 0;
-        let rst = (flags & 0x8) != 0;
-        if (flags & !0b1111) != 0 {
-            return None;
-        }
-        Some((syn, ack, fin, rst))
-    })(bytes)
+    nom::Parser::parse(
+        &mut nom::combinator::map_opt(nom::number::streaming::be_u16, |flags| {
+            let syn = (flags & 0x1) != 0;
+            let ack = (flags & 0x2) != 0;
+            let fin = (flags & 0x4) != 0;
+            let rst = (flags & 0x8) != 0;
+            if (flags & !0b1111) != 0 {
+                return None;
+            }
+            Some((syn, ack, fin, rst))
+        }),
+        bytes,
+    )
 }
 
 #[cfg(test)]

--- a/lib/src/libp2p/peer_id.rs
+++ b/lib/src/libp2p/peer_id.rs
@@ -79,8 +79,8 @@ impl PublicKey {
 
         // As indicated in the libp2p specification, the public key must be encoded
         // deterministically, and thus the fields are decoded deterministically in a precise order.
-        let mut parser = nom::combinator::all_consuming::<_, _, ErrorWrapper, _>(
-            nom::combinator::complete(nom::sequence::tuple((
+        let mut parser =
+            nom::combinator::all_consuming::<_, ErrorWrapper, _>(nom::combinator::complete((
                 nom::sequence::preceded(
                     nom::combinator::peek(nom::combinator::verify(
                         protobuf::tag_decode,
@@ -101,10 +101,9 @@ impl PublicKey {
                             .map_err(|_| FromProtobufEncodingError::BadEd25519Key)
                     }),
                 ),
-            ))),
-        );
+            )));
 
-        match nom::Finish::finish(parser(bytes)) {
+        match nom::Finish::finish(nom::Parser::parse(&mut parser, bytes)) {
             Ok((_, (1, key))) => Ok(PublicKey::Ed25519(key)),
             Ok((_, (_, _))) => Err(FromProtobufEncodingError::UnsupportedAlgorithm),
             Err(err) => Err(err.0),

--- a/lib/src/network/codec/identify.rs
+++ b/lib/src/network/codec/identify.rs
@@ -126,7 +126,7 @@ pub fn decode_identify_response(
     IdentifyResponse<'_, vec::IntoIter<&[u8]>, vec::IntoIter<&str>>,
     DecodeIdentifyResponseError,
 > {
-    let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
+    let mut parser = nom::combinator::all_consuming::<_, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
             #[optional] protocol_version = 5 => protobuf::string_tag_decode,
             #[optional] agent_version = 6 => protobuf::string_tag_decode,
@@ -137,7 +137,7 @@ pub fn decode_identify_response(
         }),
     );
 
-    let decoded = match nom::Finish::finish(parser(response_bytes)) {
+    let decoded = match nom::Finish::finish(nom::Parser::parse(&mut parser, response_bytes)) {
         Ok((_, out)) => out,
         Err(_) => return Err(DecodeIdentifyResponseError::ProtobufDecode),
     };

--- a/lib/src/network/codec/state_request.rs
+++ b/lib/src/network/codec/state_request.rs
@@ -109,13 +109,13 @@ pub fn build_state_request(config: StateRequest) -> impl Iterator<Item = impl As
 ///
 /// On success, contains a Merkle proof.
 pub fn decode_state_response(response_bytes: &[u8]) -> Result<&[u8], DecodeStateResponseError> {
-    let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
+    let mut parser = nom::combinator::all_consuming::<_, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
             #[required] proof = 2 => protobuf::bytes_tag_decode,
         }),
     );
 
-    let proof = match nom::Finish::finish(parser(response_bytes)) {
+    let proof = match nom::Finish::finish(nom::Parser::parse(&mut parser, response_bytes)) {
         Ok((_, proof)) => proof.proof,
         Err(_) => return Err(DecodeStateResponseError::ProtobufDecode),
     };

--- a/lib/src/network/codec/storage_call_proof.rs
+++ b/lib/src/network/codec/storage_call_proof.rs
@@ -107,7 +107,7 @@ pub fn decode_storage_or_call_proof_response(
 
     // TODO: while the `proof` field is correctly optional, the `response` field isn't supposed to be optional; make it `#[required]` again once https://github.com/paritytech/substrate/pull/12732 has been merged and released
 
-    let mut parser = nom::combinator::all_consuming::<_, _, nom::error::Error<&[u8]>, _>(
+    let mut parser = nom::combinator::all_consuming::<_, nom::error::Error<&[u8]>, _>(
         nom::combinator::complete(protobuf::message_decode! {
             #[optional] response = field_num => protobuf::message_tag_decode(protobuf::message_decode!{
                 #[optional] proof = 2 => protobuf::bytes_tag_decode
@@ -115,7 +115,7 @@ pub fn decode_storage_or_call_proof_response(
         }),
     );
 
-    let proof = match nom::Finish::finish(parser(response_bytes)) {
+    let proof = match nom::Finish::finish(nom::Parser::parse(&mut parser, response_bytes)) {
         Ok((_, out)) => out.response.and_then(|r| r.proof),
         Err(_) => return Err(DecodeStorageCallProofResponseError::ProtobufDecode),
     };

--- a/lib/src/trie.rs
+++ b/lib/src/trie.rs
@@ -274,10 +274,12 @@ pub fn ordered_root(
                 let key = value_req
                     .key()
                     .collect::<arrayvec::ArrayVec<u8, USIZE_COMPACT_BYTES>>();
-                let value = match nom::combinator::all_consuming(
-                    util::nom_scale_compact_usize::<nom::error::Error<&[u8]>>,
-                )(&key)
-                {
+                let value = match nom::Parser::parse(
+                    &mut nom::combinator::all_consuming(
+                        util::nom_scale_compact_usize::<nom::error::Error<&[u8]>>,
+                    ),
+                    &key,
+                ) {
                     Ok((_, key)) => entries.get(key).map(move |v| (v, version)),
                     Err(_) => None,
                 };

--- a/lib/src/trie/proof_decode.rs
+++ b/lib/src/trie/proof_decode.rs
@@ -91,10 +91,15 @@ where
     // the function actually take less time than if it was a legitimate proof.
     let entries_by_merkle_value = {
         // TODO: don't use a Vec?
-        let (_, decoded_proof) = nom::combinator::all_consuming(nom::combinator::flat_map(
-            crate::util::nom_scale_compact_usize,
-            |num_elems| nom::multi::many_m_n(num_elems, num_elems, crate::util::nom_bytes_decode),
-        ))(config.proof.as_ref())
+        let (_, decoded_proof) = nom::Parser::parse(
+            &mut nom::combinator::all_consuming(nom::combinator::flat_map(
+                crate::util::nom_scale_compact_usize,
+                |num_elems| {
+                    nom::multi::many_m_n(num_elems, num_elems, crate::util::nom_bytes_decode)
+                },
+            )),
+            config.proof.as_ref(),
+        )
         .map_err(|_: nom::Err<nom::error::Error<&[u8]>>| Error::InvalidFormat)?;
 
         let entries_by_merkle_value = decoded_proof

--- a/wasm-node/rust/Cargo.toml
+++ b/wasm-node/rust/Cargo.toml
@@ -26,7 +26,7 @@ fnv = { version = "1.0.7", default-features = false }
 futures-lite = { version = "2.3.0", default-features = false, features = ["alloc"] }
 futures-util = { version = "0.3.27", default-features = false }
 hashbrown = { version = "0.15.0", default-features = false }
-nom = { version = "7.1.3", default-features = false }
+nom = { version = "8.0.0", default-features = false }
 pin-project = "1.1.5"
 slab = { version = "0.4.8", default-features = false }
 smoldot = { version = "0.19.0", path = "../../lib", default-features = false }


### PR DESCRIPTION
While the diff is quite big, all the changes were very straight-forward:

- Removing one generic parameter from `all_consuming`.
- Use the `Parser` trait instead of calling closures.
- Return `impl Parser` instead of `impl FnMut`.
- Make some error types explicit.
- Remove calls to `nom::sequence::tuple()` as they are no longer needed.

Everything seems to work, and first try.