### PR TITLE
Fix panic in case of invalid SR25519 signature

### DIFF
--- a/lib/src/executor/host.rs
+++ b/lib/src/executor/host.rs
@@ -3078,14 +3078,13 @@ impl SignatureVerification {
                 })
             }
             SignatureVerificationAlgorithm::Sr25519V2 => {
+                let Ok(signature) = schnorrkel::Signature::from_bytes(self.signature().as_ref())
+                else {
+                    return false;
+                };
                 schnorrkel::PublicKey::from_bytes(self.public_key().as_ref()).map_or(false, |pk| {
-                    pk.verify_simple(
-                        b"substrate",
-                        self.message().as_ref(),
-                        &schnorrkel::Signature::from_bytes(self.signature().as_ref())
-                            .unwrap_or_else(|_| unreachable!()),
-                    )
-                    .is_ok()
+                    pk.verify_simple(b"substrate", self.message().as_ref(), &signature)
+                        .is_ok()
                 })
             }
             SignatureVerificationAlgorithm::Ecdsa => {

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix panic when an invalid SR25519 signature is passed to `ext_crypto_sr25519_verify_version_2`.
+
 ## 2.0.37 - 2025-08-29
 
 ### Changed

--- a/wasm-node/CHANGELOG.md
+++ b/wasm-node/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix panic when an invalid SR25519 signature is passed to `ext_crypto_sr25519_verify_version_2`.
+- Fix panic when an invalid SR25519 signature is passed to `ext_crypto_sr25519_verify_version_2`. ([#2170](https://github.com/smol-dot/smoldot/pull/2170))
 
 ## 2.0.37 - 2025-08-29
 


### PR DESCRIPTION
I assumed that `schnorrkel::Signature::from_bytes` only checks the length of the payload. Turns out that it also verifies something else.

Fix https://github.com/smol-dot/smoldot/issues/2169

Work time: 10mn