### PR TITLE
Update slab to v0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,9 +2360,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Previous version of slab contains a "vulnerability".
This doesn't concern us, but it makes the CI of https://github.com/smol-dot/smoldot/pull/2165 happy